### PR TITLE
Send note and isLegacyAction flag to /archive/transferOwnership

### DIFF
--- a/src/directive/queries/get_admin_directive_execution_data_by_account.sql
+++ b/src/directive/queries/get_admin_directive_execution_data_by_account.sql
@@ -2,6 +2,7 @@ SELECT
   directive.directive_id "directiveId",
   directive.archive_id "archiveId",
   directive.type "directiveType",
+  directive.note,
   archive.archiveNbr "archiveSlug",
   account.primaryEmail "stewardEmail"
 FROM

--- a/src/directive/service/trigger_by_account.ts
+++ b/src/directive/service/trigger_by_account.ts
@@ -14,6 +14,7 @@ export const triggerAccountAdminDirectives = async (
     directiveId: string;
     archiveId: string;
     directiveType: string;
+    note: string;
   }>("directive.queries.get_admin_directive_execution_data_by_account", {
     accountId,
   });
@@ -24,7 +25,9 @@ export const triggerAccountAdminDirectives = async (
         if (directive.directiveType === "transfer") {
           const response = await legacyClient.transferArchiveOwnership(
             directive.stewardEmail,
-            directive.archiveSlug
+            directive.archiveSlug,
+            directive.note,
+            true
           );
           if (response.status === 200) {
             return {

--- a/src/legacy_client.ts
+++ b/src/legacy_client.ts
@@ -7,6 +7,8 @@ const authenticationSecret = process.env["LEGACY_BACKEND_SHARED_SECRET"] ?? "";
 const transferArchiveOwnership = async (
   recipientEmail: string,
   archiveSlug: string,
+  message?: string,
+  isLegacyAction?: boolean,
   storageGiftInMB?: number
 ): Promise<Response> => {
   const response = await fetch(`${hostUrl}/archive/transferOwnership`, {
@@ -20,6 +22,8 @@ const transferArchiveOwnership = async (
       recipientEmail,
       archiveNbr: archiveSlug,
       storageGiftInMB: storageGiftInMB ?? 0,
+      isLegacyAction: isLegacyAction ?? false,
+      message: message ?? null,
     }),
   });
 


### PR DESCRIPTION
We are updating the /archive/transferOwnership endpoint to send a separate email when the transfer is happening as part of a legacy plan. This commit updates the call to /archive/transferOwnership upon executing a directive to identify the action as part of a legacy call, and includes the note associated with the directive so it can be included in the email.