### PR TITLE
Update indentation so these run

### DIFF
--- a/.github/workflows/dev_validate_terraform.yml
+++ b/.github/workflows/dev_validate_terraform.yml
@@ -1,8 +1,8 @@
 name: Validate Terraform (test envs)
 on:
   push:
-  paths:
-    - ./terraform/test_cluster/**
+    paths:
+      - ./terraform/test_cluster/**
 jobs:
   validate_terraform:
     name: "Validate Terraform"

--- a/.github/workflows/prod_validate_terraform.yml
+++ b/.github/workflows/prod_validate_terraform.yml
@@ -1,8 +1,8 @@
 name: Validate Terraform (prod)
 on:
   push:
-  paths:
-    - ./terraform/prod_cluster/**
+    paths:
+      - ./terraform/prod_cluster/**
 jobs:
   validate_terraform:
     name: "Validate Terraform"


### PR DESCRIPTION
I noticed that the Terraform validation didn't run on a couple recent PRs (e.g. [here](https://github.com/PermanentOrg/stela/actions/runs/6673486682)) and I think this indentation change might fix that.