### PR TITLE
Return error when directive update uses email with no account

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "clear-database-ci": "psql postgresql://postgres:permanent@database:5432 -c 'DROP DATABASE IF EXISTS test_permanent;'",
     "create-database-ci": "psql postgresql://postgres:permanent@database:5432 -c 'CREATE DATABASE test_permanent;'",
     "set-up-database-ci": "pg_dump postgresql://postgres:permanent@database:5432/permanent --schema-only | psql postgresql://postgres:permanent@database:5432/test_permanent",
-    "test": "npm run start-containers && npm run clear-database && npm run create-database && npm run set-up-database && docker-compose run stela node --experimental-vm-modules node_modules/jest/bin/jest.js -i",
+    "test": "npm run start-containers && npm run clear-database && npm run create-database && npm run set-up-database && docker compose run stela node --experimental-vm-modules node_modules/jest/bin/jest.js -i",
     "test-ci": "npm run clear-database-ci && npm run create-database-ci && npm run set-up-database-ci && node --experimental-vm-modules node_modules/jest/bin/jest.js -i --coverage",
     "start": "ts-node --transpile-only src/index.ts",
     "start:debug": "node --no-lazy -r ts-node/register/transpile-only --inspect-brk=0.0.0.0 src/index.ts",

--- a/src/directive/queries/update_directive.sql
+++ b/src/directive/queries/update_directive.sql
@@ -2,15 +2,16 @@ UPDATE
   directive
 SET
   type = COALESCE(:type, type),
-  steward_account_id = COALESCE(
-    (SELECT
-      accountId
-    FROM
-      account
-    WHERE
-      primaryEmail = :stewardEmail),
-    steward_account_id
-  ),
+  steward_account_id = 
+    CASE WHEN :stewardEmail::text IS NULL THEN steward_account_id
+    ELSE (
+      SELECT
+        accountId
+      FROM
+        account
+      WHERE
+        primaryEmail = :stewardEmail
+    ) END,
   note = COALESCE(:note, note),
   updated_dt = CURRENT_TIMESTAMP
 WHERE

--- a/src/directive/service/update.test.ts
+++ b/src/directive/service/update.test.ts
@@ -121,6 +121,22 @@ describe("updateDirective", () => {
     }
   });
 
+  test("should error if steward email doesn't have an account", async () => {
+    let error = null;
+    try {
+      await directiveService.updateDirective(testDirectiveId, {
+        emailFromAuthToken: "test@permanent.org",
+        stewardEmail: "not_an_account@permanent.org",
+        note: testNote,
+        type: "transfer",
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error instanceof BadRequest).toBe(true);
+    }
+  });
+
   test("should error if trigger type is invalid", async () => {
     let error = null;
     try {

--- a/src/directive/service/update.ts
+++ b/src/directive/service/update.ts
@@ -2,6 +2,7 @@ import createError, { BadRequest } from "http-errors";
 import { db } from "../../database";
 import {
   isInvalidEnumError,
+  isMissingStewardAccountError,
   getInvalidValueFromInvalidEnumMessage,
 } from "../../database_util";
 import { logger } from "../../log";
@@ -50,6 +51,10 @@ export const updateDirective = async (
             `${getInvalidValueFromInvalidEnumMessage(
               err.message
             )} is not a valid value for "type"`
+          );
+        } else if (isMissingStewardAccountError(err)) {
+          throw new createError.BadRequest(
+            "Steward email must have an account"
           );
         } else if (err instanceof BadRequest) {
           throw err;


### PR DESCRIPTION
The steward email associated with a directive is required to belong to a Permanent account. If a steward email without an account is passed to the directive update endpoint, it will presently return success but decline to update the email. This is not very clear to the caller. To improve clarity, this commit updates that endpoint to return an invalid request error in this case.