### PR TITLE
Speed up local tests with better Docker caching

### DIFF
--- a/packages/api/Dockerfile.test
+++ b/packages/api/Dockerfile.test
@@ -8,15 +8,18 @@ COPY package.json ./
 COPY tsconfig.build.json ./
 COPY tsconfig.json ./
 COPY jest.config.js ./
-COPY packages ./packages
-COPY database ./database
+COPY packages/api/package.json ./packages/api/package.json
+COPY packages/logger ./packages/logger
 
 RUN npm install -g npm@8.19.3
 RUN npm cache clean --force
 RUN npm install
 RUN npm install -ws
-RUN npm run build -ws
 ENV PATH=/usr/local/apps/stela/node_modules/.bin:$PATH
+
+COPY packages/api ./packages/api
+COPY database ./database
+RUN npm run build -ws
 
 EXPOSE 8080
 

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -40,7 +40,7 @@
     "@aws-sdk/client-sns": "^3.370.0",
     "@fusionauth/typescript-client": "^1.42.0",
     "@mailchimp/mailchimp_marketing": "^3.0.80",
-    "@mailchimp/mailchimp_transactional": "^1.0.50",
+    "@mailchimp/mailchimp_transactional": "1.0.57",
     "@sentry/node": "^7.57.0",
     "@types/http-errors": "^2.0.1",
     "body-parser": "^1.19.0",


### PR DESCRIPTION
This commit moves the step that copies the contents of packages/api onto the API's test container after the npm install step. This allows dependencies to be cached, so in cases where code has changed but dependencies haven't the test container will build much faster.