### PR TITLE
Return steward name and email on GET

### DIFF
--- a/API.md
+++ b/API.md
@@ -49,7 +49,7 @@ instead return a [Joi ValidationError object](https://joi.dev/api/?v=17.9.1#vali
     createdDt: string (date),
     updatedDt: string (date),
   },
-  stewardAccountId: string,
+  stewardEmail: string,
   note: string,
   executionDt: string (date)
 }
@@ -104,7 +104,7 @@ instead return a [Joi ValidationError object](https://joi.dev/api/?v=17.9.1#vali
     createdDt: string (date),
     updatedDt: string (date),
   },
-  stewardAccountId: string,
+  stewardEmail: string,
   note: string,
   executionDt: string (date)
 }
@@ -130,7 +130,8 @@ instead return a [Joi ValidationError object](https://joi.dev/api/?v=17.9.1#vali
       createdDt: string (date),
       updatedDt: string (date),
     },
-    stewardAccountId: string,
+    stewardEmail: string,
+    stewardName: string,
     note: string,
     executionDt: string (date)
   }

--- a/API.md
+++ b/API.md
@@ -49,7 +49,10 @@ instead return a [Joi ValidationError object](https://joi.dev/api/?v=17.9.1#vali
     createdDt: string (date),
     updatedDt: string (date),
   },
-  stewardEmail: string,
+  steward {
+    email: string,
+    name: string,
+  }
   note: string,
   executionDt: string (date)
 }
@@ -104,7 +107,10 @@ instead return a [Joi ValidationError object](https://joi.dev/api/?v=17.9.1#vali
     createdDt: string (date),
     updatedDt: string (date),
   },
-  stewardEmail: string,
+  steward {
+    email: string,
+    name: string,
+  }
   note: string,
   executionDt: string (date)
 }
@@ -130,8 +136,10 @@ instead return a [Joi ValidationError object](https://joi.dev/api/?v=17.9.1#vali
       createdDt: string (date),
       updatedDt: string (date),
     },
-    stewardEmail: string,
-    stewardName: string,
+    steward: {
+      email: string,
+      name: string,
+    },
     note: string,
     executionDt: string (date)
   }

--- a/src/directive/model.ts
+++ b/src/directive/model.ts
@@ -34,7 +34,7 @@ export interface Directive {
   createdDt: Date;
   updatedDt: Date;
   trigger: DirectiveTrigger;
-  stewardAccountId?: string;
+  steward?: DirectiveSteward;
   note?: string;
   executionDt?: Date;
 }
@@ -44,4 +44,9 @@ export interface DirectiveExecutionResult {
   directiveId: string;
   outcome: "error" | "success";
   errorMessage?: string;
+}
+
+export interface DirectiveSteward {
+  email: string;
+  name: string;
 }

--- a/src/directive/queries/create_directive.sql
+++ b/src/directive/queries/create_directive.sql
@@ -21,11 +21,16 @@ RETURNING
   updated_dt "updatedDt",
   (
     SELECT
-      primaryEmail
+    jsonb_build_object(
+      'email',
+      primaryEmail,
+      'name',
+      fullName
+    )
     FROM
       account
     WHERE
       accountId = steward_account_id
-  ) "stewardEmail",
+  ) "steward",
   note,
   execution_dt "executionDt";

--- a/src/directive/queries/get_directives_by_archive.sql
+++ b/src/directive/queries/get_directives_by_archive.sql
@@ -4,7 +4,8 @@ SELECT
   directive.type,
   directive.created_dt "createdDt",
   directive.updated_dt "updatedDt",
-  directive.steward_account_id "stewardAccountId",
+  account.primaryEmail "stewardEmail",
+  account.fullName "stewardName",
   directive.note,
   directive.execution_dt "executionDt",
   jsonb_build_object(
@@ -24,5 +25,8 @@ FROM
 JOIN
   directive_trigger
   ON directive.directive_id = directive_trigger.directive_id
+JOIN
+  account
+  ON directive.steward_account_id = account.accountId
 WHERE
   directive.archive_id = :archiveId;

--- a/src/directive/queries/get_directives_by_archive.sql
+++ b/src/directive/queries/get_directives_by_archive.sql
@@ -4,8 +4,12 @@ SELECT
   directive.type,
   directive.created_dt "createdDt",
   directive.updated_dt "updatedDt",
-  account.primaryEmail "stewardEmail",
-  account.fullName "stewardName",
+  jsonb_build_object(
+    'email',
+    account.primaryEmail,
+    'name',
+    account.fullName
+  ) "steward",
   directive.note,
   directive.execution_dt "executionDt",
   jsonb_build_object(

--- a/src/directive/queries/update_directive.sql
+++ b/src/directive/queries/update_directive.sql
@@ -24,11 +24,16 @@ RETURNING
   updated_dt "updatedDt",
   (
     SELECT
-      primaryEmail
+    jsonb_build_object(
+      'email',
+      primaryEmail,
+      'name',
+      fullName
+    )
     FROM
       account
     WHERE
       accountId = steward_account_id
-  ) "stewardEmail",
+  ) "steward",
   note,
   execution_dt "executionDt";

--- a/src/directive/service/update.test.ts
+++ b/src/directive/service/update.test.ts
@@ -45,7 +45,19 @@ describe("updateDirective", () => {
         type,
         created_dt "createdDt",
         updated_dt "updatedDt",
-        steward_account_id "stewardAccountId",
+        (
+          SELECT
+          jsonb_build_object(
+            'email',
+            primaryEmail,
+            'name',
+            fullName
+          )
+          FROM
+            account
+          WHERE
+            accountId = steward_account_id
+        ) "steward",
         note,
         execution_dt "executionDt"
       FROM
@@ -55,7 +67,9 @@ describe("updateDirective", () => {
       { archiveId: 1 }
     );
     expect(directiveResult.rows.length).toBe(1);
-    expect(directiveResult.rows[0]?.stewardAccountId).toBe("4");
+    expect(directiveResult.rows[0]?.steward?.email).toBe(
+      "test+2@permanent.org"
+    );
     expect(directiveResult.rows[0]?.note).toBe(testNote);
     expect(directiveResult.rows[0]?.type).toBe("transfer");
 


### PR DESCRIPTION
Also update documentation. The other endpoints were correctly returning the email instead of the account id, but this one was not. @luciancerbu-vsp also requested that we return the name, so I included that - let me know if that'll be a problem.