### PR TITLE
Add /admin/account/set_null_subjects endpoint

### DIFF
--- a/API.md
+++ b/API.md
@@ -45,6 +45,33 @@ Queues thumbnail generation tasks for all non-root folders created between `begi
 }
 ```
 
+### POST `/admin/account/set_null_subjects`
+
+For each pair of `email` and `subject`, sets the `subject` of the account corresponding to `email` to `subject`, if that
+account's status is `status.auth.ok` and its current `subject` is `null`
+
+- Headers: Authorization: Bearer \<JWT from FusionAuth>
+
+- Request
+
+```
+{
+  accounts: [{
+    email: string (email)
+    subject: string (uuid)
+  }]
+}
+```
+
+- Response
+
+```
+{
+  updatedAccounts: [string (accountId)],
+  emailsWithErrors: [string (email)]
+}
+```
+
 ## Directives
 
 ### POST `/directive`

--- a/packages/api/src/admin/controller.test.ts
+++ b/packages/api/src/admin/controller.test.ts
@@ -1,5 +1,6 @@
 import request from "supertest";
 import type { Request, NextFunction } from "express";
+import createError from "http-errors";
 import { logger } from "@stela/logger";
 import { app } from "../app";
 import { db } from "../database";
@@ -12,15 +13,15 @@ jest.mock("@stela/logger");
 jest.mock("../middleware");
 jest.mock("../publisher_client");
 
-const loadFixtures = async (): Promise<void> => {
-  await db.sql("fixtures.create_test_folders");
-};
-
-const clearDatabase = async (): Promise<void> => {
-  await db.query("TRUNCATE folder CASCADE");
-};
-
 describe("recalculateFolderThumbnails", () => {
+  const loadFixtures = async (): Promise<void> => {
+    await db.sql("fixtures.create_test_folders");
+  };
+
+  const clearDatabase = async (): Promise<void> => {
+    await db.query("TRUNCATE folder CASCADE");
+  };
+
   const agent = request(app);
   beforeEach(async () => {
     (verifyAdminAuthentication as jest.Mock).mockImplementation(
@@ -115,5 +116,250 @@ describe("recalculateFolderThumbnails", () => {
       .post("/api/v2/admin/folder/recalculate_thumbnails")
       .send({})
       .expect(400);
+  });
+});
+
+describe("set_null_subjects", () => {
+  const agent = request(app);
+
+  const loadFixtures = async (): Promise<void> => {
+    await db.sql("fixtures.create_test_accounts");
+  };
+
+  const clearDatabase = async (): Promise<void> => {
+    await db.query("TRUNCATE account CASCADE");
+  };
+
+  beforeEach(async () => {
+    (verifyAdminAuthentication as jest.Mock).mockImplementation(
+      (req: Request, __, next: NextFunction) => {
+        (
+          req.body as {
+            beginTimestamp: Date;
+            endTimestamp: Date;
+            emailFromAuthToken: string;
+          }
+        ).emailFromAuthToken = "test@permanent.org";
+        next();
+      }
+    );
+    jest.clearAllMocks();
+    await clearDatabase();
+    await loadFixtures();
+  });
+
+  afterEach(async () => {
+    await clearDatabase();
+  });
+
+  test("should respond with 200 for a successful request", async () => {
+    await agent
+      .post("/api/v2/admin/account/set_null_subjects")
+      .send({ accounts: [] })
+      .expect(200);
+  });
+
+  test("should respond with 401 if not authenticated", async () => {
+    (verifyAdminAuthentication as jest.Mock).mockImplementation(
+      (_, __, next: NextFunction) => {
+        next(new createError.Unauthorized("Invalid token"));
+      }
+    );
+    await agent
+      .post("/api/v2/admin/account/set_null_subjects")
+      .send({})
+      .expect(401);
+  });
+
+  test("should respond with 400 if no accounts are passed in", async () => {
+    await agent
+      .post("/api/v2/admin/account/set_null_subjects")
+      .send({})
+      .expect(400);
+  });
+
+  test("should respond with 400 if accounts not an array", async () => {
+    await agent
+      .post("/api/v2/admin/account/set_null_subjects")
+      .send({ accounts: "not an array" })
+      .expect(400);
+  });
+
+  test("should respond with 400 if accounts missing emails", async () => {
+    await agent
+      .post("/api/v2/admin/account/set_null_subjects")
+      .send({
+        accounts: [{ subject: "5c3473b6-cf2e-4c55-a80e-8db51d1bc5fd" }, {}],
+      })
+      .expect(400);
+  });
+
+  test("should respond with 400 if accounts have malformed emails", async () => {
+    await agent
+      .post("/api/v2/admin/account/set_null_subjects")
+      .send({
+        accounts: [
+          {
+            email: "test@permanent.org",
+            subject: "5c3473b6-cf2e-4c55-a80e-8db51d1bc5fd",
+          },
+          {
+            email: "not_an_email",
+            subject: "5c3473b6-cf2e-4c55-a80e-8db51d1bc5fd",
+          },
+        ],
+      })
+      .expect(400);
+  });
+
+  test("should respond with 400 if accounts are missing subjects", async () => {
+    await agent
+      .post("/api/v2/admin/account/set_null_subjects")
+      .send({
+        accounts: [{ email: "test@permanent.org" }],
+      })
+      .expect(400);
+  });
+
+  test("should respond with 400 if accounts have malformed subjects", async () => {
+    await agent
+      .post("/api/v2/admin/account/set_null_subjects")
+      .send({
+        accounts: [{ email: "test@permanent.org", subject: "not_a_uuid" }],
+      })
+      .expect(400);
+  });
+
+  test("should update subjects for accounts with null subjects", async () => {
+    const testEmail = "test@permanent.org";
+    await agent
+      .post("/api/v2/admin/account/set_null_subjects")
+      .send({
+        accounts: [
+          { email: testEmail, subject: "5c3473b6-cf2e-4c55-a80e-8db51d1bc5fd" },
+        ],
+      })
+      .expect(200);
+
+    const result = await db.query<{ subject: string }>(
+      "SELECT subject FROM account WHERE primaryEmail = :email",
+      { email: testEmail }
+    );
+    expect(result.rows[0]).not.toBeNull();
+    expect(result.rows[0]?.subject).toEqual(
+      "5c3473b6-cf2e-4c55-a80e-8db51d1bc5fd"
+    );
+  });
+
+  test("should not update subjects for accounts with subjects already", async () => {
+    const testEmail = "test+1@permanent.org";
+    await agent
+      .post("/api/v2/admin/account/set_null_subjects")
+      .send({
+        accounts: [
+          { email: testEmail, subject: "5c3473b6-cf2e-4c55-a80e-8db51d1bc5fd" },
+        ],
+      })
+      .expect(200);
+
+    const result = await db.query<{ subject: string }>(
+      "SELECT subject FROM account WHERE primaryEmail = :email",
+      { email: testEmail }
+    );
+    expect(result.rows[0]).not.toBeNull();
+    expect(result.rows[0]?.subject).not.toEqual(
+      "5c3473b6-cf2e-4c55-a80e-8db51d1bc5fd"
+    );
+  });
+
+  test("should not update subjects for accounts that aren't open", async () => {
+    const testEmail = "test+3@permanent.org";
+    await agent
+      .post("/api/v2/admin/account/set_null_subjects")
+      .send({
+        accounts: [
+          { email: testEmail, subject: "5c3473b6-cf2e-4c55-a80e-8db51d1bc5fd" },
+        ],
+      })
+      .expect(200);
+
+    const result = await db.query<{ subject: string }>(
+      "SELECT subject FROM account WHERE primaryEmail = :email",
+      { email: testEmail }
+    );
+    expect(result.rows[0]).not.toBeNull();
+    expect(result.rows[0]?.subject).not.toEqual(
+      "5c3473b6-cf2e-4c55-a80e-8db51d1bc5fd"
+    );
+  });
+
+  test("should return the ids of updated accounts", async () => {
+    const testEmailOne = "test@permanent.org";
+    const testEmailTwo = "test+2@permanent.org";
+    const testEmailThree = "test+3@permanent.org";
+    await agent
+      .post("/api/v2/admin/account/set_null_subjects")
+      .send({
+        accounts: [
+          {
+            email: testEmailOne,
+            subject: "5c3473b6-cf2e-4c55-a80e-8db51d1bc5fd",
+          },
+          {
+            email: testEmailTwo,
+            subject: "a98fc110-eddc-45fd-893b-c5fd5cc2063f",
+          },
+          {
+            email: testEmailThree,
+            subject: "d3b7267c-ebdd-46ef-8396-af196b2a5af4",
+          },
+        ],
+      })
+      .expect(200, { updatedAccounts: ["2", "4"], emailsWithErrors: [] });
+  });
+
+  test("should call logger.error if database call fails", async () => {
+    const testError = new Error("out of cheese - redo from start");
+    jest.spyOn(db, "sql").mockRejectedValueOnce(testError);
+
+    const testEmailOne = "test@permanent.org";
+    await agent
+      .post("/api/v2/admin/account/set_null_subjects")
+      .send({
+        accounts: [
+          {
+            email: testEmailOne,
+            subject: "5c3473b6-cf2e-4c55-a80e-8db51d1bc5fd",
+          },
+        ],
+      })
+      .expect(200);
+    expect(logger.error).toHaveBeenCalledWith(testError);
+  });
+
+  test("should return emails for which the update failed", async () => {
+    const testError = new Error("out of cheese - redo from start");
+    jest.spyOn(db, "sql").mockRejectedValueOnce(testError);
+
+    const testEmailOne = "test@permanent.org";
+    const testEmailTwo = "test+2@permanent.org";
+    await agent
+      .post("/api/v2/admin/account/set_null_subjects")
+      .send({
+        accounts: [
+          {
+            email: testEmailOne,
+            subject: "5c3473b6-cf2e-4c55-a80e-8db51d1bc5fd",
+          },
+          {
+            email: testEmailTwo,
+            subject: "a98fc110-eddc-45fd-893b-c5fd5cc2063f",
+          },
+        ],
+      })
+      .expect(200, {
+        emailsWithErrors: [testEmailOne],
+        updatedAccounts: ["4"],
+      });
   });
 });

--- a/packages/api/src/admin/controller.ts
+++ b/packages/api/src/admin/controller.ts
@@ -2,7 +2,10 @@ import { Router } from "express";
 import type { Request, Response, NextFunction } from "express";
 import { adminService } from "./service";
 import { verifyAdminAuthentication } from "../middleware";
-import { validateRecalculateFolderThumbnailsRequest } from "./validators";
+import {
+  validateRecalculateFolderThumbnailsRequest,
+  validateAccountSetNullSubjectsRequest,
+} from "./validators";
 import { isValidationError } from "../validators/validator_util";
 
 export const adminController = Router();
@@ -21,6 +24,26 @@ adminController.post(
       } else {
         res.json(results);
       }
+    } catch (err) {
+      if (isValidationError(err)) {
+        res.status(400).json({ error: err });
+        return;
+      }
+      next(err);
+    }
+  }
+);
+
+adminController.post(
+  "/account/set_null_subjects",
+  verifyAdminAuthentication,
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      validateAccountSetNullSubjectsRequest(req.body);
+      const response = await adminService.setNullAccountSubjects(
+        req.body.accounts
+      );
+      res.json(response);
     } catch (err) {
       if (isValidationError(err)) {
         res.status(400).json({ error: err });

--- a/packages/api/src/admin/queries/set_null_account_subject.sql
+++ b/packages/api/src/admin/queries/set_null_account_subject.sql
@@ -1,0 +1,10 @@
+UPDATE
+account
+SET
+  subject = :subject
+WHERE
+  primaryemail = :email
+  AND status = 'status.auth.ok'
+  AND subject IS NULL
+RETURNING
+accountid AS "accountId";

--- a/packages/api/src/admin/service.ts
+++ b/packages/api/src/admin/service.ts
@@ -48,6 +48,39 @@ const recalculateFolderThumbnails = async (
   };
 };
 
+const setNullAccountSubjects = async (
+  accounts: {
+    email: string;
+    subject: string;
+  }[]
+): Promise<{ updatedAccounts: string[]; emailsWithErrors: string[] }> => {
+  const updatedAccounts: string[] = [];
+  const emailsWithErrors: string[] = [];
+  await Promise.all(
+    accounts.map(async (account) => {
+      const result = await db
+        .sql<{ accountId: string }>("admin.queries.set_null_account_subject", {
+          email: account.email,
+          subject: account.subject,
+        })
+        .catch((err) => {
+          logger.error(err);
+          emailsWithErrors.push(account.email);
+          return null;
+        });
+      if (result?.rows[0]) {
+        updatedAccounts.push(result.rows[0].accountId);
+      }
+    })
+  );
+
+  return {
+    updatedAccounts,
+    emailsWithErrors,
+  };
+};
+
 export const adminService = {
   recalculateFolderThumbnails,
+  setNullAccountSubjects,
 };

--- a/packages/api/src/admin/validators.ts
+++ b/packages/api/src/admin/validators.ts
@@ -14,3 +14,24 @@ export function validateRecalculateFolderThumbnailsRequest(
     throw validation.error;
   }
 }
+
+export function validateAccountSetNullSubjectsRequest(
+  data: unknown
+): asserts data is { accounts: { email: string; subject: string }[] } {
+  const validation = Joi.object()
+    .keys({
+      emailFromAuthToken: Joi.string().email().required(),
+      accounts: Joi.array()
+        .items(
+          Joi.object({
+            email: Joi.string().email().required(),
+            subject: Joi.string().uuid().required(),
+          })
+        )
+        .required(),
+    })
+    .validate(data);
+  if (validation.error) {
+    throw validation.error;
+  }
+}

--- a/packages/api/src/fixtures/create_test_accounts.sql
+++ b/packages/api/src/fixtures/create_test_accounts.sql
@@ -5,7 +5,8 @@ account (
   status,
   notificationpreferences,
   type,
-  fullname
+  fullname,
+  subject
 )
 VALUES
 (
@@ -14,7 +15,8 @@ VALUES
   'status.auth.ok',
   '{}',
   'type.account.standard',
-  'Jack Rando'
+  'Jack Rando',
+  null
 ),
 (
   3,
@@ -22,7 +24,8 @@ VALUES
   'status.auth.ok',
   '{}',
   'type.account.standard',
-  'John Rando'
+  'John Rando',
+  '553f3cb8-b753-43ce-83af-4443a404741b'
 ),
 (
   4,
@@ -30,5 +33,15 @@ VALUES
   'status.auth.ok',
   '{}',
   'type.account.standard',
-  'Jane Rando'
+  'Jane Rando',
+  null
+),
+(
+  5,
+  'test+3@permanent.org',
+  'status.generic.invited',
+  '{}',
+  'type.account.standard',
+  'Jenny Rando',
+  null
 );


### PR DESCRIPTION
We had a longstanding bug that prevented us from recording FusionAuth user IDs in the account.subject column as we intended to for certain accounts. This commit adds an admin endpoint (requiring admin authentication) that will allow us to update unset account subjects using data retrieved from FusionAuth.