### PR TITLE
Ensure host file changes are picked up

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       dockerfile: Dockerfile.test
     networks:
       - devenv
+    volumes:
+      - ../stela:/usr/local/apps/stela
 networks:
   devenv:
     name: devenv_default


### PR DESCRIPTION
Without this change, local changes weren't being reflected in the test container, causing unexpected results. This also makes the dev and test containers more similar.