### PR TITLE
PER-9114: Update stela's Github actions to publish docker images to ECR

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,19 +2,13 @@ name: unit tests
 on: [push, workflow_dispatch]
 jobs:
     run_tests:
-        runs-on: ubuntu-latest
-        services:
-            postgres:
-                image: postgres:14
-                env:
-                    POSTGRES_PASSWORD: permanent
-                ports:
-                    - 5432:5432
+        runs-on: ubuntu-20.04
         steps:
-            - uses: actions/checkout@v2
+            - uses: actions/checkout@v3
             - uses: actions/setup-node@v1
               with:
                   node-version: "18"
             - run: npm install --production=false
-            - run: npm run test-ci --coverage
+            - run: npm run start-containers
+            - run: docker compose run stela npm run test-ci --coverage
             - uses: codecov/codecov-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,10 @@
 name: unit tests
-on: [push, workflow_dispatch]
+on:
+    push:
+        branches-ignore:
+            - main
+    workflow_dispatch:
+    workflow_call:
 jobs:
     run_tests:
         runs-on: ubuntu-20.04

--- a/.github/workflows/test_and_build.yml
+++ b/.github/workflows/test_and_build.yml
@@ -1,0 +1,29 @@
+name: Test and Build
+on:
+    workflow_dispatch:
+    push:
+        branches:
+            - main
+jobs:
+    run_tests:
+        uses: ./.github/workflows/test.yml
+    build:
+        needs:
+            - run_tests
+        runs-on: ubuntu-20.04
+        steps:
+            - uses: actions/checkout@v3
+            - name: Generate Image Tag
+              run: echo "IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
+              env:
+                  AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+            - name: Build Image
+              run: docker build -t $IMAGE_TAG .
+            - name: AWS Login
+              run: aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin 364159549467.dkr.ecr.$AWS_REGION.amazonaws.com
+              env:
+                  AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+                  AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+                  AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+            - name: Publish Image to ECR
+              run: docker push $IMAGE_TAG

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+FROM node:18-alpine
+WORKDIR /usr/local/apps/stela
+
+RUN apk add curl
+
+COPY package.json ./
+RUN npm install -g npm@8.19.3
+RUN npm cache clean --force
+RUN npm install --omit dev
+ENV PATH=/usr/local/apps/stela/node_modules/.bin:$PATH
+
+COPY tsconfig.json ./
+COPY src ./src
+
+EXPOSE 8080
+
+CMD npm run start

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,0 +1,21 @@
+FROM node:18-alpine
+WORKDIR /usr/local/apps/stela
+
+RUN apk add curl \
+    postgresql-client 
+
+COPY package.json ./
+RUN npm install -g npm@8.19.3
+RUN npm cache clean --force
+RUN npm install
+ENV PATH=/usr/local/apps/stela/node_modules/.bin:$PATH
+
+WORKDIR /usr/local/apps/stela
+
+COPY tsconfig.json ./
+COPY src ./src
+COPY database ./database
+
+EXPOSE 8080
+
+CMD bash

--- a/README.md
+++ b/README.md
@@ -40,8 +40,13 @@ Note that the database tests run against is dropped and recreated at the beginni
 
 ## Running Locally
 
-Run the project locally with
+Preferred method: From the `devenv` repo, run
 
+```bash
+docker compose up -d
+```
+
+Outside a container: Run
 ```bash
 npm run start
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,3 +9,10 @@ services:
       test: pg_isready -d permanent
     ports:
       - "5432:5432"
+  stela:
+    build: 
+      context: ./
+      dockerfile: Dockerfile.test
+    depends_on:
+      database:
+        condition: service_healthy

--- a/package.json
+++ b/package.json
@@ -8,13 +8,16 @@
     "check-format": "prettier --check src",
     "eslint": "eslint --max-warnings 0 ./src --ext .ts",
     "lint": "npm run check-format && npm run check-types && npm run eslint",
-    "start-database": "docker-compose up -d",
+    "start-containers": "docker compose up -d",
     "clear-database": "psql postgresql://postgres:permanent@localhost:5432 -c 'DROP DATABASE IF EXISTS test_permanent;'",
     "create-database": "psql postgresql://postgres:permanent@localhost:5432 -c 'CREATE DATABASE test_permanent;'",
     "set-up-database": "psql postgresql://postgres:permanent@localhost:5432/test_permanent -f database/base.sql",
-    "test": "npm run start-database && npm run clear-database && npm run create-database && npm run set-up-database && jest",
-    "test-ci": "npm run clear-database && npm run create-database && npm run set-up-database && jest --coverage",
-    "start:dev": "ts-node --transpile-only src/index.ts",
+    "clear-database-ci": "psql postgresql://postgres:permanent@database:5432 -c 'DROP DATABASE IF EXISTS test_permanent;'",
+    "create-database-ci": "psql postgresql://postgres:permanent@database:5432 -c 'CREATE DATABASE test_permanent;'",
+    "set-up-database-ci": "psql postgresql://postgres:permanent@database:5432/test_permanent -f database/base.sql",
+    "test": "npm run start-containers && npm run clear-database && npm run create-database && npm run set-up-database && docker-compose run stela jest",
+    "test-ci": "npm run clear-database-ci && npm run create-database-ci && npm run set-up-database-ci && jest --coverage",
+    "start": "ts-node --transpile-only src/index.ts",
     "start:watch": "nodemon src/index.ts"
   },
   "jest": {
@@ -24,9 +27,7 @@
     "transform": {
       "^.+\\.ts?$": "ts-jest"
     },
-    "transformIgnorePatterns": [
-      "./node_modules/"
-    ]
+    "transformIgnorePatterns": ["./node_modules/"]
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -50,10 +50,11 @@
     "pg": "^8.5.1",
     "require-env-variable": "^3.1.2",
     "tinypg": "^7.0.0",
-    "winston": "^3.3.3"
+    "winston": "^3.3.3",
+    "ts-node": "^10.9.1",
+    "@tsconfig/node18-strictest": "^1.0.0"
   },
   "devDependencies": {
-    "@tsconfig/node18-strictest": "^1.0.0",
     "@types/express": "^4.17.8",
     "@types/jest": "26.0.23",
     "@types/node": "^12.20.7",
@@ -72,7 +73,6 @@
     "prettier": "^2.7.1",
     "supertest": "^5.0.0",
     "ts-jest": "27.0.2",
-    "ts-node": "^10.9.1",
     "typescript": "^4.8.4"
   }
 }

--- a/src/__mocks__/database.ts
+++ b/src/__mocks__/database.ts
@@ -3,7 +3,7 @@ import { TinyPg } from "tinypg";
 
 const db = new TinyPg({
   connection_string:
-    "postgres://postgres:permanent@localhost:5432/test_permanent",
+    "postgres://postgres:permanent@database:5432/test_permanent",
   root_dir: [path.resolve(__dirname, "..")],
   capture_stack_trace: true,
 });


### PR DESCRIPTION
This is a bit tricky to test, because `workflow_trigger` doesn't work until an action exists on `main`. You can see the new Test and Build action succeed [here](https://github.com/PermanentOrg/stela/actions/runs/3961447081), and the corresponding image in ECR [here](https://us-west-2.console.aws.amazon.com/ecr/repositories/private/364159549467/stela?region=us-west-2). If you want to run the workflow yourself, I think the simplest way would be to create a new branch off of this one, remove the restriction of the workflow's `push` trigger to the `main` branch, and push that branch.