### PR TITLE
Don't try to execute directives that are already successfully executed

### DIFF
--- a/src/directive/queries/get_admin_directive_execution_data_by_account.sql
+++ b/src/directive/queries/get_admin_directive_execution_data_by_account.sql
@@ -22,4 +22,5 @@ WHERE
   account_archive.accountId = :accountId
   AND account_archive.accessRole = 'access.role.owner'
   AND account_archive.status = 'status.generic.ok'
-  AND directive_trigger.type = 'admin';
+  AND directive_trigger.type = 'admin'
+  AND directive.execution_dt IS NULL;


### PR DESCRIPTION
Currently, nothing prevents a directive that has been successfully executed from appearing in the list of directives to execute when an account's admin directives are triggered. This would result in a confusing error, as the already executed directive would fail to execute again. To solve this problem, this commit prevents successfully executed directives from being reprocessed.