### PR TITLE
Add GET /archive/:archiveId/payer-account-storage endpoint

### DIFF
--- a/API.md
+++ b/API.md
@@ -253,6 +253,7 @@ instead return a [Joi ValidationError object](https://joi.dev/api/?v=17.9.1#vali
 ### GET `/archive/:archiveId/tags/public`
 
 - Response
+
 ```
 [
   {
@@ -268,3 +269,27 @@ instead return a [Joi ValidationError object](https://joi.dev/api/?v=17.9.1#vali
 ```
 
 - Note: If the archive doesn't exist, this will return an empty array
+
+### GET `/archive/:archiveId/payer-account-storage
+
+- Headers: Authorization: Bearer \<JWT from FusionAuth>
+
+- Response
+
+```
+{
+  accountSpaceId: string,
+  accountId: string,
+  spaceLeft: string,
+  spaceTotal: string,
+  filesLeft: string,
+  filesTotal: string,
+  status: string,
+  type: string,
+  createdDt: string (date),
+  updatedDt: string (date)
+}
+```
+
+- Note: This will return a 404 error if the archive has no payer account, or if the caller doesn't have access to that
+  archive

--- a/src/archive/controller.ts
+++ b/src/archive/controller.ts
@@ -1,6 +1,10 @@
 import { Router } from "express";
 import type { Request, Response, NextFunction } from "express";
-import { validateGetPublicTagsParams } from "./validators";
+import { verifyUserAuthentication } from "../middleware";
+import {
+  validateArchiveIdFromParams,
+  validateBodyFromAuthentication,
+} from "./validators";
 import { isValidationError } from "../validators/validator_util";
 import { archiveService } from "./service";
 
@@ -9,9 +13,31 @@ archiveController.get(
   "/:archiveId/tags/public",
   async (req: Request, res: Response, next: NextFunction) => {
     try {
-      validateGetPublicTagsParams(req.params);
+      validateArchiveIdFromParams(req.params);
       const tags = await archiveService.getPublicTags(req.params.archiveId);
       res.json(tags);
+    } catch (err) {
+      if (isValidationError(err)) {
+        res.status(400).json({ error: err });
+        return;
+      }
+      next(err);
+    }
+  }
+);
+
+archiveController.get(
+  "/:archiveId/payer-account-storage",
+  verifyUserAuthentication,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      validateArchiveIdFromParams(req.params);
+      validateBodyFromAuthentication(req.body);
+      const accountStorage = await archiveService.getPayerAccountStorage(
+        req.params.archiveId,
+        req.body.emailFromAuthToken
+      );
+      res.json(accountStorage);
     } catch (err) {
       if (isValidationError(err)) {
         res.status(400).json({ error: err });

--- a/src/archive/models.ts
+++ b/src/archive/models.ts
@@ -7,3 +7,16 @@ export interface Tag {
   createdDt: Date;
   updatedDt: Date;
 }
+
+export interface AccountStorage {
+  accountSpaceId: string;
+  accountId: string;
+  spaceLeft: string;
+  spaceTotal: string;
+  filesLeft: string;
+  filesTotal: string;
+  status: string;
+  type: string;
+  createdDt: Date;
+  updatedDt: Date;
+}

--- a/src/archive/queries/get_payer_account_storage.sql
+++ b/src/archive/queries/get_payer_account_storage.sql
@@ -1,0 +1,26 @@
+SELECT
+  account_space.account_spaceId "accountSpaceId",
+  account_space.accountId "accountId",
+  account_space.spaceLeft "spaceLeft",
+  account_space.spaceTotal "spaceTotal",
+  account_space.fileLeft "filesLeft",
+  account_space.fileTotal "filesTotal",
+  account_space.status,
+  account_space.type,
+  account_space.createdDt "createdDt",
+  account_space.updatedDt "updatedDt"
+FROM
+  account_space
+JOIN
+  archive
+  ON account_space.accountId = archive.payerAccountId
+JOIN
+  account_archive
+  ON archive.archiveId = account_archive.archiveId
+JOIN
+  account
+  ON account_archive.accountId = account.accountId
+WHERE
+  archive.archiveId = :archiveId
+  AND account.primaryEmail = :accountEmail
+  AND account_archive.status = 'status.generic.ok';

--- a/src/archive/service/get_payer_account_storage.test.ts
+++ b/src/archive/service/get_payer_account_storage.test.ts
@@ -1,0 +1,80 @@
+import { InternalServerError, NotFound } from "http-errors";
+import { db } from "../../database";
+import { archiveService } from "./index";
+import { logger } from "../../log";
+
+jest.mock("../../database");
+jest.mock("../../log", () => ({
+  logger: {
+    error: jest.fn(),
+  },
+}));
+
+const loadFixtures = async (): Promise<void> => {
+  await db.sql("fixtures.create_test_accounts");
+  await db.sql("fixtures.create_test_archive");
+  await db.sql("fixtures.create_test_account_archive");
+  await db.sql("fixtures.create_test_account_space");
+};
+
+const clearDatabase = async (): Promise<void> => {
+  await db.query(
+    "TRUNCATE account, archive, account_archive, account_space CASCADE"
+  );
+};
+
+describe("getPayerAccountStorage", () => {
+  beforeEach(async () => {
+    await clearDatabase();
+    await loadFixtures();
+  });
+  afterEach(async () => {
+    await clearDatabase();
+    jest.clearAllMocks();
+  });
+
+  test("should return payer account storage", async () => {
+    const payerAccountStorage = await archiveService.getPayerAccountStorage(
+      "1",
+      "test+1@permanent.org"
+    );
+    expect(payerAccountStorage.accountId).toEqual("2");
+    expect(payerAccountStorage.spaceLeft).toEqual("104723522");
+  });
+
+  test("should throw a not found error if account can't access the archive", async () => {
+    let error = null;
+    try {
+      await archiveService.getPayerAccountStorage("1", "test+2@permanent.org");
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error instanceof NotFound).toEqual(true);
+    }
+  });
+
+  test("should throw a not found error if archive has no payer account", async () => {
+    let error = null;
+    try {
+      await archiveService.getPayerAccountStorage("2", "test+1@permanent.org");
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error instanceof NotFound).toEqual(true);
+    }
+  });
+
+  test("should throw an internal server error if database call fails", async () => {
+    let error = null;
+    const testError = new Error("out of cheese - redo from start");
+    try {
+      jest.spyOn(db, "sql").mockRejectedValueOnce(testError);
+      await archiveService.getPayerAccountStorage("1", "test+1@permanent.org");
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error instanceof InternalServerError).toEqual(true);
+      expect(logger.error).toHaveBeenCalledWith(testError);
+    }
+  });
+});

--- a/src/archive/service/get_payer_account_storage.ts
+++ b/src/archive/service/get_payer_account_storage.ts
@@ -1,0 +1,25 @@
+import createError from "http-errors";
+import { db } from "../../database";
+import { logger } from "../../log";
+import type { AccountStorage } from "../models";
+
+export const getPayerAccountStorage = async (
+  archiveId: string,
+  accountEmail: string
+): Promise<AccountStorage> => {
+  const accountStoragesResult = await db
+    .sql<AccountStorage>("archive.queries.get_payer_account_storage", {
+      archiveId,
+      accountEmail,
+    })
+    .catch((err) => {
+      logger.error(err);
+      throw new createError.InternalServerError(
+        "failed to retrieve account storage"
+      );
+    });
+  if (!accountStoragesResult.rows[0]) {
+    throw new createError.NotFound("payer account storage not found");
+  }
+  return accountStoragesResult.rows[0];
+};

--- a/src/archive/service/get_public_tags.test.ts
+++ b/src/archive/service/get_public_tags.test.ts
@@ -1,10 +1,10 @@
 import { InternalServerError } from "http-errors";
-import { db } from "../database";
-import { archiveService } from "./service";
-import { logger } from "../log";
+import { db } from "../../database";
+import { archiveService } from "./index";
+import { logger } from "../../log";
 
-jest.mock("../database");
-jest.mock("../log", () => ({
+jest.mock("../../database");
+jest.mock("../../log", () => ({
   logger: {
     error: jest.fn(),
   },

--- a/src/archive/service/get_public_tags.ts
+++ b/src/archive/service/get_public_tags.ts
@@ -1,9 +1,9 @@
 import createError from "http-errors";
-import { db } from "../database";
-import { logger } from "../log";
-import type { Tag } from "./models";
+import { db } from "../../database";
+import { logger } from "../../log";
+import type { Tag } from "../models";
 
-const getPublicTags = async (archiveId: string): Promise<Tag[]> => {
+export const getPublicTags = async (archiveId: string): Promise<Tag[]> => {
   const tagsResult = await db
     .sql<Tag>("archive.queries.get_public_tags", { archiveId })
     .catch((err) => {
@@ -11,8 +11,4 @@ const getPublicTags = async (archiveId: string): Promise<Tag[]> => {
       throw new createError.InternalServerError("failed to retrieve tags");
     });
   return tagsResult.rows;
-};
-
-export const archiveService = {
-  getPublicTags,
 };

--- a/src/archive/service/index.ts
+++ b/src/archive/service/index.ts
@@ -1,0 +1,7 @@
+import { getPublicTags } from "./get_public_tags";
+import { getPayerAccountStorage } from "./get_payer_account_storage";
+
+export const archiveService = {
+  getPublicTags,
+  getPayerAccountStorage,
+};

--- a/src/archive/validators.test.ts
+++ b/src/archive/validators.test.ts
@@ -1,10 +1,10 @@
-import { validateGetPublicTagsParams } from "./validators";
+import { validateArchiveIdFromParams } from "./validators";
 
-describe("validateGetPublicTagsParams", () => {
+describe("validateArchiveIdFromParams", () => {
   test("should find no errors in valid parameters", () => {
     let error = null;
     try {
-      validateGetPublicTagsParams({
+      validateArchiveIdFromParams({
         archiveId: "123",
       });
     } catch (err) {
@@ -17,7 +17,7 @@ describe("validateGetPublicTagsParams", () => {
   test("should error if archiveId is missing", () => {
     let error = null;
     try {
-      validateGetPublicTagsParams({});
+      validateArchiveIdFromParams({});
     } catch (err) {
       error = err;
     } finally {
@@ -28,7 +28,7 @@ describe("validateGetPublicTagsParams", () => {
   test("should error if archiveId is wrong type", () => {
     let error = null;
     try {
-      validateGetPublicTagsParams({
+      validateArchiveIdFromParams({
         archiveId: 123,
       });
     } catch (err) {

--- a/src/archive/validators.ts
+++ b/src/archive/validators.ts
@@ -1,6 +1,9 @@
 import Joi from "joi";
+import { validateBodyFromAuthentication } from "../validators";
 
-export function validateGetPublicTagsParams(
+export { validateBodyFromAuthentication };
+
+export function validateArchiveIdFromParams(
   data: unknown
 ): asserts data is { archiveId: string } {
   const validation = Joi.object()

--- a/src/fixtures/create_test_account_archive.sql
+++ b/src/fixtures/create_test_account_archive.sql
@@ -1,4 +1,6 @@
 INSERT INTO
   account_archive (accountId, archiveId, accessRole, position, type, status)
 VALUES
-  (2, 1, 'access.role.owner', 0, 'type.account.standard', 'status.generic.ok');
+  (2, 1, 'access.role.owner', 0, 'type.account.standard', 'status.generic.ok'),
+  (3, 1, 'access.role.viewer', 0, 'type.account.standard', 'status.generic.ok'),
+  (3, 2, 'access.role.owner', 0, 'type.account.standard', 'status.generic.ok');

--- a/src/fixtures/create_test_account_space.sql
+++ b/src/fixtures/create_test_account_space.sql
@@ -1,0 +1,4 @@
+INSERT INTO 
+  account_space (accountId, spaceLeft, spaceTotal, fileLeft, fileTotal, status, type, createdDt, updatedDt)
+VALUES
+  (2, 104723522,104857600, 99999, 100000, 'status.generic.ok', 'type.generic.placeholder', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);

--- a/src/fixtures/create_test_archive.sql
+++ b/src/fixtures/create_test_archive.sql
@@ -1,5 +1,5 @@
 INSERT INTO
-  archive (archiveId, archiveNbr)
+  archive (archiveId, archiveNbr, payerAccountId)
 VALUES
-  (1, '0001-0001'),
-  (2, '0001-0002');
+  (1, '0001-0001', 2),
+  (2, '0001-0002', NULL);

--- a/src/fixtures/create_test_records.sql
+++ b/src/fixtures/create_test_records.sql
@@ -1,8 +1,8 @@
 INSERT INTO 
-  record (recordId, archiveId, publicDt, displayName, uploadAccountId, uploadFilename, status, type)
+  record (recordId, archiveId, publicDt, displayName, uploadAccountId, uploadPayerAccountId, uploadFilename, status, type)
 VALUES
-  (1, 1, '2023-06-21', 'Public File', 2, 'public_file.jpg', 'status.generic.ok', 'type.record.image'),
-  (2, 1, NULL, 'Private File', 2, 'private_file.jpg', 'status.generic.ok', 'type.record.image'),
-  (3, 1, CURRENT_TIMESTAMP + '1 day'::interval, 'Future Public File', 2, 'future_public_file.jpg', 'status.generic.ok', 'type.record.image'),
-  (4, 1, '2023-06-21', 'Deleted File', 2, 'public_file.jpg', 'status.generic.deleted', 'type.record.image'),
-  (5, 2, '2023-06-21', 'Public File', 3, 'public_file.jpg', 'status.generic.ok', 'type.record.image');
+  (1, 1, '2023-06-21', 'Public File', 2, 2, 'public_file.jpg', 'status.generic.ok', 'type.record.image'),
+  (2, 1, NULL, 'Private File', 2, 2, 'private_file.jpg', 'status.generic.ok', 'type.record.image'),
+  (3, 1, CURRENT_TIMESTAMP + '1 day'::interval, 'Future Public File', 2, 2, 'future_public_file.jpg', 'status.generic.ok', 'type.record.image'),
+  (4, 1, '2023-06-21', 'Deleted File', 2, 2, 'public_file.jpg', 'status.generic.deleted', 'type.record.image'),
+  (5, 2, '2023-06-21', 'Public File', 3, 3, 'public_file.jpg', 'status.generic.ok', 'type.record.image');


### PR DESCRIPTION
For archives with payer accounts, we'd like to display the remaining storage available to that archive. To that end, this commit adds an endpoint that returns the storage available to the payer account of an archive, if that archive has a payer account.