### PR TITLE
Add authentication middleware

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -1,1 +1,9 @@
+PORT=8080
+
 DATABASE_URL="postgres://postgres:permanent@localhost:5432/test_permanent"
+
+FUSIONAUTH_HOST=<host URL here>
+FUSIONAUTH_API_KEY=<API key here>
+FUSIONAUTH_TENANT=<Tenant ID here>
+FUSIONAUTH_BACKEND_APPLICATION_ID=<backend application ID here>
+FUSIONAUTH_ADMIN_APPLICATION_ID=<admin application ID here>

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -14,7 +14,11 @@
     "import/prefer-default-export": "off",
     "import/no-default-export": "error",
     "@typescript-eslint/prefer-readonly-parameter-types": "off",
-    "prettier/prettier": "error"
+    "prettier/prettier": "error",
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      { "argsIgnorePattern": "^_" }
+    ]
   },
   "env": {
     "es6": true,

--- a/README.md
+++ b/README.md
@@ -24,9 +24,15 @@ npm install
 
 ## Environment Variables
 
-| Variable     | Default                                                     | Notes                                  |
-| ------------ | ----------------------------------------------------------- | -------------------------------------- |
-| DATABASE_URL | postgres://postgres:permanent@localhost:5432/test_permanent | Run tests to generate default database |
+| Variable                          | Default                                                     | Notes                                                                  |
+| --------------------------------- | ----------------------------------------------------------- | ---------------------------------------------------------------------- |
+| DATABASE_URL                      | postgres://postgres:permanent@localhost:5432/test_permanent | Run tests to generate default database                                 |
+| PORT                              | 8080                                                        | Tells stela what port to run on                                        |
+| FUSIONAUTH_HOST                   | none                                                        | Can be found in `back-end`'s library/base/constants/base.constants.php |
+| FUSIONAUTH_API_KEY                | none                                                        | Can be found in `back-end`'s library/base/constants/base.constants.php |
+| FUSIONAUTH_TENANT                 | none                                                        | Can be found in `back-end`'s library/base/constants/base.constants.php |
+| FUSIONAUTH_BACKEND_APPLICATION_ID | none                                                        | Can be found in `back-end`'s library/base/constants/base.constants.php |
+| FUSIONAUTH_ADMIN_APPLICATION_ID   | none                                                        | Can be found in the FusionAuth Admin application                       |
 
 ## Testing
 
@@ -46,7 +52,14 @@ Preferred method: From the `devenv` repo, run
 docker compose up -d
 ```
 
+or if you've added or updated dependencies, run
+
+```bash
+docker compose up -d --build stela
+```
+
 Outside a container: Run
+
 ```bash
 npm run start
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,17 +9,21 @@
       "version": "0.0.0",
       "license": "AGPL-3.0",
       "dependencies": {
+        "@fusionauth/typescript-client": "^1.42.0",
+        "@tsconfig/node18-strictest": "^1.0.0",
+        "@types/http-errors": "^2.0.1",
         "body-parser": "^1.19.0",
         "dotenv": "^8.2.0",
         "express": "^4.17.3",
         "express-winston": "^4.1.0",
+        "http-errors": "^2.0.0",
         "pg": "^8.5.1",
         "require-env-variable": "^3.1.2",
         "tinypg": "^7.0.0",
+        "ts-node": "^10.9.1",
         "winston": "^3.3.3"
       },
       "devDependencies": {
-        "@tsconfig/node18-strictest": "^1.0.0",
         "@types/express": "^4.17.8",
         "@types/jest": "26.0.23",
         "@types/node": "^12.20.7",
@@ -38,7 +42,6 @@
         "prettier": "^2.7.1",
         "supertest": "^5.0.0",
         "ts-jest": "27.0.2",
-        "ts-node": "^10.9.1",
         "typescript": "^4.8.4"
       },
       "engines": {
@@ -1079,7 +1082,6 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/trace-mapping": "0.3.9"
       },
@@ -1136,6 +1138,14 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/@fusionauth/typescript-client": {
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@fusionauth/typescript-client/-/typescript-client-1.42.0.tgz",
+      "integrity": "sha512-WJgcmy+t4Rrg/BEEtErH7bLblSOBc1Cu37VedWswo+0MbbSfSX3k9xgfnJunsfYe6dglafw0BYLCIMw4My253w==",
+      "dependencies": {
+        "node-fetch": "^2.6.1"
       }
     },
     "node_modules/@humanwhocodes/config-array": {
@@ -1957,7 +1967,6 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
       "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-      "dev": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1965,14 +1974,12 @@
     "node_modules/@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-      "dev": true
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "node_modules/@jridgewell/trace-mapping": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -2043,32 +2050,27 @@
     "node_modules/@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-      "dev": true
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
     },
     "node_modules/@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
     },
     "node_modules/@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
     },
     "node_modules/@tsconfig/node16": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
-      "dev": true
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
     },
     "node_modules/@tsconfig/node18-strictest": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@tsconfig/node18-strictest/-/node18-strictest-1.0.0.tgz",
-      "integrity": "sha512-bOuNKwO4Fzbt+Su5wqI9zNHwx5C25gLnutwVQA1sBZk0cW8UjVPVcwzIUhJIIJDUx7zDEbAwdCD2HfvIsV8dYg==",
-      "dev": true
+      "integrity": "sha512-bOuNKwO4Fzbt+Su5wqI9zNHwx5C25gLnutwVQA1sBZk0cW8UjVPVcwzIUhJIIJDUx7zDEbAwdCD2HfvIsV8dYg=="
     },
     "node_modules/@types/babel__core": {
       "version": "7.1.14",
@@ -2174,6 +2176,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ=="
+    },
     "node_modules/@types/istanbul-lib-coverage": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
@@ -2229,8 +2236,7 @@
     "node_modules/@types/node": {
       "version": "12.20.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
-      "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA==",
-      "dev": true
+      "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA=="
     },
     "node_modules/@types/pg": {
       "version": "7.14.10",
@@ -2668,8 +2674,7 @@
     "node_modules/arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
     "node_modules/argparse": {
       "version": "1.0.10",
@@ -2908,6 +2913,21 @@
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "dependencies": {
         "ms": "2.0.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/body-parser/node_modules/ms": {
@@ -3352,8 +3372,7 @@
     "node_modules/create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
     },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
@@ -3501,7 +3520,6 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
       "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true,
       "engines": {
         "node": ">=0.3.1"
       }
@@ -4953,18 +4971,34 @@
       "dev": true
     },
     "node_modules/http-errors": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
       "dependencies": {
-        "depd": "~1.1.2",
+        "depd": "2.0.0",
         "inherits": "2.0.4",
         "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
+        "statuses": "2.0.1",
         "toidentifier": "1.0.1"
       },
       "engines": {
-        "node": ">= 0.6"
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-errors/node_modules/depd": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+      "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/http-errors/node_modules/statuses": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+      "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ==",
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/http-proxy-agent": {
@@ -7767,8 +7801,7 @@
     "node_modules/make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "node_modules/makeerror": {
       "version": "1.0.11",
@@ -7907,6 +7940,44 @@
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-fetch/node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/node-fetch/node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/node-fetch/node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
       }
     },
     "node_modules/node-int64": {
@@ -8599,6 +8670,21 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/raw-body/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/react-is": {
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
@@ -8858,6 +8944,21 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
+    },
+    "node_modules/send/node_modules/http-errors": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "dependencies": {
+        "depd": "~1.1.2",
+        "inherits": "2.0.4",
+        "setprototypeof": "1.2.0",
+        "statuses": ">= 1.5.0 < 2",
+        "toidentifier": "1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/send/node_modules/ms": {
       "version": "2.1.3",
@@ -9540,7 +9641,6 @@
       "version": "10.9.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
       "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-      "dev": true,
       "dependencies": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -9583,7 +9683,6 @@
       "version": "8.8.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
       "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
-      "dev": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -9595,7 +9694,6 @@
       "version": "8.2.0",
       "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
       "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-      "dev": true,
       "engines": {
         "node": ">=0.4.0"
       }
@@ -9691,7 +9789,6 @@
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
       "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
-      "dev": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -9763,8 +9860,7 @@
     "node_modules/v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
     },
     "node_modules/v8-to-istanbul": {
       "version": "7.1.2",
@@ -10121,7 +10217,6 @@
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
       "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true,
       "engines": {
         "node": ">=6"
       }
@@ -11097,7 +11192,6 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz",
       "integrity": "sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==",
-      "dev": true,
       "requires": {
         "@jridgewell/trace-mapping": "0.3.9"
       }
@@ -11144,6 +11238,14 @@
             "argparse": "^2.0.1"
           }
         }
+      }
+    },
+    "@fusionauth/typescript-client": {
+      "version": "1.42.0",
+      "resolved": "https://registry.npmjs.org/@fusionauth/typescript-client/-/typescript-client-1.42.0.tgz",
+      "integrity": "sha512-WJgcmy+t4Rrg/BEEtErH7bLblSOBc1Cu37VedWswo+0MbbSfSX3k9xgfnJunsfYe6dglafw0BYLCIMw4My253w==",
+      "requires": {
+        "node-fetch": "^2.6.1"
       }
     },
     "@humanwhocodes/config-array": {
@@ -11825,20 +11927,17 @@
     "@jridgewell/resolve-uri": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.0.tgz",
-      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w==",
-      "dev": true
+      "integrity": "sha512-F2msla3tad+Mfht5cJq7LSXcdudKTWCVYUgw6pLFOOHSTtZlj6SWNYAp+AhuqLmWdBO2X5hPrLcu8cVP8fy28w=="
     },
     "@jridgewell/sourcemap-codec": {
       "version": "1.4.14",
       "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.4.14.tgz",
-      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw==",
-      "dev": true
+      "integrity": "sha512-XPSJHWmi394fuUuzDnGz1wiKqWfo1yXecHQMRf2l6hztTO+nPru658AyDngaBe7isIxEkRsPR3FZh+s7iVa4Uw=="
     },
     "@jridgewell/trace-mapping": {
       "version": "0.3.9",
       "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz",
       "integrity": "sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==",
-      "dev": true,
       "requires": {
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
@@ -11897,32 +11996,27 @@
     "@tsconfig/node10": {
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.9.tgz",
-      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA==",
-      "dev": true
+      "integrity": "sha512-jNsYVVxU8v5g43Erja32laIDHXeoNvFEpX33OK4d6hljo3jDhCBDhx5dhCCTMWUojscpAagGiRkBKxpdl9fxqA=="
     },
     "@tsconfig/node12": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.11.tgz",
-      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==",
-      "dev": true
+      "integrity": "sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag=="
     },
     "@tsconfig/node14": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.3.tgz",
-      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==",
-      "dev": true
+      "integrity": "sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow=="
     },
     "@tsconfig/node16": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.3.tgz",
-      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ==",
-      "dev": true
+      "integrity": "sha512-yOlFc+7UtL/89t2ZhjPvvB/DeAr3r+Dq58IgzsFkOAvVC6NMJXmCGjbptdXdR9qsX7pKcTL+s87FtYREi2dEEQ=="
     },
     "@tsconfig/node18-strictest": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@tsconfig/node18-strictest/-/node18-strictest-1.0.0.tgz",
-      "integrity": "sha512-bOuNKwO4Fzbt+Su5wqI9zNHwx5C25gLnutwVQA1sBZk0cW8UjVPVcwzIUhJIIJDUx7zDEbAwdCD2HfvIsV8dYg==",
-      "dev": true
+      "integrity": "sha512-bOuNKwO4Fzbt+Su5wqI9zNHwx5C25gLnutwVQA1sBZk0cW8UjVPVcwzIUhJIIJDUx7zDEbAwdCD2HfvIsV8dYg=="
     },
     "@types/babel__core": {
       "version": "7.1.14",
@@ -12028,6 +12122,11 @@
         "@types/node": "*"
       }
     },
+    "@types/http-errors": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.1.tgz",
+      "integrity": "sha512-/K3ds8TRAfBvi5vfjuz8y6+GiAYBZ0x4tXv1Av6CWBWn0IlADc+ZX9pMq7oU0fNQPnBwIZl3rmeLp6SBApbxSQ=="
+    },
     "@types/istanbul-lib-coverage": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.3.tgz",
@@ -12083,8 +12182,7 @@
     "@types/node": {
       "version": "12.20.7",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-12.20.7.tgz",
-      "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA==",
-      "dev": true
+      "integrity": "sha512-gWL8VUkg8VRaCAUgG9WmhefMqHmMblxe2rVpMF86nZY/+ZysU+BkAp+3cz03AixWDSSz0ks5WX59yAhv/cDwFA=="
     },
     "@types/pg": {
       "version": "7.14.10",
@@ -12392,8 +12490,7 @@
     "arg": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==",
-      "dev": true
+      "integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
     },
     "argparse": {
       "version": "1.0.10",
@@ -12586,6 +12683,18 @@
           "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
           "requires": {
             "ms": "2.0.0"
+          }
+        },
+        "http-errors": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+          "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.2.0",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.1"
           }
         },
         "ms": {
@@ -12933,8 +13042,7 @@
     "create-require": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/create-require/-/create-require-1.1.1.tgz",
-      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==",
-      "dev": true
+      "integrity": "sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ=="
     },
     "cross-spawn": {
       "version": "7.0.3",
@@ -13048,8 +13156,7 @@
     "diff": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-      "dev": true
+      "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
     },
     "diff-sequences": {
       "version": "26.6.2",
@@ -14142,15 +14249,27 @@
       "dev": true
     },
     "http-errors": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
-      "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
+      "integrity": "sha512-FtwrG/euBzaEjYeRqOgly7G0qviiXoJWnvEH2Z1plBdXgbyjv34pHTSb9zoeHMyDy33+DWy5Wt9Wo+TURtOYSQ==",
       "requires": {
-        "depd": "~1.1.2",
+        "depd": "2.0.0",
         "inherits": "2.0.4",
         "setprototypeof": "1.2.0",
-        "statuses": ">= 1.5.0 < 2",
+        "statuses": "2.0.1",
         "toidentifier": "1.0.1"
+      },
+      "dependencies": {
+        "depd": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+          "integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw=="
+        },
+        "statuses": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/statuses/-/statuses-2.0.1.tgz",
+          "integrity": "sha512-RwNA9Z/7PrK06rYLIzFMlaF+l73iwpzsqRIFgbMLbTcLD6cOao82TaWefPXQvB2fOC4AjuYSEndS7N/mTCbkdQ=="
+        }
       }
     },
     "http-proxy-agent": {
@@ -16375,8 +16494,7 @@
     "make-error": {
       "version": "1.3.6",
       "resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-      "dev": true
+      "integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
     },
     "makeerror": {
       "version": "1.0.11",
@@ -16483,6 +16601,35 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
       "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg=="
+    },
+    "node-fetch": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.9.tgz",
+      "integrity": "sha512-DJm/CJkZkRjKKj4Zi4BsKVZh3ValV5IR5s7LVZnW+6YMh0W1BfNA8XSs6DLMGYlId5F3KnA70uu2qepcR08Qqg==",
+      "requires": {
+        "whatwg-url": "^5.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "0.0.3",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+          "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+        },
+        "webidl-conversions": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+          "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+        },
+        "whatwg-url": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+          "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+          "requires": {
+            "tr46": "~0.0.3",
+            "webidl-conversions": "^3.0.0"
+          }
+        }
+      }
     },
     "node-int64": {
       "version": "0.4.0",
@@ -16974,6 +17121,20 @@
         "http-errors": "1.8.1",
         "iconv-lite": "0.4.24",
         "unpipe": "1.0.0"
+      },
+      "dependencies": {
+        "http-errors": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+          "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.2.0",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.1"
+          }
+        }
       }
     },
     "react-is": {
@@ -17166,6 +17327,18 @@
               "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
               "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A=="
             }
+          }
+        },
+        "http-errors": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.8.1.tgz",
+          "integrity": "sha512-Kpk9Sm7NmI+RHhnj6OIWDI1d6fIoFAtFt9RLaTMRlg/8w49juAStsrBgp0Dp4OdxdVbRIeKhtCUvoi/RuAhO4g==",
+          "requires": {
+            "depd": "~1.1.2",
+            "inherits": "2.0.4",
+            "setprototypeof": "1.2.0",
+            "statuses": ">= 1.5.0 < 2",
+            "toidentifier": "1.0.1"
           }
         },
         "ms": {
@@ -17699,7 +17872,6 @@
       "version": "10.9.1",
       "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.9.1.tgz",
       "integrity": "sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==",
-      "dev": true,
       "requires": {
         "@cspotcode/source-map-support": "^0.8.0",
         "@tsconfig/node10": "^1.0.7",
@@ -17719,14 +17891,12 @@
         "acorn": {
           "version": "8.8.1",
           "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-          "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
-          "dev": true
+          "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA=="
         },
         "acorn-walk": {
           "version": "8.2.0",
           "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
-          "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
-          "dev": true
+          "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA=="
         }
       }
     },
@@ -17799,8 +17969,7 @@
     "typescript": {
       "version": "4.8.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.8.4.tgz",
-      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ==",
-      "dev": true
+      "integrity": "sha512-QCh+85mCy+h0IGff8r5XWzOVSbBO+KfeYrMQh7NJ58QujwcE22u+NUSmUxqF+un70P9GXKxa2HCNiTTMJknyjQ=="
     },
     "unbox-primitive": {
       "version": "1.0.2",
@@ -17853,8 +18022,7 @@
     "v8-compile-cache-lib": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz",
-      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==",
-      "dev": true
+      "integrity": "sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg=="
     },
     "v8-to-istanbul": {
       "version": "7.1.2",
@@ -18131,8 +18299,7 @@
     "yn": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==",
-      "dev": true
+      "integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
     },
     "yocto-queue": {
       "version": "0.1.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "check-format": "prettier --check src",
     "eslint": "eslint --max-warnings 0 ./src --ext .ts",
     "lint": "npm run check-format && npm run check-types && npm run eslint",
-    "start-containers": "docker compose up -d",
+    "start-containers": "docker compose up -d --build stela",
     "clear-database": "psql postgresql://postgres:permanent@localhost:5432 -c 'DROP DATABASE IF EXISTS test_permanent;'",
     "create-database": "psql postgresql://postgres:permanent@localhost:5432 -c 'CREATE DATABASE test_permanent;'",
     "set-up-database": "psql postgresql://postgres:permanent@localhost:5432/test_permanent -f database/base.sql",
@@ -43,16 +43,19 @@
     "node": ">=18.0"
   },
   "dependencies": {
+    "@fusionauth/typescript-client": "^1.42.0",
+    "@tsconfig/node18-strictest": "^1.0.0",
+    "@types/http-errors": "^2.0.1",
     "body-parser": "^1.19.0",
     "dotenv": "^8.2.0",
     "express": "^4.17.3",
     "express-winston": "^4.1.0",
+    "http-errors": "^2.0.0",
     "pg": "^8.5.1",
     "require-env-variable": "^3.1.2",
     "tinypg": "^7.0.0",
-    "winston": "^3.3.3",
     "ts-node": "^10.9.1",
-    "@tsconfig/node18-strictest": "^1.0.0"
+    "winston": "^3.3.3"
   },
   "devDependencies": {
     "@types/express": "^4.17.8",

--- a/src/fusionauth.ts
+++ b/src/fusionauth.ts
@@ -1,0 +1,9 @@
+import { FusionAuthClient } from "@fusionauth/typescript-client";
+
+const fusionAuthClient = new FusionAuthClient(
+  process.env["FUSIONAUTH_API_KEY"] ?? "",
+  process.env["FUSIONAUTH_HOST"] ?? "",
+  process.env["FUSIONAUTH_TENANT"] ?? ""
+);
+
+export { fusionAuthClient };

--- a/src/middleware/authentication.test.ts
+++ b/src/middleware/authentication.test.ts
@@ -1,0 +1,121 @@
+import type { IntrospectResponse } from "@fusionauth/typescript-client";
+import ClientResponse from "@fusionauth/typescript-client/build/src/ClientResponse";
+import type { Request, Response } from "express";
+import { verifyUserAuthentication } from "./authentication";
+import { fusionAuthClient } from "../fusionauth";
+
+jest.mock("../fusionauth");
+
+const successfulIntrospectionResponse =
+  new ClientResponse<IntrospectResponse>();
+successfulIntrospectionResponse.statusCode = 200;
+successfulIntrospectionResponse.response = {
+  active: true,
+  email: "test@permanent.org",
+  wasSuccessful: (): boolean => true,
+};
+
+const failedIntrospectionResponse = new ClientResponse<IntrospectResponse>();
+failedIntrospectionResponse.statusCode = 200;
+failedIntrospectionResponse.response = {
+  wasSuccessful: (): boolean => false,
+  exception: { message: "Out of Cheese Error. Redo From Start" },
+};
+
+const expiredTokenIntrospectionResponse =
+  new ClientResponse<IntrospectResponse>();
+expiredTokenIntrospectionResponse.statusCode = 200;
+expiredTokenIntrospectionResponse.response = {
+  active: false,
+  wasSuccessful: (): boolean => true,
+};
+
+const missingEmailIntrospectionResponse =
+  new ClientResponse<IntrospectResponse>();
+missingEmailIntrospectionResponse.statusCode = 200;
+missingEmailIntrospectionResponse.response = {
+  active: true,
+  wasSuccessful: (): boolean => true,
+};
+
+test("should add the email to the request body if the token is valid", async () => {
+  const request = {
+    body: {},
+    get: (_: string) => "Bearer test",
+  } as Request<unknown, unknown, { emailFromAuthToken?: string }>;
+  jest
+    .spyOn(fusionAuthClient, "introspectAccessToken")
+    .mockImplementation(async () => successfulIntrospectionResponse);
+  await verifyUserAuthentication(request, {} as Response, () => {});
+
+  expect(request.body.emailFromAuthToken).toBe("test@permanent.org");
+});
+
+test("should throw unauthorized if authorization header is missing", async () => {
+  const request = {
+    body: {},
+    get: (_: string): string | null => null,
+  } as Request;
+  jest
+    .spyOn(fusionAuthClient, "introspectAccessToken")
+    .mockImplementation(async () => successfulIntrospectionResponse);
+  await verifyUserAuthentication(request, {} as Response, (err) => {
+    expect((err as { statusCode: number }).statusCode).toBe(401);
+  });
+});
+
+test("should throw unauthorized if authorization header has the wrong number of words", async () => {
+  const request = {
+    body: {},
+    get: (_: string) => "test",
+  } as Request;
+  jest
+    .spyOn(fusionAuthClient, "introspectAccessToken")
+    .mockImplementation(async () => successfulIntrospectionResponse);
+  await verifyUserAuthentication(request, {} as Response, (err) => {
+    expect((err as { statusCode: number }).statusCode).toBe(401);
+  });
+});
+
+test("should throw unauthorized if authorization header doesn't start with Bearer", async () => {
+  const request = {
+    body: {},
+    get: (_: string) => "test test",
+  } as Request;
+  jest
+    .spyOn(fusionAuthClient, "introspectAccessToken")
+    .mockImplementation(async () => successfulIntrospectionResponse);
+  await verifyUserAuthentication(request, {} as Response, (err) => {
+    expect((err as { statusCode: number }).statusCode).toBe(401);
+  });
+});
+
+test("should throw unauthorized if token validation call fails", async () => {
+  const request = { body: {}, get: (_: string) => "Bearer test" } as Request;
+  jest
+    .spyOn(fusionAuthClient, "introspectAccessToken")
+    .mockImplementation(async () => failedIntrospectionResponse);
+  await verifyUserAuthentication(request, {} as Response, (err) => {
+    expect((err as { statusCode: number }).statusCode).toBe(401);
+  });
+});
+
+test("should throw unauthorized if token is expired", async () => {
+  const request = { body: {}, get: (_: string) => "Bearer test" } as Request;
+  jest
+    .spyOn(fusionAuthClient, "introspectAccessToken")
+    .mockImplementation(async () => expiredTokenIntrospectionResponse);
+  await verifyUserAuthentication(request, {} as Response, (err) => {
+    expect((err as { statusCode: number }).statusCode).toBe(401);
+  });
+});
+
+test("should throw unauthorized if token doesn't include an email", async () => {
+  const request = { body: {}, get: (_: string) => "Bearer test" } as Request;
+  jest
+    .spyOn(fusionAuthClient, "introspectAccessToken")
+    .mockImplementation(async () => missingEmailIntrospectionResponse);
+  await verifyUserAuthentication(request, {} as Response, (err) => {
+    expect((err as { statusCode: number }).statusCode).toBe(401);
+  });
+});

--- a/src/middleware/authentication.ts
+++ b/src/middleware/authentication.ts
@@ -1,0 +1,57 @@
+import type { RequestHandler, Request, Response, NextFunction } from "express";
+import createError from "http-errors";
+import { fusionAuthClient } from "../fusionauth";
+
+const buildAuthenticationVerifier =
+  (
+    applicationId: string
+  ): RequestHandler<unknown, unknown, { emailFromAuthToken?: string }> =>
+  async (
+    req: Request<unknown, unknown, { emailFromAuthToken?: string }>,
+    _: Response,
+    next: NextFunction
+  ): Promise<void> => {
+    const authorizationHeaderParts = req.get("Authorization")?.split(" ");
+    if (
+      !authorizationHeaderParts ||
+      authorizationHeaderParts.length !== 2 ||
+      authorizationHeaderParts[0] !== "Bearer"
+    ) {
+      next(new createError.Unauthorized("Invalid Authorization header format"));
+      return;
+    }
+    const authenticationToken = authorizationHeaderParts[1];
+
+    const introspectionResponse = await fusionAuthClient.introspectAccessToken(
+      applicationId,
+      authenticationToken ?? ""
+    );
+    if (!introspectionResponse.wasSuccessful()) {
+      next(
+        new createError.Unauthorized(
+          `Token validation failed: ${introspectionResponse.exception.message}`
+        )
+      );
+      return;
+    }
+    if (
+      introspectionResponse.response["active"] !== true ||
+      typeof introspectionResponse.response["email"] !== "string" ||
+      introspectionResponse.response["email"] === ""
+    ) {
+      next(new createError.Unauthorized("Invalid token"));
+      return;
+    }
+
+    req.body.emailFromAuthToken = introspectionResponse.response["email"];
+    next();
+  };
+
+const verifyUserAuthentication = buildAuthenticationVerifier(
+  process.env["FUSIONAUTH_BACKEND_APPLICATION_ID"] ?? ""
+);
+const verifyAdminAuthentication = buildAuthenticationVerifier(
+  process.env["FUSIONAUTH_ADMIN_APPLICATION_ID"] ?? ""
+);
+
+export { verifyUserAuthentication, verifyAdminAuthentication };

--- a/src/middleware/index.ts
+++ b/src/middleware/index.ts
@@ -1,0 +1,4 @@
+export {
+  verifyUserAuthentication,
+  verifyAdminAuthentication,
+} from "./authentication";

--- a/terraform/dev/secrets.tf
+++ b/terraform/dev/secrets.tf
@@ -4,6 +4,7 @@ resource "kubernetes_secret" "dev-secrets" {
   }
 
   data = {
-    "DATABASE_URL" = var.database_url
+    "DATABASE_URL"       = var.database_url
+    "FUSIONAUTH_API_KEY" = var.fusionauth_api_key
   }
 }

--- a/terraform/dev/stela_deployment.tf
+++ b/terraform/dev/stela_deployment.tf
@@ -35,6 +35,36 @@ resource "kubernetes_deployment" "stela" {
             }
           }
 
+          env {
+            name = "FUSIONAUTH_API_KEY"
+            value_from {
+              secret_key_ref {
+                name     = "dev-secrets"
+                key      = "FUSIONAUTH_API_KEY"
+                optional = false
+              }
+            }
+          }
+
+          env {
+            name  = "FUSIONAUTH_HOST"
+            value = var.fusionauth_host
+          }
+
+          env {
+            name  = "FUSIONAUTH_TENANT"
+            value = var.fusionauth_tenant
+          }
+
+          env {
+            name  = "FUSIONAUTH_BACKEND_APPLICATION_ID"
+            value = var.fusionauth_backend_application_id
+          }
+
+          env {
+            name  = "FUSIONAUTH_ADMIN_APPLICATION_ID"
+            value = var.fusionauth_admin_application_id
+          }
 
           port {
             container_port = 80

--- a/terraform/dev/variables.tf
+++ b/terraform/dev/variables.tf
@@ -31,3 +31,32 @@ variable "security_group_id" {
   type        = string
   default     = "sg-eca0e789"
 }
+
+variable "fusionauth_api_key" {
+  description = "API key for the FusionAuth API"
+  type        = string
+}
+
+variable "fusionauth_host" {
+  description = "Host URL for the FusionAuth API"
+  type        = string
+  default     = "https://permanent-dev.fusionauth.io/"
+}
+
+variable "fusionauth_tenant" {
+  description = "ID of the FusionAuth tenant used by this application"
+  type        = string
+  default     = "45586253-3e3b-448c-a27a-44eae469ec35"
+}
+
+variable "fusionauth_backend_application_id" {
+  description = "ID of the FusionAuth application that manages authentication to the web-app's backend"
+  type        = string
+  default     = "0853df7b-d5eb-48d6-bec8-9ec48533b008"
+}
+
+variable "fusionauth_admin_application_id" {
+  description = "ID of the FusionAuth application that manages authentication to the admin portal"
+  type        = string
+  default     = "f2043bfb-9886-4df8-a0f0-7cd1d75651a0"
+}


### PR DESCRIPTION
In order to serve endpoints more substantial than a health check, stela's web server will need to be able to verify the authentication of callers. To this end, this commit adds middleware for verifying user JWTs and admin JWTs (in both cases using FusionAuth).

*Testing Instructions*
* Before testing, you'll have to add FusionAuth environment variables to your `.env` (see updates to README)
* Since there are no endpoints currently existing in this project that need authentication (just a health check), nothing is using the authentication middleware as of this commit. Thus, to test the middleware you'll have to add either
```
apiRoutes.use(verifyUserAuthentication)
```
or
```
apiRoutes.use(verifyAdminAuthentication)
```
to `src/routes/index.ts` right before the `apiRoutes.get` call.
* To test user authentication, add the appropriate middleware to the health check as described above. Observe that after that hitting the endpoint with no "Authorization" header results in a 401, but with an "Authorization" header of the form "Bearer: <A user JWT, such as that returned by `back-end`'s login endpoint>" it will work as usual
* To test admin authentication:
    1. Create a user in FusionAuth on the Local tenant
    2. Add a registration to the user for the admin-local application
    3. Hit FusionAuth's `/api/login` endpoint to get a JWT for that user
    4. Use that JWT to test `stela` admin authentication using the same process used for testing user authentication above