### PR TITLE
Fix tsserver analysis of tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1967,9 +1967,9 @@
       }
     },
     "node_modules/@mailchimp/mailchimp_transactional": {
-      "version": "1.0.50",
-      "resolved": "https://registry.npmjs.org/@mailchimp/mailchimp_transactional/-/mailchimp_transactional-1.0.50.tgz",
-      "integrity": "sha512-SaNFseFPSDQlOYM9JTyYY6wauMu6qJ8eExo+jssFyb20ZaVvxKX1eTb3Gm5aW/4aWuxn6nofU+02sCk51//wdw==",
+      "version": "1.0.57",
+      "resolved": "https://registry.npmjs.org/@mailchimp/mailchimp_transactional/-/mailchimp_transactional-1.0.57.tgz",
+      "integrity": "sha512-MRIjr73lJBXlKgH4NJTHe4nw8oLLTdypfHWGt1xk9Dbd38RZC0Js1dkokhdgm/GGdDzYurRDBWQi6FblkLPHWw==",
       "dependencies": {
         "axios": "^0.21.1"
       },
@@ -12178,7 +12178,7 @@
         "@aws-sdk/client-sns": "^3.370.0",
         "@fusionauth/typescript-client": "^1.42.0",
         "@mailchimp/mailchimp_marketing": "^3.0.80",
-        "@mailchimp/mailchimp_transactional": "^1.0.50",
+        "@mailchimp/mailchimp_transactional": "^1.0.57",
         "@sentry/node": "^7.57.0",
         "@stela/logger": "^1.0.0",
         "@types/http-errors": "^2.0.1",
@@ -13869,9 +13869,9 @@
       }
     },
     "@mailchimp/mailchimp_transactional": {
-      "version": "1.0.50",
-      "resolved": "https://registry.npmjs.org/@mailchimp/mailchimp_transactional/-/mailchimp_transactional-1.0.50.tgz",
-      "integrity": "sha512-SaNFseFPSDQlOYM9JTyYY6wauMu6qJ8eExo+jssFyb20ZaVvxKX1eTb3Gm5aW/4aWuxn6nofU+02sCk51//wdw==",
+      "version": "1.0.57",
+      "resolved": "https://registry.npmjs.org/@mailchimp/mailchimp_transactional/-/mailchimp_transactional-1.0.57.tgz",
+      "integrity": "sha512-MRIjr73lJBXlKgH4NJTHe4nw8oLLTdypfHWGt1xk9Dbd38RZC0Js1dkokhdgm/GGdDzYurRDBWQi6FblkLPHWw==",
       "requires": {
         "axios": "^0.21.1"
       }
@@ -14652,7 +14652,7 @@
         "@aws-sdk/client-sns": "^3.370.0",
         "@fusionauth/typescript-client": "^1.42.0",
         "@mailchimp/mailchimp_marketing": "^3.0.80",
-        "@mailchimp/mailchimp_transactional": "^1.0.50",
+        "@mailchimp/mailchimp_transactional": "^1.0.57",
         "@sentry/node": "^7.57.0",
         "@stela/logger": "^1.0.0",
         "@types/http-errors": "^2.0.1",

--- a/packages/api/.eslintrc.json
+++ b/packages/api/.eslintrc.json
@@ -1,6 +1,0 @@
-{
-  "extends": "../../.eslintrc.json",
-  "parserOptions": {
-    "project": "./tsconfig.lint.json"
-  }
-}

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -22,7 +22,7 @@
     "eslint": "eslint --max-warnings 0 ./src --ext .ts",
     "lint-sql": "docker run -i --rm -v $PWD:/sql sqlfluff/sqlfluff:2.3.5 lint --dialect postgres --nocolor src/*/queries/ src/fixtures",
     "lint": "npm run check-format && npm run check-types && npm run eslint && npm run lint-sql",
-    "build": "rm -rf dist/* && tsc -p tsconfig.json && tscp -p tsconfig.tscp.json",
+    "build": "rm -rf dist/* && tsc -p tsconfig.build.json && tscp -p tsconfig.tscp.json",
     "start:watch": "rm -rf dist/* && tsc-watch --onSuccess \"npm run start\"",
     "start": "tscp -p tsconfig.tscp.json && node dist/index.js",
     "start-containers": "(cd ../..; docker compose up -d --build stela)",
@@ -36,12 +36,12 @@
     "test-ci": "npm run clear-database-ci && npm run create-database-ci && npm run set-up-database-ci && node --experimental-vm-modules ../../node_modules/jest/bin/jest.js -i --coverage"
   },
   "dependencies": {
-    "@stela/logger": "^1.0.0",
     "@aws-sdk/client-sns": "^3.370.0",
     "@fusionauth/typescript-client": "^1.42.0",
     "@mailchimp/mailchimp_marketing": "^3.0.80",
-    "@mailchimp/mailchimp_transactional": "^1.0.50",
+    "@mailchimp/mailchimp_transactional": "1.0.57",
     "@sentry/node": "^7.57.0",
+    "@stela/logger": "^1.0.0",
     "@types/http-errors": "^2.0.1",
     "body-parser": "^1.19.0",
     "cors": "^2.8.5",

--- a/packages/api/tsconfig.build.json
+++ b/packages/api/tsconfig.build.json
@@ -1,5 +1,4 @@
 {
-  "exclude": ["node_modules", "packages/*/dist"],
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "outDir": "./dist/",

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -1,4 +1,5 @@
 {
+  "exclude": ["node_modules", "packages/*/dist"],
   "extends": "../../tsconfig.build.json",
   "compilerOptions": {
     "outDir": "./dist/",


### PR DESCRIPTION
I was observing a problem where tsserver, the standard Typescript LPS, wasn't picking up on settings in our tsconfig files for test files. This was because our tsconfig.json excluded test files in order to omit them from our builds. tsserver cannot be configured to read an alternative tsconfig file, so this commit renames the api package's tsconfig.json to tsconfig.build.json, renames its tsconfig.lint.json to tsconfig.json, and updates the build script to use tsconfig.build.json.