### PR TITLE
Fix test coverage analysis

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,5 +33,5 @@ jobs:
             - run: touch stela/.env
             - run: (cd devenv; docker compose up database_setup -d; docker logs devenv-database_setup-1)
             - run: (cd stela; npm run start-containers)
-            - run: (cd stela; docker compose run stela npm run test-ci --coverage)
+            - run: (cd stela; docker compose run stela npm run test-ci)
             - uses: codecov/codecov-action@v2

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,8 @@ services:
       - devenv
     environment:
       - ENV=test
+    volumes:
+      - ./coverage:/usr/local/apps/stela/coverage
 networks:
   devenv:
     name: devenv_default


### PR DESCRIPTION
When codecov was installed in this repo, the tests weren't yet running in their own docker container. When the tests were moved to a container, the coverage report wasn't sent from that container back to the Github actions box where the codecov action runs, so coverage reports stopped reaching codecov. This commit fixes this by voluming the coverage directory on the test container.