### PR TITLE
Update EKS test cluster to 1.25

### DIFF
--- a/terraform/test_cluster/eks-cluster.tf
+++ b/terraform/test_cluster/eks-cluster.tf
@@ -3,7 +3,7 @@ module "eks" {
   version = "19.0.4"
 
   cluster_name    = local.cluster_name
-  cluster_version = "1.24"
+  cluster_version = "1.25"
 
   vpc_id                         = var.vpc_id
   subnet_ids                     = var.subnet_ids


### PR DESCRIPTION
Kubernetes v1.24 is about to fall out of standard support in EKS, so we need to upgrade. This commit upgrades just the test cluster, so we can ensure the upgrade doesn't cause problems before upgrading on production.