### PR TITLE
Allow tests to access secrets during deploy workflow

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   run_tests:
     uses: ./.github/workflows/test.yml
+    secrets: inherit
+
   build:
     needs:
       - run_tests


### PR DESCRIPTION
It turns out that secrets don't automatically propagate to workflows called from other workflows. This means while the test workflow can check out `back-end` and `devenv` just fine when run on it's own, it can't when called from the deploy workflow. This commit fixes that issue by telling the deploy workflow to let the test workflow see secrets.