### PR TITLE
Use case insensitive email lookup in /admin/account/set_null_subjects

### DIFF
--- a/packages/api/src/admin/controller.test.ts
+++ b/packages/api/src/admin/controller.test.ts
@@ -318,6 +318,21 @@ describe("set_null_subjects", () => {
       .expect(200, { updatedAccounts: ["2", "4"], emailsWithErrors: [] });
   });
 
+  test("should look up emails case-insensitively", async () => {
+    const testEmail = "test+4@permanent.org";
+    await agent
+      .post("/api/v2/admin/account/set_null_subjects")
+      .send({
+        accounts: [
+          {
+            email: testEmail,
+            subject: "5c3473b6-cf2e-4c55-a80e-8db51d1bc5fd",
+          },
+        ],
+      })
+      .expect(200, { updatedAccounts: ["6"], emailsWithErrors: [] });
+  });
+
   test("should call logger.error if database call fails", async () => {
     const testError = new Error("out of cheese - redo from start");
     jest.spyOn(db, "sql").mockRejectedValueOnce(testError);

--- a/packages/api/src/admin/queries/set_null_account_subject.sql
+++ b/packages/api/src/admin/queries/set_null_account_subject.sql
@@ -3,7 +3,7 @@ account
 SET
   subject = :subject
 WHERE
-  primaryemail = :email
+  LOWER(primaryemail) = LOWER(:email)
   AND status = 'status.auth.ok'
   AND subject IS NULL
 RETURNING

--- a/packages/api/src/fixtures/create_test_accounts.sql
+++ b/packages/api/src/fixtures/create_test_accounts.sql
@@ -44,4 +44,13 @@ VALUES
   'type.account.standard',
   'Jenny Rando',
   null
+),
+(
+  6,
+  'TEST+4@permanent.org',
+  'status.auth.ok',
+  '{}',
+  'type.account.standard',
+  'Jenny Rando',
+  null
 );


### PR DESCRIPTION
This endpoint is a tool for using FusionAuth data to fill in missing subjects in Permanent's database. FusionAuth stores emails in lowercase, while Permanent stores them however the user provided them, so when matching emails from FusionAuth data to Permanent accounts, we must use case-insensitive comparison.