### PR TITLE
Update prod EKS cluster to Kubernetes 1.25

### DIFF
--- a/terraform/prod_cluster/eks-cluster.tf
+++ b/terraform/prod_cluster/eks-cluster.tf
@@ -3,7 +3,7 @@ module "eks" {
   version = "19.0.4"
 
   cluster_name    = local.cluster_name
-  cluster_version = "1.24"
+  cluster_version = "1.25"
 
   vpc_id                         = var.vpc_id
   subnet_ids                     = var.subnet_ids


### PR DESCRIPTION
Kubernetes 1.24 will pass out of standard EKS support at the end of this month, and we've successfully updated our test cluster to 1.25, so this commit updates the prod cluster as well.