### PR TITLE
Prevent accounts from being their own legacy contact or archive steward

### DIFF
--- a/src/directive/validators.test.ts
+++ b/src/directive/validators.test.ts
@@ -59,6 +59,24 @@ describe("validateCreateDirectiveRequest", () => {
       expect(error).not.toBeNull();
     }
   });
+  test("should raise an error if stewardEmail is the active account's email", () => {
+    let error = null;
+    try {
+      validateCreateDirectiveRequest({
+        emailFromAuthToken: "test@permanent.org",
+        stewardEmail: "test@permanent.org",
+        archiveId: "1",
+        type: "transfer",
+        trigger: {
+          type: "admin",
+        },
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
   test("should raise an error if type is missing", () => {
     let error = null;
     try {
@@ -465,6 +483,23 @@ describe("validateUpdateDirectiveRequest", () => {
         emailFromAuthToken: "test@permanent.org",
         stewardEmail: "test+1@permanent.org",
         type: "delete",
+        trigger: {
+          type: "admin",
+        },
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+  test("should raise an error if stewardEmail is the active account's email", () => {
+    let error = null;
+    try {
+      validateUpdateDirectiveRequest({
+        emailFromAuthToken: "test@permanent.org",
+        stewardEmail: "test@permanent.org",
+        type: "transfer",
         trigger: {
           type: "admin",
         },

--- a/src/directive/validators.ts
+++ b/src/directive/validators.ts
@@ -13,7 +13,10 @@ export const validateCreateDirectiveRequest = (
       archiveId: Joi.string().required(),
       stewardEmail: Joi.when("type", {
         is: Joi.string().valid("transfer"),
-        then: Joi.string().email().required(),
+        then: Joi.string()
+          .email()
+          .invalid(Joi.ref("emailFromAuthToken"))
+          .required(),
         otherwise: Joi.valid(null),
       }),
       type: Joi.string().required(),
@@ -53,7 +56,7 @@ export const validateUpdateDirectiveRequest = (
       emailFromAuthToken: Joi.string().email().required(),
       stewardEmail: Joi.when("type", {
         is: Joi.string().valid("transfer"),
-        then: Joi.string().email(),
+        then: Joi.string().invalid(Joi.ref("emailFromAuthToken")).email(),
         otherwise: Joi.valid(null),
       }),
       type: Joi.string(),

--- a/src/legacy_contact/validators.test.ts
+++ b/src/legacy_contact/validators.test.ts
@@ -101,6 +101,20 @@ describe("validateCreateLegacyContactRequest", () => {
       expect(error).not.toBeNull();
     }
   });
+  test("should raise an error if email is the active account's", () => {
+    let error = null;
+    try {
+      validateCreateLegacyContactRequest({
+        emailFromAuthToken: "test@permanent.org",
+        email: "test@permanent.org",
+        name: "John Rando",
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
   test("should raise an error if name is missing", () => {
     let error = null;
     try {
@@ -210,6 +224,19 @@ describe("validateUpdateLegacyContactRequest", () => {
       validateUpdateLegacyContactRequest({
         emailFromAuthToken: "test@permanent.org",
         email: "not_an_email",
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+  test("should raise an error when email is the active account's", () => {
+    let error = null;
+    try {
+      validateUpdateLegacyContactRequest({
+        emailFromAuthToken: "test@permanent.org",
+        email: "test@permanent.org",
       });
     } catch (err) {
       error = err;

--- a/src/legacy_contact/validators.ts
+++ b/src/legacy_contact/validators.ts
@@ -10,7 +10,10 @@ export const validateCreateLegacyContactRequest = (
   const validation = Joi.object()
     .keys({
       emailFromAuthToken: Joi.string().email().required(),
-      email: Joi.string().email().required(),
+      email: Joi.string()
+        .email()
+        .invalid(Joi.ref("emailFromAuthToken"))
+        .required(),
       name: Joi.string().required(),
     })
     .validate(data);
@@ -26,7 +29,7 @@ export const validateUpdateLegacyContactRequest = (
   const validation = Joi.object()
     .keys({
       emailFromAuthToken: Joi.string().email().required(),
-      email: Joi.string().email(),
+      email: Joi.string().email().invalid(Joi.ref("emailFromAuthToken")),
       name: Joi.string(),
     })
     .validate(data);


### PR DESCRIPTION
It doesn't make sense for a user to be their own legacy contact or the steward of their own archive, as these roles are intended to take actions after the user has passed away or become incapacitated. Thus, this commit adds a validation check to prevent users from becoming their own legacy contact the steward of their own archive.