### PR TITLE
Add Mailchimp Transactional API key to terraform secrets

### DIFF
--- a/terraform/prod_cluster/secrets.tf
+++ b/terraform/prod_cluster/secrets.tf
@@ -4,8 +4,10 @@ resource "kubernetes_secret" "prod-secrets" {
   }
 
   data = {
-    "DATABASE_URL"                 = var.prod_database_url
-    "FUSIONAUTH_API_KEY"           = var.prod_fusionauth_api_key
-    "LEGACY_BACKEND_SHARED_SECRET" = var.prod_legacy_backend_shared_secret
+    "DATABASE_URL"                    = var.prod_database_url
+    "FUSIONAUTH_API_KEY"              = var.prod_fusionauth_api_key
+    "LEGACY_BACKEND_SHARED_SECRET"    = var.prod_legacy_backend_shared_secret
+    "MAILCHIMP_API_KEY"               = var.mailchimp_api_key
+    "MAILCHIMP_TRANSACTIONAL_API_KEY" = var.mailchimp_transactional_api_key
   }
 }

--- a/terraform/prod_cluster/stela_prod_deployment.tf
+++ b/terraform/prod_cluster/stela_prod_deployment.tf
@@ -88,6 +88,38 @@ resource "kubernetes_deployment" "stela_prod" {
             value = var.legacy_backend_prod_host_url
           }
 
+          env {
+            name = "MAILCHIMP_API_KEY"
+            value_from {
+              secret_key_ref {
+                name     = "prod-secrets"
+                key      = "MAILCHIMP_API_KEY"
+                optional = false
+              }
+            }
+          }
+
+          env {
+            name = "MAILCHIMP_TRANSACTIONAL_API_KEY"
+            value_from {
+              secret_key_ref {
+                name     = "prod-secrets"
+                key      = "MAILCHIMP_TRANSACTIONAL_API_KEY"
+                optional = false
+              }
+            }
+          }
+
+          env {
+            name  = "MAILCHIMP_DATACENTER"
+            value = var.mailchimp_datacenter
+          }
+
+          env {
+            name  = "MAILCHIMP_COMMUNITY_LIST_ID"
+            value = var.prod_mailchimp_community_list_id
+          }
+
           port {
             container_port = 80
           }

--- a/terraform/prod_cluster/variables.tf
+++ b/terraform/prod_cluster/variables.tf
@@ -77,3 +77,25 @@ variable "prod_legacy_backend_shared_secret" {
   description = "Shared secret for authenticating calls to the legacy backend in the prod environment"
   type        = string
 }
+
+variable "mailchimp_api_key" {
+  description = "API key for Mailchimp Marketing"
+  type        = string
+}
+
+variable "mailchimp_transactional_api_key" {
+  description = "API key for Mailchimp Transactional"
+  type        = string
+}
+
+variable "mailchimp_datacenter" {
+  description = "The identifier for the Mailchimp datacenter where our account is hosted"
+  type        = string
+  default     = "us12"
+}
+
+variable "prod_mailchimp_community_list_id" {
+  description = "The ID of the Mailchimp audience we use in the prod environment"
+  type        = string
+  default     = "487bd863fb"
+}

--- a/terraform/test_cluster/secrets.tf
+++ b/terraform/test_cluster/secrets.tf
@@ -4,10 +4,11 @@ resource "kubernetes_secret" "dev-secrets" {
   }
 
   data = {
-    "DATABASE_URL"                 = var.dev_database_url
-    "FUSIONAUTH_API_KEY"           = var.dev_fusionauth_api_key
-    "LEGACY_BACKEND_SHARED_SECRET" = var.dev_legacy_backend_shared_secret
-    "MAILCHIMP_API_KEY"            = var.mailchimp_api_key
+    "DATABASE_URL"                    = var.dev_database_url
+    "FUSIONAUTH_API_KEY"              = var.dev_fusionauth_api_key
+    "LEGACY_BACKEND_SHARED_SECRET"    = var.dev_legacy_backend_shared_secret
+    "MAILCHIMP_API_KEY"               = var.mailchimp_api_key
+    "MAILCHIMP_TRANSACTIONAL_API_KEY" = var.mailchimp_transactional_api_key
   }
 }
 
@@ -17,9 +18,10 @@ resource "kubernetes_secret" "staging-secrets" {
   }
 
   data = {
-    "DATABASE_URL"                 = var.staging_database_url
-    "FUSIONAUTH_API_KEY"           = var.staging_fusionauth_api_key
-    "LEGACY_BACKEND_SHARED_SECRET" = var.staging_legacy_backend_shared_secret
-    "MAILCHIMP_API_KEY"            = var.mailchimp_api_key
+    "DATABASE_URL"                    = var.staging_database_url
+    "FUSIONAUTH_API_KEY"              = var.staging_fusionauth_api_key
+    "LEGACY_BACKEND_SHARED_SECRET"    = var.staging_legacy_backend_shared_secret
+    "MAILCHIMP_API_KEY"               = var.mailchimp_api_key
+    "MAILCHIMP_TRANSACTIONAL_API_KEY" = var.mailchimp_transactional_api_key
   }
 }

--- a/terraform/test_cluster/stela_dev_deployment.tf
+++ b/terraform/test_cluster/stela_dev_deployment.tf
@@ -100,6 +100,17 @@ resource "kubernetes_deployment" "stela_dev" {
           }
 
           env {
+            name = "MAILCHIMP_TRANSACTIONAL_API_KEY"
+            value_from {
+              secret_key_ref {
+                name     = "dev-secrets"
+                key      = "MAILCHIMP_TRANSACTIONAL_API_KEY"
+                optional = false
+              }
+            }
+          }
+
+          env {
             name  = "MAILCHIMP_DATACENTER"
             value = var.mailchimp_datacenter
           }

--- a/terraform/test_cluster/stela_staging_deployment.tf
+++ b/terraform/test_cluster/stela_staging_deployment.tf
@@ -100,6 +100,17 @@ resource "kubernetes_deployment" "stela_staging" {
           }
 
           env {
+            name = "MAILCHIMP_TRANSACTIONAL_API_KEY"
+            value_from {
+              secret_key_ref {
+                name     = "staging-secrets"
+                key      = "MAILCHIMP_TRANSACTIONAL_API_KEY"
+                optional = false
+              }
+            }
+          }
+
+          env {
             name  = "MAILCHIMP_DATACENTER"
             value = var.mailchimp_datacenter
           }

--- a/terraform/test_cluster/variables.tf
+++ b/terraform/test_cluster/variables.tf
@@ -135,7 +135,12 @@ variable "staging_legacy_backend_shared_secret" {
 }
 
 variable "mailchimp_api_key" {
-  description = "API key for Mailchimp"
+  description = "API key for Mailchimp Marketing"
+  type        = string
+}
+
+variable "mailchimp_transactional_api_key" {
+  description = "API key for Mailchimp Transactional"
   type        = string
 }
 


### PR DESCRIPTION
Now that we're using Mailchimp Transactional in this project, terraform needs to know about its API key so it can supply it to the deployments. This commit adds the API key to terraform's secrets.