### PR TITLE
PER-9159: Back-end: write read endpoint for directives

### DIFF
--- a/src/directive/controller.ts
+++ b/src/directive/controller.ts
@@ -8,6 +8,8 @@ import {
 import {
   validateCreateDirectiveRequest,
   validateTriggerAdminDirectivesParams,
+  validateGetDirectivesByArchiveIdParams,
+  validateBodyFromAuthentication,
 } from "./validators";
 import { isValidationError } from "../validator_util";
 
@@ -56,6 +58,38 @@ directiveController.post(
           await directiveService.triggerAccountAdminDirectives(
             req.params.accountId
           );
+        res.json(responseBody);
+      } catch (err) {
+        next(err);
+      }
+    }
+  }
+);
+
+directiveController.get(
+  "/archive/:archiveId",
+  verifyUserAuthentication,
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      validateGetDirectivesByArchiveIdParams(req.params);
+      validateBodyFromAuthentication(req.body);
+    } catch (err) {
+      if (isValidationError(err)) {
+        res.status(400).json({ error: err });
+        return;
+      }
+      next(err);
+    }
+
+    if (
+      validateGetDirectivesByArchiveIdParams(req.params) &&
+      validateBodyFromAuthentication(req.body)
+    ) {
+      try {
+        const responseBody = await directiveService.getDirectivesByArchiveId(
+          req.params.archiveId,
+          req.body.emailFromAuthToken
+        );
         res.json(responseBody);
       } catch (err) {
         next(err);

--- a/src/directive/queries/check_archive_ownership.sql
+++ b/src/directive/queries/check_archive_ownership.sql
@@ -10,4 +10,5 @@ SELECT EXISTS (
     archiveId = :archiveId
     AND account.primaryEmail = :email
     AND account_archive.accessRole = 'access.role.owner'
+    AND account_archive.status = 'status.generic.ok'
 ) "hasAccess";

--- a/src/directive/queries/get_directives_by_archive.sql
+++ b/src/directive/queries/get_directives_by_archive.sql
@@ -1,0 +1,28 @@
+SELECT
+  directive.directive_id "directiveId",
+  directive.archive_id "archiveId",
+  directive.type,
+  directive.created_dt "createdDt",
+  directive.updated_dt "updatedDt",
+  directive.steward_account_id "stewardAccountId",
+  directive.note,
+  directive.execution_dt "executionDt",
+  jsonb_build_object(
+    'directiveTriggerId',
+    directive_trigger.directive_trigger_id,
+    'directiveId',
+    directive_trigger.directive_id,
+    'type',
+    directive_trigger.type,
+    'createdDt',
+    directive_trigger.created_dt,
+    'updatedDt',
+    directive_trigger.updated_dt
+  ) "trigger"
+FROM
+  directive
+JOIN
+  directive_trigger
+  ON directive.directive_id = directive_trigger.directive_id
+WHERE
+  directive.archive_id = :archiveId;

--- a/src/directive/service/create.ts
+++ b/src/directive/service/create.ts
@@ -10,24 +10,15 @@ import {
   getInvalidValueFromInvalidEnumMessage,
 } from "../../database_util";
 import { logger } from "../../log";
-
-interface HasAccessResult {
-  hasAccess: boolean;
-}
+import { confirmArchiveOwnership } from "./utils";
 
 export const createDirective = async (
   requestBody: CreateDirectiveRequest
 ): Promise<Directive> => {
-  const accessResult = await db.sql<HasAccessResult>(
-    "directive.queries.check_archive_ownership",
-    {
-      archiveId: requestBody.archiveId,
-      email: requestBody.emailFromAuthToken,
-    }
+  await confirmArchiveOwnership(
+    requestBody.archiveId,
+    requestBody.emailFromAuthToken
   );
-  if (!accessResult.rows[0] || !accessResult.rows[0].hasAccess) {
-    throw new createError.NotFound("Archive not found");
-  }
 
   const directiveToReturn = await db.transaction(async (transactionDb) => {
     const directive = await (async (): Promise<Directive> => {

--- a/src/directive/service/get_by_archive_id.test.ts
+++ b/src/directive/service/get_by_archive_id.test.ts
@@ -1,0 +1,76 @@
+import { NotFound } from "http-errors";
+import { db } from "../../database";
+import { directiveService } from "./index";
+
+jest.mock("../../database");
+
+const testDirectiveId = "39b2a5fa-3508-4030-91b6-21dc6ec7a1ab";
+const testArchiveId = 1;
+const testEmail = "test@permanent.org";
+
+const loadFixtures = async (): Promise<void> => {
+  await db.sql("fixtures.create_test_accounts");
+  await db.sql("fixtures.create_test_archive");
+  await db.sql("fixtures.create_test_account_archive");
+  await db.sql("fixtures.create_test_directive");
+  await db.sql("fixtures.create_test_directive_trigger");
+};
+
+const clearDatabase = async (): Promise<void> => {
+  await db.query(
+    "TRUNCATE account, archive, account_archive, directive, directive_trigger CASCADE"
+  );
+};
+
+describe("getDirectivesByArchiveId", () => {
+  beforeEach(async () => {
+    await clearDatabase();
+    await loadFixtures();
+  });
+  afterEach(async () => {
+    await clearDatabase();
+  });
+
+  test("should return directive from the database", async () => {
+    const response = await directiveService.getDirectivesByArchiveId(
+      testArchiveId,
+      testEmail
+    );
+    expect(response.length).toBe(1);
+    expect(response[0]?.directiveId).toBe(testDirectiveId);
+  });
+
+  test("should throw not found if archive doesn't exist", async () => {
+    let error = null;
+    try {
+      await directiveService.getDirectivesByArchiveId(9999, testEmail);
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error instanceof NotFound).toBe(true);
+    }
+  });
+
+  test("should throw not found if account doesn't own archive", async () => {
+    let error = null;
+    try {
+      await directiveService.getDirectivesByArchiveId(
+        testArchiveId,
+        "test+1@permanent.org"
+      );
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error instanceof NotFound).toBe(true);
+    }
+  });
+
+  test("should return empty list if there are no directives", async () => {
+    await db.query("TRUNCATE directive, directive_trigger");
+    const response = await directiveService.getDirectivesByArchiveId(
+      testArchiveId,
+      testEmail
+    );
+    expect(response.length).toBe(0);
+  });
+});

--- a/src/directive/service/get_by_archive_id.ts
+++ b/src/directive/service/get_by_archive_id.ts
@@ -1,0 +1,15 @@
+import { db } from "../../database";
+import type { Directive } from "../model";
+import { confirmArchiveOwnership } from "./utils";
+
+export const getDirectivesByArchiveId = async (
+  archiveId: number,
+  emailFromAuthToken: string
+): Promise<Directive[]> => {
+  await confirmArchiveOwnership(archiveId, emailFromAuthToken);
+  const directiveRows = await db.sql<Directive>(
+    "directive.queries.get_directives_by_archive",
+    { archiveId }
+  );
+  return directiveRows.rows;
+};

--- a/src/directive/service/index.ts
+++ b/src/directive/service/index.ts
@@ -1,7 +1,9 @@
 import { createDirective } from "./create";
 import { triggerAccountAdminDirectives } from "./trigger_by_account";
+import { getDirectivesByArchiveId } from "./get_by_archive_id";
 
 export const directiveService = {
   createDirective,
   triggerAccountAdminDirectives,
+  getDirectivesByArchiveId,
 };

--- a/src/directive/service/utils.test.ts
+++ b/src/directive/service/utils.test.ts
@@ -1,0 +1,61 @@
+import { NotFound } from "http-errors";
+import { db } from "../../database";
+import { confirmArchiveOwnership } from "./utils";
+
+jest.mock("../../database");
+
+const testArchiveId = 1;
+const testEmail = "test@permanent.org";
+
+const loadFixtures = async (): Promise<void> => {
+  await db.sql("fixtures.create_test_accounts");
+  await db.sql("fixtures.create_test_archive");
+  await db.sql("fixtures.create_test_account_archive");
+};
+
+const clearDatabase = async (): Promise<void> => {
+  await db.query("TRUNCATE account, archive, account_archive CASCADE");
+};
+
+describe("confirmArchiveOwnership", () => {
+  beforeEach(async () => {
+    await clearDatabase();
+    await loadFixtures();
+  });
+  afterEach(async () => {
+    await clearDatabase();
+  });
+
+  test("should not error if account owns archive", async () => {
+    let error = null;
+    try {
+      await confirmArchiveOwnership(testArchiveId, testEmail);
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).toBeNull();
+    }
+  });
+
+  test("should return NotFound error if account doesn't own archive", async () => {
+    let error = null;
+    try {
+      await confirmArchiveOwnership(testArchiveId, "test+1@permanent.org");
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error instanceof NotFound).toBe(true);
+    }
+  });
+
+  test("should return NotFound error if archive doesn't exist", async () => {
+    let error = null;
+    try {
+      await confirmArchiveOwnership(9999, testEmail);
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error instanceof NotFound).toBe(true);
+    }
+  });
+});

--- a/src/directive/service/utils.ts
+++ b/src/directive/service/utils.ts
@@ -1,0 +1,22 @@
+import createError from "http-errors";
+import { db } from "../../database";
+
+interface HasAccessResult {
+  hasAccess: boolean;
+}
+
+export const confirmArchiveOwnership = async (
+  archiveId: number,
+  email: string
+): Promise<void> => {
+  const accessResult = await db.sql<HasAccessResult>(
+    "directive.queries.check_archive_ownership",
+    {
+      archiveId,
+      email,
+    }
+  );
+  if (!accessResult.rows[0] || !accessResult.rows[0].hasAccess) {
+    throw new createError.NotFound("Archive not found");
+  }
+};

--- a/src/directive/validators.test.ts
+++ b/src/directive/validators.test.ts
@@ -1,6 +1,8 @@
 import {
   validateCreateDirectiveRequest,
   validateTriggerAdminDirectivesParams,
+  validateGetDirectivesByArchiveIdParams,
+  validateBodyFromAuthentication,
 } from "./validators";
 
 describe("validateCreateDirectiveRequest", () => {
@@ -254,7 +256,9 @@ describe("validateCreateDirectiveRequest", () => {
         archiveId: 1,
         stewardAccountId: 1,
         type: "transfer",
-        trigger: "admin",
+        trigger: {
+          type: "admin",
+        },
       });
     } catch (err) {
       error = err;
@@ -270,7 +274,27 @@ describe("validateCreateDirectiveRequest", () => {
         archiveId: 1,
         stewardAccountId: 1,
         type: "transfer",
-        trigger: "admin",
+        trigger: {
+          type: "admin",
+        },
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+  test("should raise an error if emailFromAuthToken is wrong type", () => {
+    let error = null;
+    try {
+      validateCreateDirectiveRequest({
+        emailFromAuthToken: 1,
+        archiveId: 1,
+        stewardAccountId: 1,
+        type: "transfer",
+        trigger: {
+          type: "admin",
+        },
       });
     } catch (err) {
       error = err;
@@ -320,6 +344,104 @@ describe("validateTriggerAdminDirectivesParams", () => {
     try {
       validateTriggerAdminDirectivesParams({
         accountId: 0,
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+});
+
+describe("validateGetDirectivesByArchiveIdParams", () => {
+  test("should find no errors in valid parameter set", () => {
+    let error = null;
+    try {
+      validateGetDirectivesByArchiveIdParams({
+        archiveId: 1,
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).toBeNull();
+    }
+  });
+  test("should raise an error if archiveId is missing", () => {
+    let error = null;
+    try {
+      validateGetDirectivesByArchiveIdParams({});
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+  test("should raise an error if archiveId is the wrong type", () => {
+    let error = null;
+    try {
+      validateGetDirectivesByArchiveIdParams({
+        archiveId: "one",
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+  test("should raise an error if archiveId is an invalid value", () => {
+    let error = null;
+    try {
+      validateGetDirectivesByArchiveIdParams({
+        archiveId: 0,
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+});
+
+describe("validateBodyFromAuthentication", () => {
+  test("should find no errors in valid parameter set", () => {
+    let error = null;
+    try {
+      validateBodyFromAuthentication({
+        emailFromAuthToken: "test@permanent.org",
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).toBeNull();
+    }
+  });
+  test("should raise an error if emailFromAuthToken is missing", () => {
+    let error = null;
+    try {
+      validateBodyFromAuthentication({});
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+  test("should raise an error if emailFromAuthToken is the wrong type", () => {
+    let error = null;
+    try {
+      validateBodyFromAuthentication({
+        emailFromAuthToken: 1,
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+  test("should raise an error if emailFromAuthToken is an invalid value", () => {
+    let error = null;
+    try {
+      validateBodyFromAuthentication({
+        emailFromAuthToken: "not_an_email",
       });
     } catch (err) {
       error = err;

--- a/src/directive/validators.ts
+++ b/src/directive/validators.ts
@@ -41,3 +41,29 @@ export const validateTriggerAdminDirectivesParams = (
   }
   return true;
 };
+
+export const validateGetDirectivesByArchiveIdParams = (
+  data: unknown
+): data is { archiveId: number } => {
+  const validation = Joi.object()
+    .keys({
+      archiveId: Joi.number().integer().min(1).required(),
+    })
+    .validate(data);
+  if (validation.error) {
+    throw validation.error;
+  }
+  return true;
+};
+
+export const validateBodyFromAuthentication = (
+  data: unknown
+): data is { emailFromAuthToken: string } => {
+  const validation = Joi.object()
+    .keys({ emailFromAuthToken: Joi.string().email().required() })
+    .validate(data);
+  if (validation.error) {
+    throw validation.error;
+  }
+  return true;
+};


### PR DESCRIPTION
This is build atop the PER-9148 PR, so if that isn't merged yet compare to `per-9148` to see what's new here.