### PR TITLE
Stop depending on local pg_dump version (to discuss)

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start-containers": "docker compose up -d --build stela",
     "clear-database": "psql postgresql://postgres:permanent@localhost:5432 -c 'DROP DATABASE IF EXISTS test_permanent;'",
     "create-database": "psql postgresql://postgres:permanent@localhost:5432 -c 'CREATE DATABASE test_permanent;'",
-    "set-up-database": "pg_dump postgresql://postgres:permanent@localhost:5432/permanent --schema-only | psql postgresql://postgres:permanent@localhost:5432/test_permanent",
+    "set-up-database": "docker exec --env='PGPASSWORD=permanent' devenv_database_1 pg_dump -U postgres permanent --schema-only | psql postgresql://postgres:permanent@localhost:5432/test_permanent",
     "clear-database-ci": "psql postgresql://postgres:permanent@database:5432 -c 'DROP DATABASE IF EXISTS test_permanent;'",
     "create-database-ci": "psql postgresql://postgres:permanent@database:5432 -c 'CREATE DATABASE test_permanent;'",
     "set-up-database-ci": "pg_dump postgresql://postgres:permanent@database:5432/permanent --schema-only | psql postgresql://postgres:permanent@database:5432/test_permanent",


### PR DESCRIPTION
I ran into a problem where my local pg_dump was an older version than the one in the containers, so I couldn't load the database and tests failed. It seems to me that it shouldn't matter what version I'm on in the host.

This change works, but `devenv_database_1` seems like the wrong name to use - shouldn't just "database" work? It didn't for me, but I could be missing something. Will `devenv_database_1` always be the name of the container?