### PR TITLE
Use npm install in dev container

### DIFF
--- a/packages/api/Dockerfile.dev
+++ b/packages/api/Dockerfile.dev
@@ -12,9 +12,9 @@ COPY .env ./
 
 RUN npm install -g npm@9.5.0
 RUN npm cache clean --force
-RUN npm ci
-RUN npm ci --dev
-RUN npm ci -ws
+RUN npm install
+RUN npm install --dev
+RUN npm install -ws
 ENV PATH=/usr/local/apps/stela/node_modules/.bin:$PATH
 
 EXPOSE 8080


### PR DESCRIPTION
When building the dev container for the stela API, we currently use npm ci, but this overwrites node_modules each time it runs, which is a problem because we need to install both the project level and workspace level dependencies. Thus we should use npm install instead.