### PR TITLE
Allow www origin for production requests

### DIFF
--- a/src/app.ts
+++ b/src/app.ts
@@ -11,7 +11,7 @@ const env = process.env["ENV"] ?? "";
 const app = express();
 app.use(
   cors({
-    origin: `https://${env === "production" ? "" : `${env}.`}permanent.org`,
+    origin: `https://${env === "production" ? "www" : `${env}`}.permanent.org`,
   })
 );
 app.use(expressWinston.logger({ level: "http", winstonInstance: logger }));


### PR DESCRIPTION
We redirect permanent.org to www.permanent.org, so should expect the latter to be the origin for requests.

Reviewers, should we also allow requests from plain permanent.org?