### PR TITLE
Fix validator util import in account controller

### DIFF
--- a/src/account/controller.ts
+++ b/src/account/controller.ts
@@ -2,7 +2,7 @@ import { Router } from "express";
 import type { Request, Response, NextFunction } from "express";
 import { verifyUserAuthentication } from "../middleware";
 import { validateUpdateTagsRequest } from "./validators";
-import { isValidationError } from "../validator_util";
+import { isValidationError } from "../validators/validator_util";
 import { accountService } from "./service";
 
 export const accountController = Router();


### PR DESCRIPTION
The latest merge introduced an error because the path to validator utils had changed on `main` but not on the feature branch. This commit fixes that.