### PR TITLE
Add create endpoint for legacy contacts

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "start-containers": "docker compose up -d --build stela",
     "clear-database": "psql postgresql://postgres:permanent@localhost:5432 -c 'DROP DATABASE IF EXISTS test_permanent;'",
     "create-database": "psql postgresql://postgres:permanent@localhost:5432 -c 'CREATE DATABASE test_permanent;'",
-    "set-up-database": "docker exec --env='PGPASSWORD=permanent' devenv_database_1 pg_dump -U postgres permanent --schema-only | psql postgresql://postgres:permanent@localhost:5432/test_permanent",
+    "set-up-database": "docker exec --env='PGPASSWORD=permanent' devenv-database-1 pg_dump -U postgres permanent --schema-only | psql postgresql://postgres:permanent@localhost:5432/test_permanent",
     "clear-database-ci": "psql postgresql://postgres:permanent@database:5432 -c 'DROP DATABASE IF EXISTS test_permanent;'",
     "create-database-ci": "psql postgresql://postgres:permanent@database:5432 -c 'CREATE DATABASE test_permanent;'",
     "set-up-database-ci": "pg_dump postgresql://postgres:permanent@database:5432/permanent --schema-only | psql postgresql://postgres:permanent@database:5432/test_permanent",

--- a/src/legacy_contact/controller.ts
+++ b/src/legacy_contact/controller.ts
@@ -1,0 +1,33 @@
+import { Router } from "express";
+import type { Request, Response, NextFunction } from "express";
+import { verifyUserAuthentication } from "../middleware";
+import { validateCreateLegacyContactRequest } from "./validators";
+import { isValidationError } from "../validator_util";
+import { legacyContactService } from "./service";
+
+export const legacyContactController = Router();
+legacyContactController.post(
+  "/",
+  verifyUserAuthentication,
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      validateCreateLegacyContactRequest(req.body);
+    } catch (err) {
+      if (isValidationError(err)) {
+        res.status(400).json({ error: err });
+        return;
+      }
+      next(err);
+    }
+    if (validateCreateLegacyContactRequest(req.body)) {
+      try {
+        const legacyContact = await legacyContactService.createLegacyContact(
+          req.body
+        );
+        res.json(legacyContact);
+      } catch (err) {
+        next(err);
+      }
+    }
+  }
+);

--- a/src/legacy_contact/index.ts
+++ b/src/legacy_contact/index.ts
@@ -1,0 +1,1 @@
+export { legacyContactController } from "./controller";

--- a/src/legacy_contact/model.ts
+++ b/src/legacy_contact/model.ts
@@ -1,0 +1,14 @@
+export interface CreateLegacyContactRequest {
+  emailFromAuthToken: string;
+  email: string;
+  name: string;
+}
+
+export interface LegacyContact {
+  legacyContactId: string;
+  accountId: string;
+  name: string;
+  email: string;
+  createdDt: Date;
+  updatedDt: Date;
+}

--- a/src/legacy_contact/queries/create_legacy_contact.sql
+++ b/src/legacy_contact/queries/create_legacy_contact.sql
@@ -1,0 +1,21 @@
+INSERT INTO
+  legacy_contact (account_id, name, email)
+VALUES (
+  (
+    SELECT
+      accountId
+    FROM
+      account
+    WHERE
+      primaryEmail = :accountEmail
+  ),
+  :name,
+  :email
+)
+RETURNING
+  legacy_contact_id "legacyContactId",
+  account_id "accountId",
+  name,
+  email,
+  created_dt "createdDt",
+  updated_dt "updatedDt";

--- a/src/legacy_contact/service/create.test.ts
+++ b/src/legacy_contact/service/create.test.ts
@@ -1,0 +1,83 @@
+import { InternalServerError } from "http-errors";
+import { db } from "../../database";
+import { legacyContactService } from "./index";
+import type { LegacyContact } from "../model";
+
+jest.mock("../../database");
+
+const loadFixtures = async (): Promise<void> => {
+  await db.sql("fixtures.create_test_accounts");
+};
+
+const clearDatabase = async (): Promise<void> => {
+  await db.query("TRUNCATE account, legacy_contact CASCADE");
+};
+
+describe("createLegacyContact", () => {
+  beforeEach(async () => {
+    await clearDatabase();
+    await loadFixtures();
+  });
+  afterEach(async () => {
+    await clearDatabase();
+  });
+
+  test("should successfully create a legacy contact", async () => {
+    await legacyContactService.createLegacyContact({
+      emailFromAuthToken: "test@permanent.org",
+      name: "Legacy Contact",
+      email: "legacy.contact@permanent.org",
+    });
+
+    const legacyContactResult = await db.query<LegacyContact>(
+      `SELECT
+        legacy_contact_id "legacyContactId",
+        account_id "accountId",
+        name,
+        email,
+        created_dt "createdDt",
+        updated_dt "updatedDt"
+      FROM
+        legacy_contact
+      WHERE
+        account_id = :accountId`,
+      { accountId: 2 }
+    );
+    expect(legacyContactResult.rows.length).toBe(1);
+  });
+
+  test("should error if emailFromAuthToken doesn't correspond to an account", async () => {
+    let error = null;
+    try {
+      await legacyContactService.createLegacyContact({
+        emailFromAuthToken: "not_an_account@permanent.org",
+        name: "Legacy Contact",
+        email: "legacy.contact@permanent.org",
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error instanceof InternalServerError).toBe(true);
+    }
+  });
+
+  test("should error if legacy contact can't be created", async () => {
+    let error = null;
+    try {
+      jest
+        .spyOn(db, "sql")
+        .mockImplementationOnce(
+          (async () => ({ rows: [] } as object)) as unknown as typeof db.sql
+        );
+      await legacyContactService.createLegacyContact({
+        emailFromAuthToken: "not_an_account@permanent.org",
+        name: "Legacy Contact",
+        email: "legacy.contact@permanent.org",
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error instanceof InternalServerError).toBe(true);
+    }
+  });
+});

--- a/src/legacy_contact/service/create.ts
+++ b/src/legacy_contact/service/create.ts
@@ -1,0 +1,28 @@
+import createError from "http-errors";
+import type { CreateLegacyContactRequest, LegacyContact } from "../model";
+import { db } from "../../database";
+import { logger } from "../../log";
+
+export const createLegacyContact = async (
+  requestBody: CreateLegacyContactRequest
+): Promise<LegacyContact> => {
+  try {
+    const legacyContactResult = await db.sql<LegacyContact>(
+      "legacy_contact.queries.create_legacy_contact",
+      {
+        accountEmail: requestBody.emailFromAuthToken,
+        name: requestBody.name,
+        email: requestBody.email,
+      }
+    );
+    if (legacyContactResult.rows[0] === undefined) {
+      throw new Error();
+    }
+    return legacyContactResult.rows[0];
+  } catch (err) {
+    logger.error(err);
+    throw new createError.InternalServerError(
+      "Failed to create legacy contact"
+    );
+  }
+};

--- a/src/legacy_contact/service/index.ts
+++ b/src/legacy_contact/service/index.ts
@@ -1,0 +1,5 @@
+import { createLegacyContact } from "./create";
+
+export const legacyContactService = {
+  createLegacyContact,
+};

--- a/src/legacy_contact/validators.test.ts
+++ b/src/legacy_contact/validators.test.ts
@@ -1,0 +1,127 @@
+import { validateCreateLegacyContactRequest } from "./validators";
+
+describe("validateCreateLegacyContactRequest", () => {
+  test("should find no errors in a valid request", () => {
+    let error = null;
+    try {
+      validateCreateLegacyContactRequest({
+        emailFromAuthToken: "test@permanent.org",
+        email: "test+1@permanent.org",
+        name: "John Rando",
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).toBeNull();
+    }
+  });
+  test("should raise an error if emailFromAuthToken is missing", () => {
+    let error = null;
+    try {
+      validateCreateLegacyContactRequest({
+        email: "test+1@permanent.org",
+        name: "John Rando",
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+  test("should raise an error if emailFromAuthToken is wrong type", () => {
+    let error = null;
+    try {
+      validateCreateLegacyContactRequest({
+        emailFromAuthToken: 1,
+        email: "test+1@permanent.org",
+        name: "John Rando",
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+  test("should raise an error if emailFromAuthToken is wrong format", () => {
+    let error = null;
+    try {
+      validateCreateLegacyContactRequest({
+        emailFromAuthToken: "not_an_email",
+        email: "test+1@permanent.org",
+        name: "John Rando",
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+  test("should raise an error if email is missing", () => {
+    let error = null;
+    try {
+      validateCreateLegacyContactRequest({
+        emailFromAuthToken: "test@permanent.org",
+        name: "John Rando",
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+  test("should raise an error if email is wrong type", () => {
+    let error = null;
+    try {
+      validateCreateLegacyContactRequest({
+        emailFromAuthToken: "test@permanent.org",
+        email: 1,
+        name: "John Rando",
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+  test("should raise an error if email is wrong format", () => {
+    let error = null;
+    try {
+      validateCreateLegacyContactRequest({
+        emailFromAuthToken: "test@permanent.org",
+        email: "not_an_email",
+        name: "John Rando",
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+  test("should raise an error if name is missing", () => {
+    let error = null;
+    try {
+      validateCreateLegacyContactRequest({
+        emailFromAuthToken: "test@permanent.org",
+        email: "test+1@permanent.org",
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+  test("should raise an error if name is wrong type", () => {
+    let error = null;
+    try {
+      validateCreateLegacyContactRequest({
+        emailFromAuthToken: "test@permanent.org",
+        email: "test+1@permanent.org",
+        name: 1,
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+});

--- a/src/legacy_contact/validators.ts
+++ b/src/legacy_contact/validators.ts
@@ -1,0 +1,18 @@
+import Joi from "joi";
+import type { CreateLegacyContactRequest } from "./model";
+
+export const validateCreateLegacyContactRequest = (
+  data: unknown
+): data is CreateLegacyContactRequest => {
+  const validation = Joi.object()
+    .keys({
+      emailFromAuthToken: Joi.string().email().required(),
+      email: Joi.string().email().required(),
+      name: Joi.string().required(),
+    })
+    .validate(data);
+  if (validation.error) {
+    throw validation.error;
+  }
+  return true;
+};

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -1,9 +1,11 @@
 import express from "express";
 import { healthController } from "../health";
 import { directiveController } from "../directive";
+import { legacyContactController } from "../legacy_contact";
 
 const apiRoutes = express.Router();
 apiRoutes.get("/health", healthController.getHealth);
 apiRoutes.use("/directive", directiveController);
+apiRoutes.use("/legacy-contact", legacyContactController);
 
 export { apiRoutes };


### PR DESCRIPTION
To support our legacy planning feature, users need to be able to record legacy contacts in our system. This commit adds an endpoint for creating such records.