### PR TITLE
Update archive.public to a boolean in base.sql

### DIFF
--- a/database/base.sql
+++ b/database/base.sql
@@ -367,7 +367,7 @@ CREATE TABLE public.archive (
     archiveid bigint NOT NULL,
     publicdt timestamp with time zone,
     archivenbr text,
-    public integer DEFAULT 0,
+    public boolean DEFAULT false,
     allowpublicdownload boolean DEFAULT true NOT NULL,
     view text,
     viewproperty text,

--- a/src/archive/queries/get_featured_archives.sql
+++ b/src/archive/queries/get_featured_archives.sql
@@ -20,4 +20,4 @@ WHERE
   profile_item.fieldNameUI = 'profile.basic'
   AND folder.type = 'type.folder.root.public'
   AND archive.public IS NOT NULL
-  AND archive.public = 1;
+  AND archive.public;

--- a/src/archive/queries/make_featured_archive.sql
+++ b/src/archive/queries/make_featured_archive.sql
@@ -8,7 +8,7 @@ INSERT INTO
   WHERE
     archiveId = :archiveId
     AND public IS NOT NULL
-    AND public = 1
+    AND public
 )
 ON CONFLICT DO NOTHING
 RETURNING archive_id;

--- a/src/fixtures/create_test_archive.sql
+++ b/src/fixtures/create_test_archive.sql
@@ -1,6 +1,6 @@
 INSERT INTO
   archive (archiveId, archiveNbr, payerAccountId, public, type, thumbUrl200)
 VALUES
-  (1, '0001-0001', 2, 0, 'type.archive.person', NULL),
-  (2, '0001-0002', NULL, 0, 'type.archive.person', NULL),
-  (3, '0001-0003', NULL, 1, 'type.archive.person', 'https://test-archive-thumbnail');
+  (1, '0001-0001', 2, false, 'type.archive.person', NULL),
+  (2, '0001-0002', NULL, false, 'type.archive.person', NULL),
+  (3, '0001-0003', NULL, true, 'type.archive.person', 'https://test-archive-thumbnail');


### PR DESCRIPTION
In base.sql, the file from which we build our local database, the column archive.public has the type integer, while in deployed environments it is a boolean. This commit corrects that error.