### PR TITLE
Fix separation between staging and dev in the test EKS cluster

### DIFF
--- a/terraform/test_cluster/eks-cluster.tf
+++ b/terraform/test_cluster/eks-cluster.tf
@@ -8,7 +8,7 @@ module "eks" {
   vpc_id                         = var.vpc_id
   subnet_ids                     = var.subnet_ids
   cluster_endpoint_public_access = true
-  cluster_security_group_id      = var.security_group_id
+  cluster_security_group_id      = var.dev_security_group_id
   aws_auth_users = [
     {
       userarn  = "arn:aws:iam::364159549467:user/liam"
@@ -36,7 +36,7 @@ module "eks" {
     one = {
       name = "node-group-1"
 
-      vpc_security_group_ids = [var.security_group_id]
+      vpc_security_group_ids = [var.dev_security_group_id, var.staging_security_group_id]
 
       instance_types = ["t3.small"]
 

--- a/terraform/test_cluster/stela_dev_deployment.tf
+++ b/terraform/test_cluster/stela_dev_deployment.tf
@@ -2,7 +2,7 @@ resource "kubernetes_deployment" "stela_dev" {
   metadata {
     name = "stela-dev"
     labels = {
-      App         = "stela"
+      App         = "stela-dev"
       Environment = "dev"
     }
   }
@@ -11,13 +11,13 @@ resource "kubernetes_deployment" "stela_dev" {
     replicas = 2
     selector {
       match_labels = {
-        App = "stela"
+        App = "stela-dev"
       }
     }
     template {
       metadata {
         labels = {
-          App = "stela"
+          App = "stela-dev"
         }
       }
       spec {

--- a/terraform/test_cluster/stela_staging_deployment.tf
+++ b/terraform/test_cluster/stela_staging_deployment.tf
@@ -2,7 +2,7 @@ resource "kubernetes_deployment" "stela_staging" {
   metadata {
     name = "stela-staging"
     labels = {
-      App         = "stela"
+      App         = "stela-staging"
       Environment = "staging"
     }
   }
@@ -11,13 +11,13 @@ resource "kubernetes_deployment" "stela_staging" {
     replicas = 2
     selector {
       match_labels = {
-        App = "stela"
+        App = "stela-staging"
       }
     }
     template {
       metadata {
         labels = {
-          App = "stela"
+          App = "stela-staging"
         }
       }
       spec {

--- a/terraform/test_cluster/variables.tf
+++ b/terraform/test_cluster/variables.tf
@@ -36,10 +36,16 @@ variable "stela_staging_image" {
   type        = string
 }
 
-variable "security_group_id" {
-  description = "ID of the security group the cluster should exist in"
+variable "dev_security_group_id" {
+  description = "ID of the Development security group"
   type        = string
   default     = "sg-eca0e789"
+}
+
+variable "staging_security_group_id" {
+  description = "ID of the Staging security group"
+  type        = string
+  default     = "sg-fea0e79b"
 }
 
 variable "dev_fusionauth_api_key" {


### PR DESCRIPTION
Currently, requests to `stela` endpoints in `dev` or `staging` can end up routed to a pod from the other environment. This commit should fix that.