### PR TITLE
Added /billing/gift endpoint

### DIFF
--- a/API.md
+++ b/API.md
@@ -22,6 +22,7 @@ These endpoints are all authenticated with admin authentication tokens, generate
 [documentation](https://permanent.atlassian.net/wiki/spaces/EN/pages/2072576001/Trigger+Admin+Directives)
 
 ### POST `/admin/folder/recalculate_thumbnails`
+
 Queues thumbnail generation tasks for all non-root folders created between `beginTimestamp` and `endTimestamp`.
 
 - Headers: Authorization: Bearer \<JWT from FusionAuth>
@@ -335,6 +336,7 @@ Queues thumbnail generation tasks for all non-root folders created between `begi
 ### GET `/archive/featured`
 
 - Response
+
 ```
 {
   archiveId: string,
@@ -343,5 +345,33 @@ Queues thumbnail generation tasks for all non-root folders created between `begi
   archiveNbr: string,
   profileImage: string (URL),
   bannerImage: string (URL)
+}
+```
+
+## Billing
+
+### POST `/billing/gift`
+
+- Headers: Authorization: Bearer \<JWT from FusionAuth>
+- Request Body
+
+```
+{
+  storageAmount: int (expressed in GB, given to each recipient)
+  recipientEmails: [string] (email format, list must be non-empty)
+  note: string
+}
+```
+
+- Response
+
+```
+{
+  storageGifted: int (expressed in GB) // total amount of storage given away
+  giftDelivered: [string] // emails to which the gift has been successfully delivered
+  // emails which don't have Permanent accounts yet, gift will be delivered when the accept the invite
+  invitationSent: [string]
+  // emails to which no gift could be made because they have no account and have already been invited
+  alreadyInvited: [string]
 }
 ```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,8 @@ services:
       dockerfile: Dockerfile.test
     networks:
       - devenv
+    environment:
+      - ENV=test
 networks:
   devenv:
     name: devenv_default

--- a/package.json
+++ b/package.json
@@ -28,9 +28,7 @@
     "transform": {
       "^.+\\.ts?$": "ts-jest"
     },
-    "transformIgnorePatterns": [
-      "./node_modules/"
-    ]
+    "transformIgnorePatterns": ["./node_modules/"]
   },
   "repository": {
     "type": "git",

--- a/src/archive/service/get_payer_account_storage.test.ts
+++ b/src/archive/service/get_payer_account_storage.test.ts
@@ -2,6 +2,7 @@ import { InternalServerError, NotFound } from "http-errors";
 import { db } from "../../database";
 import { archiveService } from "./index";
 import { logger } from "../../log";
+import { GB } from "../../constants";
 
 jest.mock("../../database");
 jest.mock("../../log", () => ({
@@ -39,7 +40,7 @@ describe("getPayerAccountStorage", () => {
       "test+1@permanent.org"
     );
     expect(payerAccountStorage.accountId).toEqual("2");
-    expect(payerAccountStorage.spaceLeft).toEqual("104723522");
+    expect(+payerAccountStorage.spaceLeft).toEqual(2 * GB);
   });
 
   test("should throw a not found error if account can't access the archive", async () => {

--- a/src/billing/controller.test.ts
+++ b/src/billing/controller.test.ts
@@ -1,0 +1,664 @@
+import request from "supertest";
+import type { Request, NextFunction } from "express";
+import { app } from "../app";
+import { verifyUserAuthentication } from "../middleware";
+import { db } from "../database";
+import { GB } from "../constants";
+import { sendInvitationNotification } from "../email";
+import { logger } from "../log";
+import type { GiftStorageRequest, GiftStorageResponse } from "./models";
+
+jest.mock("../database");
+jest.mock("../middleware");
+jest.mock("../email");
+jest.mock("../log");
+
+interface AccountSpace {
+  spaceLeft: number;
+  spaceTotal: number;
+}
+
+const senderAccountId = "2";
+const recipientOneAccountId = "3";
+const recipientTwoAccountId = "4";
+
+const clearDatabase = async (): Promise<void> => {
+  await db.query(
+    "TRUNCATE account, account_space, ledger_financial, email, invite CASCADE"
+  );
+};
+
+const getAccountSpace = async (
+  accountId: string
+): Promise<AccountSpace | undefined> => {
+  const result = await db.query<AccountSpace>(
+    'SELECT spaceLeft "spaceLeft", spaceTotal "spaceTotal" FROM account_space WHERE accountId = :accountId',
+    { accountId }
+  );
+  return result.rows[0];
+};
+
+const checkLedgerEntries = async (
+  gifterAccountId: string,
+  recipientAccountId: string,
+  giftAmountInGB: number,
+  initialSenderSpace: AccountSpace | undefined,
+  initialRecipientSpace: AccountSpace | undefined
+): Promise<void> => {
+  const ledgerEntryResponse = await db.query<{
+    spaceDelta: string;
+    fromSpaceBefore: string;
+    fromSpaceLeft: string;
+    fromSpaceTotal: string;
+    toSpaceBefore: string;
+    toSpaceLeft: string;
+    toSpaceTotal: string;
+  }>(
+    `SELECT
+      spaceDelta "spaceDelta",
+      fromSpaceBefore "fromSpaceBefore",
+      fromSpaceLeft "fromSpaceLeft",
+      fromSpaceTotal "fromSpaceTotal",
+      toSpaceBefore "toSpaceBefore",
+      toSpaceLeft "toSpaceLeft",
+      toSpaceTotal "toSpaceTotal"
+    FROM
+      ledger_financial
+    WHERE
+      fromAccountId = :senderAccountId
+      AND toAccountId = :recipientAccountId`,
+    { senderAccountId: gifterAccountId, recipientAccountId }
+  );
+
+  ledgerEntryResponse.rows.forEach((ledgerEntry) => {
+    expect(ledgerEntry.spaceDelta).toBe((giftAmountInGB * GB).toString());
+
+    if (
+      initialSenderSpace?.spaceTotal === undefined ||
+      initialRecipientSpace?.spaceTotal === undefined
+    ) {
+      expect(true).toBe(false);
+    } else {
+      // In the event of multiple recipients, we can't know precisely how much space the sender had before each gift
+      // so we check that it's less than or equal to the initial space total and that it's decreased in increments
+      // equal to the gift size
+      expect(+ledgerEntry.fromSpaceBefore).toBeLessThanOrEqual(
+        +initialSenderSpace.spaceTotal
+      );
+      expect(
+        (+initialSenderSpace.spaceTotal - +ledgerEntry.fromSpaceBefore) %
+          (giftAmountInGB * GB)
+      ).toStrictEqual(0);
+      expect(+ledgerEntry.fromSpaceLeft).toBe(
+        +ledgerEntry.fromSpaceBefore - giftAmountInGB * GB
+      );
+      expect(+ledgerEntry.fromSpaceTotal).toBe(
+        +ledgerEntry.fromSpaceBefore - giftAmountInGB * GB
+      );
+
+      if (recipientAccountId === "0") {
+        expect(+ledgerEntry.toSpaceBefore).toBe(0);
+        expect(+ledgerEntry.toSpaceLeft).toBe(0);
+        expect(+ledgerEntry.toSpaceTotal).toBe(0);
+      } else {
+        expect(ledgerEntry.toSpaceBefore).toBe(
+          initialRecipientSpace.spaceTotal
+        );
+        expect(+ledgerEntry.toSpaceLeft).toBe(
+          +initialRecipientSpace.spaceTotal + giftAmountInGB * GB
+        );
+        expect(+ledgerEntry.toSpaceTotal).toBe(
+          +initialRecipientSpace.spaceTotal + giftAmountInGB * GB
+        );
+      }
+    }
+  });
+};
+
+describe("/billing/gift", () => {
+  const agent = request(app);
+
+  beforeEach(async () => {
+    (verifyUserAuthentication as jest.Mock).mockImplementation(
+      (req: Request, __, next: NextFunction) => {
+        (req.body as GiftStorageRequest).emailFromAuthToken =
+          "test@permanent.org";
+        next();
+      }
+    );
+    await clearDatabase();
+  });
+
+  afterEach(async () => {
+    await clearDatabase();
+    jest.clearAllMocks();
+  });
+
+  test("should call verifyUserAuthentication", async () => {
+    await agent.post("/api/v2/billing/gift");
+    expect(verifyUserAuthentication).toHaveBeenCalled();
+  });
+
+  test("should return invalid request status if email from auth token is missing", async () => {
+    (verifyUserAuthentication as jest.Mock).mockImplementation(
+      (_, __, next: NextFunction) => {
+        next();
+      }
+    );
+    await agent.post("/api/v2/billing/gift").expect(400);
+  });
+
+  test("should return invalid request status if email from auth token is wrong type", async () => {
+    (verifyUserAuthentication as jest.Mock).mockImplementation(
+      (req: Request, __, next: NextFunction) => {
+        (req.body as GiftStorageRequest).emailFromAuthToken =
+          1 as unknown as string;
+        next();
+      }
+    );
+    await agent.post("/api/v2/billing/gift").expect(400);
+  });
+
+  test("should return invalid request status if email from auth token is not an email", async () => {
+    (verifyUserAuthentication as jest.Mock).mockImplementation(
+      (req: Request, __, next: NextFunction) => {
+        (req.body as GiftStorageRequest).emailFromAuthToken = "test";
+        next();
+      }
+    );
+    await agent.post("/api/v2/billing/gift").expect(400);
+  });
+
+  test("should return invalid request status if storage amount is missing", async () => {
+    await agent
+      .post("/api/v2/billing/gift")
+      .send({ recipientEmails: ["test+recipient@permanent.org"] })
+      .expect(400);
+  });
+
+  test("should return invalid request status if storage amount is wrong type", async () => {
+    await agent
+      .post("/api/v2/billing/gift")
+      .send({
+        storageAmount: "test",
+        recipientEmails: ["test+recipient@permanent.org"],
+      })
+      .expect(400);
+  });
+
+  test("should return invalid request status if storage amount is non-integer", async () => {
+    await agent
+      .post("/api/v2/billing/gift")
+      .send({
+        storageAmount: 1.5,
+        recipientEmails: ["test+recipient@permanent.org"],
+      })
+      .expect(400);
+  });
+
+  test("should return invalid request status if storage amount is less than 1", async () => {
+    await agent
+      .post("/api/v2/billing/gift")
+      .send({
+        storageAmount: 0,
+        recipientEmails: ["test+recipient@permanent.org"],
+      })
+      .expect(400);
+  });
+
+  test("should return invalid request status if recipient emails is missing", async () => {
+    await agent
+      .post("/api/v2/billing/gift")
+      .send({ storageAmount: 1 })
+      .expect(400);
+  });
+
+  test("should return invalid request status if recipient emails is not an array", async () => {
+    await agent
+      .post("/api/v2/billing/gift")
+      .send({ storageAmount: 1, recipientEmails: "test" })
+      .expect(400);
+  });
+
+  test("should return invalid request status if recipient emails is empty", async () => {
+    await agent
+      .post("/api/v2/billing/gift")
+      .send({ storageAmount: 1, recipientEmails: [] })
+      .expect(400);
+  });
+
+  test("should return invalid request status if recipient emails contains non-email items", async () => {
+    await agent
+      .post("/api/v2/billing/gift")
+      .send({
+        storageAmount: 1,
+        recipientEmails: ["test+recipient@permanent.org", "test"],
+      })
+      .expect(400);
+  });
+
+  test("should return invalid request status if note is wrong type", async () => {
+    await agent
+      .post("/api/v2/billing/gift")
+      .send({
+        storageAmount: 1,
+        recipientEmails: ["test+recipient@permanent.org"],
+        note: 1,
+      })
+      .expect(400);
+  });
+
+  test("should return a 500 error if email from auth token has no permanent account", async () => {
+    await db.sql("fixtures.create_test_accounts");
+    await db.sql("fixtures.create_test_account_space");
+    await db.sql("fixtures.create_test_emails");
+    (verifyUserAuthentication as jest.Mock).mockImplementation(
+      (req: Request, __, next: NextFunction) => {
+        (req.body as GiftStorageRequest).emailFromAuthToken =
+          "not_a_user@permanent.org";
+        next();
+      }
+    );
+
+    await agent
+      .post("/api/v2/billing/gift")
+      .send({
+        storageAmount: 1,
+        recipientEmails: ["test+1@permanent.org"],
+      })
+      .expect(500);
+  });
+
+  test("should create a ledger entry with correct values if recipient already has an account", async () => {
+    await db.sql("fixtures.create_test_accounts");
+    await db.sql("fixtures.create_test_account_space");
+    await db.sql("fixtures.create_test_emails");
+
+    const initialSenderSpace = await getAccountSpace(senderAccountId);
+    const initialRecipientSpace = await getAccountSpace(recipientOneAccountId);
+    await agent
+      .post("/api/v2/billing/gift")
+      .send({ storageAmount: 1, recipientEmails: ["test+1@permanent.org"] })
+      .expect(200);
+    await checkLedgerEntries(
+      senderAccountId,
+      recipientOneAccountId,
+      1,
+      initialSenderSpace,
+      initialRecipientSpace
+    );
+  });
+
+  test("successful gift should update account_space for sender", async () => {
+    await db.sql("fixtures.create_test_accounts");
+    await db.sql("fixtures.create_test_account_space");
+    await db.sql("fixtures.create_test_emails");
+
+    const initialAccountSpace = await getAccountSpace(senderAccountId);
+    await agent
+      .post("/api/v2/billing/gift")
+      .send({ storageAmount: 1, recipientEmails: ["test+1@permanent.org"] })
+      .expect(200);
+    const updatedAccountSpace = await getAccountSpace(senderAccountId);
+    if (
+      initialAccountSpace?.spaceLeft === undefined ||
+      updatedAccountSpace?.spaceLeft === undefined
+    ) {
+      expect(false).toBe(true);
+    } else {
+      expect(+updatedAccountSpace.spaceLeft).toBe(
+        initialAccountSpace.spaceLeft - GB
+      );
+    }
+    if (
+      initialAccountSpace?.spaceTotal === undefined ||
+      updatedAccountSpace?.spaceTotal === undefined
+    ) {
+      expect(false).toBe(true);
+    } else {
+      expect(+updatedAccountSpace.spaceTotal).toBe(
+        initialAccountSpace.spaceTotal - GB
+      );
+    }
+  });
+
+  test("successful gift should update account_space for recipient", async () => {
+    await db.sql("fixtures.create_test_accounts");
+    await db.sql("fixtures.create_test_emails");
+    await db.sql("fixtures.create_test_account_space");
+    const initialAccountSpace = await getAccountSpace(recipientOneAccountId);
+    await agent
+      .post("/api/v2/billing/gift")
+      .send({ storageAmount: 1, recipientEmails: ["test+1@permanent.org"] })
+      .expect(200);
+    const updatedAccountSpace = await getAccountSpace(recipientOneAccountId);
+    if (
+      initialAccountSpace?.spaceLeft === undefined ||
+      updatedAccountSpace?.spaceLeft === undefined
+    ) {
+      expect(false).toBe(true);
+    } else {
+      expect(+updatedAccountSpace.spaceLeft).toBe(
+        +initialAccountSpace.spaceLeft + GB
+      );
+    }
+    if (
+      initialAccountSpace?.spaceTotal === undefined ||
+      updatedAccountSpace?.spaceTotal === undefined
+    ) {
+      expect(false).toBe(true);
+    } else {
+      expect(+updatedAccountSpace.spaceTotal).toBe(
+        +initialAccountSpace.spaceTotal + GB
+      );
+    }
+  });
+
+  test("should create a multiple correct ledger entries if there are multiple recipients", async () => {
+    await db.sql("fixtures.create_test_accounts");
+    await db.sql("fixtures.create_test_account_space");
+    await db.sql("fixtures.create_test_emails");
+
+    const initialSenderSpace = await getAccountSpace(senderAccountId);
+    const initialRecipientOneSpace = await getAccountSpace(
+      recipientOneAccountId
+    );
+    const initialRecipientTwoSpace = await getAccountSpace(
+      recipientTwoAccountId
+    );
+    await agent
+      .post("/api/v2/billing/gift")
+      .send({
+        storageAmount: 1,
+        recipientEmails: ["test+1@permanent.org", "test+2@permanent.org"],
+      })
+      .expect(200);
+    await checkLedgerEntries(
+      senderAccountId,
+      recipientOneAccountId,
+      1,
+      initialSenderSpace,
+      initialRecipientOneSpace
+    );
+    await checkLedgerEntries(
+      senderAccountId,
+      recipientTwoAccountId,
+      1,
+      initialSenderSpace,
+      initialRecipientTwoSpace
+    );
+  });
+
+  test("should return an invalid request status if sender doesn't have enough storage", async () => {
+    await db.sql("fixtures.create_test_accounts");
+    await db.sql("fixtures.create_test_account_space");
+    await db.sql("fixtures.create_test_emails");
+
+    await agent
+      .post("/api/v2/billing/gift")
+      .send({
+        storageAmount: 5,
+        recipientEmails: ["test+1@permanent.org"],
+      })
+      .expect(400);
+  });
+
+  test("should create an invite if recipient doesn't have an account", async () => {
+    await db.sql("fixtures.create_test_accounts");
+    await db.sql("fixtures.create_test_account_space");
+    await db.sql("fixtures.create_test_emails");
+
+    const newUserEmails = [
+      "test+not_a_user_yet@permanent.org",
+      "test+also_not_a_user_yet@permanent.org",
+    ];
+
+    await agent
+      .post("/api/v2/billing/gift")
+      .send({
+        storageAmount: 1,
+        recipientEmails: newUserEmails,
+      })
+      .expect(200);
+
+    const inviteResponse = await db.query<{ inviteId: string; token: string }>(
+      "SELECT inviteId, token FROM invite WHERE email = ANY(:newUserEmails) AND byAccountId = :senderAccountId",
+      { newUserEmails, senderAccountId }
+    );
+    expect(inviteResponse.rows.length).toBe(2);
+    expect(inviteResponse.rows[0]?.token).not.toBe(
+      inviteResponse.rows[1]?.token
+    );
+  });
+
+  test("should not create an invite if recipient already has an invite", async () => {
+    await db.sql("fixtures.create_test_accounts");
+    await db.sql("fixtures.create_test_account_space");
+    await db.sql("fixtures.create_test_emails");
+    await db.sql("fixtures.create_test_invites");
+
+    const newUserEmails = ["test+already_invited@permanent.org"];
+
+    await agent
+      .post("/api/v2/billing/gift")
+      .send({
+        storageAmount: 1,
+        recipientEmails: newUserEmails,
+      })
+      .expect(200);
+
+    const inviteResponse = await db.query<{ inviteId: string }>(
+      "SELECT inviteId FROM invite WHERE email = ANY(:newUserEmails) AND byAccountId = :senderAccountId",
+      { newUserEmails, senderAccountId }
+    );
+    expect(inviteResponse.rows.length).toBe(0);
+  });
+
+  test("should create a gift purchase ledger entry if recipient doesn't have an account", async () => {
+    await db.sql("fixtures.create_test_accounts");
+    await db.sql("fixtures.create_test_account_space");
+    await db.sql("fixtures.create_test_emails");
+
+    const initialSenderSpace = await getAccountSpace(senderAccountId);
+
+    const newUserEmails = [
+      "test+not_a_user_yet@permanent.org",
+      "test+also_not_a_user_yet@permanent.org",
+    ];
+
+    await agent
+      .post("/api/v2/billing/gift")
+      .send({
+        storageAmount: 1,
+        recipientEmails: newUserEmails,
+      })
+      .expect(200);
+
+    await checkLedgerEntries(senderAccountId, "0", 1, initialSenderSpace, {
+      spaceLeft: 0,
+      spaceTotal: 0,
+    });
+  });
+
+  test("should send invitation email if recipient doesn't have an account", async () => {
+    await db.sql("fixtures.create_test_accounts");
+    await db.sql("fixtures.create_test_account_space");
+    await db.sql("fixtures.create_test_emails");
+
+    const newUserEmails = [
+      "test+not_a_user_yet@permanent.org",
+      "test+also_not_a_user_yet@permanent.org",
+    ];
+
+    await agent
+      .post("/api/v2/billing/gift")
+      .send({
+        storageAmount: 1,
+        recipientEmails: newUserEmails,
+      })
+      .expect(200);
+
+    expect(sendInvitationNotification).toHaveBeenCalledTimes(2);
+  });
+
+  test("should report what happened to each email passed in", async () => {
+    await db.sql("fixtures.create_test_accounts");
+    await db.sql("fixtures.create_test_account_space");
+    await db.sql("fixtures.create_test_emails");
+    await db.sql("fixtures.create_test_invites");
+
+    const recipientEmails = [
+      "test+already_invited@permanent.org",
+      "test+not_a_user_yet@permanent.org",
+      "test+1@permanent.org",
+    ];
+
+    const results = await agent
+      .post("/api/v2/billing/gift")
+      .send({
+        storageAmount: 1,
+        recipientEmails,
+      })
+      .expect(200);
+
+    expect((results.body as GiftStorageResponse).giftDelivered).toEqual([
+      "test+1@permanent.org",
+    ]);
+    expect((results.body as GiftStorageResponse).invitationSent).toEqual([
+      "test+not_a_user_yet@permanent.org",
+    ]);
+    expect((results.body as GiftStorageResponse).alreadyInvited).toEqual([
+      "test+already_invited@permanent.org",
+    ]);
+    expect((results.body as GiftStorageResponse).storageGifted).toEqual(2);
+  });
+
+  test("should log error and return 500 if check for existing emails fails", async () => {
+    const testError = new Error("test error");
+    jest.spyOn(db, "sql").mockImplementation(async () => {
+      throw testError;
+    });
+
+    await agent
+      .post("/api/v2/billing/gift")
+      .send({ storageAmount: 1, recipientEmails: ["test+1@permanent.org"] })
+      .expect(500);
+
+    expect(logger.error).toHaveBeenCalledWith(testError);
+  });
+
+  test("should log error and return 500 if check for invited emails fails", async () => {
+    const testError = new Error("test error");
+    jest
+      .spyOn(db, "sql")
+      .mockImplementationOnce((async () => ({
+        rows: [],
+      })) as unknown as typeof db.sql)
+      .mockImplementationOnce(async () => {
+        throw testError;
+      });
+
+    await agent
+      .post("/api/v2/billing/gift")
+      .send({ storageAmount: 1, recipientEmails: ["test+1@permanent.org"] })
+      .expect(500);
+
+    expect(logger.error).toHaveBeenCalledWith(testError);
+  });
+
+  test("should log error and return 500 if check for available space fails", async () => {
+    const testError = new Error("test error");
+    jest
+      .spyOn(db, "sql")
+      .mockImplementationOnce((async () => ({
+        rows: [],
+      })) as unknown as typeof db.sql)
+      .mockImplementationOnce((async () => ({
+        rows: [],
+      })) as unknown as typeof db.sql)
+      .mockImplementationOnce(async () => {
+        throw testError;
+      });
+
+    await agent
+      .post("/api/v2/billing/gift")
+      .send({ storageAmount: 1, recipientEmails: ["test+1@permanent.org"] })
+      .expect(500);
+
+    expect(logger.error).toHaveBeenCalledWith(testError);
+  });
+
+  test("should log error and return 500 if check for available space finds nothing", async () => {
+    jest
+      .spyOn(db, "sql")
+      .mockImplementationOnce((async () => ({
+        rows: [],
+      })) as unknown as typeof db.sql)
+      .mockImplementationOnce((async () => ({
+        rows: [],
+      })) as unknown as typeof db.sql)
+      .mockImplementationOnce((async () => ({
+        rows: [],
+      })) as unknown as typeof db.sql);
+
+    await agent
+      .post("/api/v2/billing/gift")
+      .send({ storageAmount: 1, recipientEmails: ["test+1@permanent.org"] })
+      .expect(500);
+
+    expect(logger.error).toHaveBeenCalledWith(
+      "Empty response from account_space query"
+    );
+  });
+
+  test("should log error and return 500 if recording gifts for existing accounts fails", async () => {
+    const testError = new Error("test error");
+    jest
+      .spyOn(db, "sql")
+      .mockImplementationOnce((async () => ({
+        rows: [],
+      })) as unknown as typeof db.sql)
+      .mockImplementationOnce((async () => ({
+        rows: [],
+      })) as unknown as typeof db.sql)
+      .mockImplementationOnce((async () => ({
+        rows: [{ spaceLeft: 2 * GB }],
+      })) as unknown as typeof db.sql)
+      .mockImplementationOnce(async () => {
+        throw testError;
+      });
+
+    await agent
+      .post("/api/v2/billing/gift")
+      .send({ storageAmount: 1, recipientEmails: ["test+1@permanent.org"] })
+      .expect(500);
+
+    expect(logger.error).toHaveBeenCalledWith(testError);
+  });
+
+  test("should log error and return 500 if creating invites fails", async () => {
+    const testError = new Error("test error");
+    jest
+      .spyOn(db, "sql")
+      .mockImplementationOnce((async () => ({
+        rows: [],
+      })) as unknown as typeof db.sql)
+      .mockImplementationOnce((async () => ({
+        rows: [],
+      })) as unknown as typeof db.sql)
+      .mockImplementationOnce((async () => ({
+        rows: [{ spaceLeft: 2 * GB }],
+      })) as unknown as typeof db.sql)
+      .mockImplementationOnce((async () => null) as unknown as typeof db.sql)
+      .mockImplementationOnce(async () => {
+        throw testError;
+      });
+
+    await agent
+      .post("/api/v2/billing/gift")
+      .send({ storageAmount: 1, recipientEmails: ["test+1@permanent.org"] })
+      .expect(500);
+
+    expect(logger.error).toHaveBeenCalledWith(testError);
+  });
+});

--- a/src/billing/controller.ts
+++ b/src/billing/controller.ts
@@ -1,0 +1,27 @@
+import { Router } from "express";
+import type { Request, Response, NextFunction } from "express";
+import { verifyUserAuthentication } from "../middleware";
+import { validateGiftStorageRequest } from "./validators";
+import { isValidationError } from "../validators/validator_util";
+import { issueGift } from "./service";
+
+export const billingController = Router();
+
+billingController.post(
+  "/gift",
+  verifyUserAuthentication,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      validateGiftStorageRequest(req.body);
+      const result = await issueGift(req.body);
+
+      res.status(200).json(result);
+    } catch (err) {
+      if (isValidationError(err)) {
+        res.status(400).json({ error: err.message });
+        return;
+      }
+      next(err);
+    }
+  }
+);

--- a/src/billing/index.ts
+++ b/src/billing/index.ts
@@ -1,0 +1,1 @@
+export { billingController } from "./controller";

--- a/src/billing/models.ts
+++ b/src/billing/models.ts
@@ -1,0 +1,13 @@
+export interface GiftStorageRequest {
+  emailFromAuthToken: string;
+  storageAmount: number;
+  recipientEmails: string[];
+  note: string;
+}
+
+export interface GiftStorageResponse {
+  storageGifted: number;
+  giftDelivered: string[];
+  invitationSent: string[];
+  alreadyInvited: string[];
+}

--- a/src/billing/queries/create_invites.sql
+++ b/src/billing/queries/create_invites.sql
@@ -1,0 +1,89 @@
+WITH from_account AS (
+  SELECT
+    accountId
+  FROM
+    account
+  WHERE primaryEmail = :byAccountEmail
+), from_account_space AS (
+  UPDATE
+    account_space
+  SET
+    spaceLeft = spaceLeft - :storageAmountInBytes::bigint * :recipientCount,
+    spaceTotal = spaceTotal - :storageAmountInBytes::bigint * :recipientCount,
+    updatedDt = CURRENT_TIMESTAMP
+  WHERE
+    accountId = (SELECT accountId FROM from_account)
+  RETURNING
+    spaceTotal,
+    fileTotal
+), invitations AS (
+  INSERT INTO
+    invite(email, giftSizeInMb, status, type, expiresDt, token, byAccountId, timesSent, createdDt, updatedDt)
+  SELECT
+    email,
+    :storageAmountInBytes::bigint / (1024 * 1024),
+    'status.invite.pending',
+    'type.invite.invite_early_access',
+    CURRENT_TIMESTAMP + INTERVAL '30 days',  
+    token,
+    (SELECT accountId FROM from_account),
+    1,
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP
+  FROM
+    unnest(:emails::text[], :tokens::text[]) temp(email, token)
+  RETURNING
+    inviteId
+)
+INSERT INTO
+  ledger_financial (
+    type,
+    spaceDelta,
+    fileDelta,
+    fromAccountId,
+    fromSpaceBefore,
+    fromSpaceLeft,
+    fromSpaceTotal,
+    fromFileBefore,
+    fromFileLeft,
+    fromFileTotal,
+    toAccountId,
+    toSpaceBefore,
+    toSpaceLeft,
+    toSpaceTotal,
+    toFileBefore,
+    toFileLeft,
+    toFileTotal,
+    status,
+    createdDt,
+    updatedDt
+  )
+  SELECT
+    'type.billing.gift.purchase',
+    :storageAmountInBytes,
+    0,
+    (SELECT accountId FROM from_account),
+    (SELECT spaceTotal FROM from_account_space) + row_number() OVER () * :storageAmountInBytes::bigint,
+    -- the following two fields get the same value for backward
+    -- compatibility, in the long run one of them should be dropped
+    -- (or potentially we should start tacking old and new values of
+    -- spaceLeft here)
+    (SELECT spaceTotal FROM from_account_space) + (row_number() OVER () - 1) * :storageAmountInBytes::bigint,
+    (SELECT spaceTotal FROM from_account_space) + (row_number() OVER () - 1) * :storageAmountInBytes::bigint,
+    -- fileTotal wasn't changed, see above commment on backward
+    -- compatibility for why fromFileTotal = fromFileLeft
+    (SELECT fileTotal FROM from_account_space),
+    (SELECT fileTotal FROM from_account_space),
+    (SELECT fileTotal FROM from_account_space),
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    'status.generic.ok',
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP
+  FROM
+   invitations;

--- a/src/billing/queries/get_account_space_for_update.sql
+++ b/src/billing/queries/get_account_space_for_update.sql
@@ -1,0 +1,10 @@
+SELECT
+  spaceLeft "spaceLeft"
+FROM
+  account_space
+JOIN
+  account
+  ON account_space.accountId = account.accountId
+WHERE
+  account.primaryEmail = :email
+FOR NO KEY UPDATE;

--- a/src/billing/queries/get_existing_account_emails.sql
+++ b/src/billing/queries/get_existing_account_emails.sql
@@ -1,0 +1,6 @@
+SELECT
+  email
+FROM
+  email
+WHERE
+  email = ANY(:emails);

--- a/src/billing/queries/get_invited_emails.sql
+++ b/src/billing/queries/get_invited_emails.sql
@@ -1,0 +1,6 @@
+SELECT
+  email
+FROM
+  invite
+WHERE
+  email = ANY(:emails);

--- a/src/billing/queries/record_gift.sql
+++ b/src/billing/queries/record_gift.sql
@@ -1,0 +1,97 @@
+WITH from_account AS (
+  SELECT
+    accountId
+  FROM
+    account
+  WHERE
+    primaryEmail = :fromEmail
+), to_account AS (
+  SELECT
+    accountId
+  FROM
+    account
+  WHERE
+    primaryEmail = ANY(:toEmails)
+), from_account_space AS (
+  UPDATE
+    account_space
+  SET
+    spaceLeft = spaceLeft - :storageAmountInBytes::bigint * :recipientCount,
+    spaceTotal = spaceTotal - :storageAmountInBytes::bigint * :recipientCount,
+    updatedDt = CURRENT_TIMESTAMP
+  WHERE
+    accountId = (SELECT accountId FROM from_account)
+  RETURNING
+    spaceTotal,
+    fileTotal
+), to_account_space AS (
+  UPDATE
+    account_space
+  SET
+    spaceLeft = spaceLeft + :storageAmountInBytes,
+    spaceTotal = spaceTotal + :storageAmountInBytes,
+    updatedDt = CURRENT_TIMESTAMP
+  FROM
+    to_account
+  WHERE
+    account_space.accountId = to_account.accountId
+  RETURNING
+    to_account.accountId,
+    spaceTotal,
+    fileTotal
+)
+INSERT INTO
+  ledger_financial (
+    type,
+    spaceDelta,
+    fileDelta,
+    fromAccountId,
+    fromSpaceBefore,
+    fromSpaceLeft,
+    fromSpaceTotal,
+    fromFileBefore,
+    fromFileLeft,
+    fromFileTotal,
+    toAccountId,
+    toSpaceBefore,
+    toSpaceLeft,
+    toSpaceTotal,
+    toFileBefore,
+    toFileLeft,
+    toFileTotal,
+    status,
+    createdDt,
+    updatedDt
+  )
+  SELECT
+    'type.billing.gift.account_to_account',
+    :storageAmountInBytes,
+    0,
+    (SELECT accountId FROM from_account),
+    (SELECT spaceTotal FROM from_account_space) + row_number() OVER () * :storageAmountInBytes::bigint,
+    -- the following two fields get the same value for backward
+    -- compatibility, in the long run one of them should be dropped
+    -- (or potentially we should start tacking old and new values of
+    -- spaceLeft here)
+    (SELECT spaceTotal FROM from_account_space) + (row_number() OVER () - 1) * :storageAmountInBytes::bigint,
+    (SELECT spaceTotal FROM from_account_space) + (row_number() OVER () - 1) * :storageAmountInBytes::bigint,
+    -- fileTotal wasn't changed, see above commment on backward
+    -- compatibility for why fromFileTotal = fromFileLeft
+    (SELECT fileTotal FROM from_account_space),
+    (SELECT fileTotal FROM from_account_space),
+    (SELECT fileTotal FROM from_account_space),
+    accountId,
+    spaceTotal - :storageAmountInBytes,
+    -- same backward compatibility reasoning as above applies here
+    spaceTotal,
+    spaceTotal,
+    -- fileTotal wasn't changed, see above commment on backward
+    -- compatibility for why toFileTotal = toFileLeft
+    fileTotal,
+    fileTotal,
+    fileTotal,
+    'status.generic.ok',
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP
+  FROM
+    to_account_space;

--- a/src/billing/service.ts
+++ b/src/billing/service.ts
@@ -1,0 +1,136 @@
+import createError from "http-errors";
+import { db } from "../database";
+import type { GiftStorageRequest, GiftStorageResponse } from "./models";
+import { logger } from "../log";
+import { GB } from "../constants";
+import { sendInvitationNotification } from "../email";
+
+const getRandomAlphanumericString = (length: number): string => {
+  const chars = "0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+  let result = "";
+  for (let i = 0; i < length; i += 1) {
+    result += chars.charAt(Math.floor(Math.random() * chars.length));
+  }
+  return result;
+};
+
+export const issueGift = async (
+  requestBody: GiftStorageRequest
+): Promise<GiftStorageResponse> => {
+  const existingAccountEmailResult = await db
+    .sql<{ email: string }>("billing.queries.get_existing_account_emails", {
+      emails: requestBody.recipientEmails,
+    })
+    .catch((err) => {
+      logger.error(err);
+      throw new createError.InternalServerError(
+        "Failed to check for existing recipient accounts"
+      );
+    });
+  const existingAccountEmails = existingAccountEmailResult.rows.map(
+    (row) => row.email
+  );
+  const newEmails = requestBody.recipientEmails.filter(
+    (email) => !existingAccountEmails.includes(email)
+  );
+
+  const alreadyInvitedEmailResult = await db
+    .sql<{ email: string }>("billing.queries.get_invited_emails", {
+      emails: newEmails,
+    })
+    .catch((err) => {
+      logger.error(err);
+      throw new createError.InternalServerError(
+        "Failed to check for existing invites"
+      );
+    });
+
+  const alreadyInvitedEmails = alreadyInvitedEmailResult.rows.map(
+    (row) => row.email
+  );
+  const emailsToInvite = newEmails.filter(
+    (email) => !alreadyInvitedEmails.includes(email)
+  );
+
+  const inviteTokens = emailsToInvite.map((_) =>
+    getRandomAlphanumericString(10)
+  );
+
+  await db.transaction(async (transactionDb) => {
+    const senderStorage = await transactionDb
+      .sql<{ spaceLeft: string }>(
+        "billing.queries.get_account_space_for_update",
+        {
+          email: requestBody.emailFromAuthToken,
+        }
+      )
+      .catch((err) => {
+        logger.error(err);
+        throw new createError.InternalServerError(
+          "Failed to look up sender account space"
+        );
+      });
+
+    if (!senderStorage.rows[0]) {
+      logger.error("Empty response from account_space query");
+      throw new createError.InternalServerError(
+        "Failed to look up sender account space"
+      );
+    } else if (
+      +senderStorage.rows[0].spaceLeft <
+      requestBody.storageAmount *
+        GB *
+        (existingAccountEmails.length + emailsToInvite.length)
+    ) {
+      throw new createError.BadRequest("Not enough storage to issue gift(s)");
+    }
+
+    await transactionDb
+      .sql("billing.queries.record_gift", {
+        fromEmail: requestBody.emailFromAuthToken,
+        toEmails: existingAccountEmails,
+        storageAmountInBytes: requestBody.storageAmount * GB,
+        recipientCount: existingAccountEmails.length,
+      })
+      .catch((err) => {
+        logger.error(err);
+        throw new createError.InternalServerError("Failed to issue gift");
+      });
+
+    await transactionDb
+      .sql("billing.queries.create_invites", {
+        emails: emailsToInvite,
+        storageAmountInBytes: requestBody.storageAmount * GB,
+        tokens: inviteTokens,
+        byAccountEmail: requestBody.emailFromAuthToken,
+        recipientCount: emailsToInvite.length,
+      })
+      .catch((err) => {
+        logger.error(err);
+        throw new createError.InternalServerError("Failed to create invites");
+      });
+  });
+
+  await Promise.all(
+    emailsToInvite.map(async (email, idx) => {
+      await sendInvitationNotification(
+        requestBody.emailFromAuthToken,
+        email,
+        requestBody.note,
+        requestBody.storageAmount,
+        // inviteTokens should always be the same length as emailsToInvite, so this will always be defined, but
+        // TypeScript doesn't know that
+        inviteTokens[idx] ?? ""
+      );
+    })
+  );
+
+  return {
+    storageGifted:
+      requestBody.storageAmount *
+      (existingAccountEmails.length + emailsToInvite.length),
+    giftDelivered: existingAccountEmails,
+    invitationSent: emailsToInvite,
+    alreadyInvited: alreadyInvitedEmails,
+  };
+};

--- a/src/billing/validators.ts
+++ b/src/billing/validators.ts
@@ -1,0 +1,21 @@
+import Joi from "joi";
+import type { GiftStorageRequest } from "./models";
+
+export function validateGiftStorageRequest(
+  data: unknown
+): asserts data is GiftStorageRequest {
+  const validation = Joi.object()
+    .keys({
+      emailFromAuthToken: Joi.string().email().required(),
+      storageAmount: Joi.number().integer().min(1).required(),
+      recipientEmails: Joi.array()
+        .min(1)
+        .items(Joi.string().email())
+        .required(),
+      note: Joi.string().allow("").optional(),
+    })
+    .validate(data);
+  if (validation.error) {
+    throw validation.error;
+  }
+}

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,1 @@
+export const GB = 1024 * 1024 * 1024;

--- a/src/email/index.ts
+++ b/src/email/index.ts
@@ -1,6 +1,11 @@
 import {
   sendLegacyContactNotification,
   sendArchiveStewardNotification,
+  sendInvitationNotification,
 } from "./service";
 
-export { sendLegacyContactNotification, sendArchiveStewardNotification };
+export {
+  sendLegacyContactNotification,
+  sendArchiveStewardNotification,
+  sendInvitationNotification,
+};

--- a/src/email/queries/get_full_name_by_account_email.sql
+++ b/src/email/queries/get_full_name_by_account_email.sql
@@ -1,0 +1,6 @@
+SELECT
+  fullName "fullName"
+FROM
+  account
+WHERE
+  primaryEmail = :email;

--- a/src/fixtures/create_test_account_space.sql
+++ b/src/fixtures/create_test_account_space.sql
@@ -1,4 +1,36 @@
 INSERT INTO 
   account_space (accountId, spaceLeft, spaceTotal, fileLeft, fileTotal, status, type, createdDt, updatedDt)
 VALUES
-  (2, 104723522,104857600, 99999, 100000, 'status.generic.ok', 'type.generic.placeholder', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP);
+  (
+    2,
+    2147483648,
+    2147483648,
+    100000,
+    100000,
+    'status.generic.ok',
+    'type.generic.placeholder',
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP
+  ),
+  (
+    3,
+    2147483648,
+    2147483648,
+    100000,
+    100000,
+    'status.generic.ok',
+    'type.generic.placeholder',
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP
+  ),
+  (
+    4,
+    2147483648,
+    2147483648,
+    100000,
+    100000,
+    'status.generic.ok',
+    'type.generic.placeholder',
+    CURRENT_TIMESTAMP,
+    CURRENT_TIMESTAMP
+  );

--- a/src/fixtures/create_test_emails.sql
+++ b/src/fixtures/create_test_emails.sql
@@ -1,0 +1,6 @@
+INSERT INTO
+  email (email, accountId, status, type)
+VALUES
+  ('test@permanent.org', 2, 'status.generic.ok', 'type.email.primary'),  
+  ('test+1@permanent.org', 3, 'status.generic.ok', 'type.email.primary'),
+  ('test+2@permanent.org', 4, 'status.generic.ok', 'type.email.primary');  

--- a/src/fixtures/create_test_invites.sql
+++ b/src/fixtures/create_test_invites.sql
@@ -1,4 +1,5 @@
 INSERT INTO
   invite (email, byAccountId, token, status, type)
 VALUES
-  ('test@permanent.org', 2, 'earlyb1rd', 'status.invite.revoked', 'type.invite.invite_code');
+  ('test@permanent.org', 2, 'earlyb1rd', 'status.invite.revoked', 'type.invite.invite_code'),
+  ('test+already_invited@permanent.org', 3, 'earlyb1rd', 'status.invite.pending', 'type.invite.invite_early_access');

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -5,6 +5,7 @@ import { legacyContactController } from "../legacy_contact";
 import { accountController } from "../account";
 import { archiveController } from "../archive";
 import { adminController } from "../admin";
+import { billingController } from "../billing";
 
 const apiRoutes = express.Router();
 apiRoutes.get("/health", healthController.getHealth);
@@ -13,5 +14,6 @@ apiRoutes.use("/legacy-contact", legacyContactController);
 apiRoutes.use("/account", accountController);
 apiRoutes.use("/archive", archiveController);
 apiRoutes.use("/admin", adminController);
+apiRoutes.use("/billing", billingController);
 
 export { apiRoutes };

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "lib",
     "noEmit": true,
-    "typeRoots": ["src/types", "node_modules/@types"]
+    "typeRoots": ["src/types", "node_modules/@types"],
+    "lib": ["es2022", "DOM"]
   },
   "include": ["src"],
   "ts-node": { "files": true }


### PR DESCRIPTION
In service of our forthcoming bulk gifting feature, we need an endpoint that can take in many emails and efficiently issue a gift to each of them. Such an endpoint (which can also handle gifts to individual users) is added in this commit.