### PR TITLE
Return errors as JSON

### DIFF
--- a/API.md
+++ b/API.md
@@ -2,6 +2,18 @@
 
 - Path: `<host>/api/v2`
 
+## Errors
+Errors that can be foreseen, including any errors intended to be part of client control flow, will come with a JSON
+response body, of the form
+```
+{
+  "error": <error object>
+}
+```
+
+For most errors, the error object will include at least a "message" field describing the error. Validation errors will
+instead return a [Joi ValidationError object](https://joi.dev/api/?v=17.9.1#validationerror).
+
 ## Directives
 
 ### POST `/directive`

--- a/src/app.ts
+++ b/src/app.ts
@@ -3,10 +3,12 @@ import expressWinston from "express-winston";
 import bodyParser from "body-parser";
 import { apiRoutes } from "./routes";
 import { logger } from "./log";
+import { handleHttpError } from "./middleware/handleHttpError";
 
 const app = express();
 app.use(expressWinston.logger({ level: "http", winstonInstance: logger }));
 app.use(bodyParser.json());
 app.use("/api/v2", apiRoutes);
+app.use(handleHttpError);
 
 export { app };

--- a/src/middleware/handleHttpError.ts
+++ b/src/middleware/handleHttpError.ts
@@ -1,0 +1,18 @@
+import type { Request, Response, NextFunction } from "express";
+import type { HttpError } from "http-errors";
+
+const isHttpError = (err: unknown): err is HttpError =>
+  !!(err as HttpError).statusCode;
+
+export const handleHttpError = async (
+  err: unknown,
+  _: Request,
+  res: Response,
+  next: NextFunction
+): Promise<void> => {
+  if (isHttpError(err)) {
+    res.status(err.statusCode).json({ error: err });
+  } else {
+    next(err);
+  }
+};


### PR DESCRIPTION
Since stela endpoints return their normal responses and their validation errors as JSON, they should return other errors as JSON too so clients only need to parse one format when consuming this API. This commit adds middleware to translate HTTP errors into JSON before returning them to the client. It also adds documentation on our error formats to the API documentation file.