### PR TITLE
Add env vars for calls to legacy backend

### DIFF
--- a/terraform/dev/secrets.tf
+++ b/terraform/dev/secrets.tf
@@ -4,7 +4,8 @@ resource "kubernetes_secret" "dev-secrets" {
   }
 
   data = {
-    "DATABASE_URL"       = var.database_url
-    "FUSIONAUTH_API_KEY" = var.fusionauth_api_key
+    "DATABASE_URL"                 = var.database_url
+    "FUSIONAUTH_API_KEY"           = var.fusionauth_api_key
+    "LEGACY_BACKEND_SHARED_SECRET" = var.legacy_backend_shared_secret
   }
 }

--- a/terraform/dev/stela_deployment.tf
+++ b/terraform/dev/stela_deployment.tf
@@ -47,6 +47,17 @@ resource "kubernetes_deployment" "stela" {
           }
 
           env {
+            name = "LEGACY_BACKEND_SHARED_SECRET"
+            value_from {
+              secret_key_ref {
+                name     = "dev-secrets"
+                key      = "LEGACY_BACKEND_SHARED_SECRET"
+                optional = false
+              }
+            }
+          }
+
+          env {
             name  = "FUSIONAUTH_HOST"
             value = var.fusionauth_host
           }
@@ -64,6 +75,11 @@ resource "kubernetes_deployment" "stela" {
           env {
             name  = "FUSIONAUTH_ADMIN_APPLICATION_ID"
             value = var.fusionauth_admin_application_id
+          }
+
+          env {
+            name  = "LEGACY_BACKEND_HOST_URL"
+            value = var.legacy_backend_host_url
           }
 
           port {

--- a/terraform/dev/variables.tf
+++ b/terraform/dev/variables.tf
@@ -52,11 +52,22 @@ variable "fusionauth_tenant" {
 variable "fusionauth_backend_application_id" {
   description = "ID of the FusionAuth application that manages authentication to the web-app's backend"
   type        = string
-  default     = "0853df7b-d5eb-48d6-bec8-9ec48533b008"
+  default     = "8048057e-4f77-406a-a77d-2962a81cea21"
 }
 
 variable "fusionauth_admin_application_id" {
   description = "ID of the FusionAuth application that manages authentication to the admin portal"
   type        = string
   default     = "f2043bfb-9886-4df8-a0f0-7cd1d75651a0"
+}
+
+variable "legacy_backend_host_url" {
+  description = "Host URL of the legacy PHP backend"
+  type        = string
+  default     = "https://dev.permanent.org/api"
+}
+
+variable "legacy_backend_shared_secret" {
+  description = "Shared secret for authenticating calls to the legacy backend"
+  type        = string
 }


### PR DESCRIPTION
A previous commit added a client to make calls to `back-end`, but didn't add the necessary env vars for that client to terraform. This commit adds them.