### PR TITLE
Add POST /event endpoint

### DIFF
--- a/API.md
+++ b/API.md
@@ -402,3 +402,37 @@ account's status is `status.auth.ok` and its current `subject` is `null`
   alreadyInvited: [string]
 }
 ```
+
+## Events
+
+### POST `/event`
+
+Records events in the database's `event` table. If `body.mixpanel` is populated, sends the event described by that field
+to Mixpanel.
+
+- Headers: Authorization: Bearer \<JWT from FusionAuth> (can be user or admin)
+- Request Body
+
+```
+{
+  entity: string (see database for valid values),
+  action: string (see database for valid values),
+  version: number,
+  entityId: string (should be the ID of the database object the event happened to),
+  userAgent: string (optional),
+  body: {
+    analytics: {
+      event: string,
+      distinctId: string,
+      data: {} (required but can be empty)
+    } (optional)
+    (optionally, any other data desired)
+  }
+}
+```
+
+- Response
+
+```
+{}
+```

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ npm install -ws
 | AWS_ACCESS_KEY_ID                 | none                                                  | The same one you use in `devenv`                                                                                                           |
 | AWS_SECRET_ACCESS_KEY             | none                                                  | The same one you use in `devenv`                                                                                                           |
 | LOW_PRIORITY_TOPIC_ARN            | test                                                  | Doesn't need to be set to a real ARN unless your work touches it specifically                                                              |
+| MIXPANEL_TOKEN                    | none                                                  | Found in Mixpanel at Settings > Project Settings > Project Token                                                                           |
 
 ## Linting
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -8780,6 +8780,17 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/mixpanel": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/mixpanel/-/mixpanel-0.18.0.tgz",
+      "integrity": "sha512-VyUoiLB/S/7abYYHGD5x0LijeuJCUabG8Hb+FvYU3Y99xHf1Qh+s4/pH9lt50fRitAHncWbU1FE01EknUfVVjQ==",
+      "dependencies": {
+        "https-proxy-agent": "5.0.0"
+      },
+      "engines": {
+        "node": ">=10.0"
+      }
+    },
     "node_modules/mkdirp": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
@@ -12178,7 +12189,7 @@
         "@aws-sdk/client-sns": "^3.370.0",
         "@fusionauth/typescript-client": "^1.42.0",
         "@mailchimp/mailchimp_marketing": "^3.0.80",
-        "@mailchimp/mailchimp_transactional": "^1.0.57",
+        "@mailchimp/mailchimp_transactional": "1.0.57",
         "@sentry/node": "^7.57.0",
         "@stela/logger": "^1.0.0",
         "@types/http-errors": "^2.0.1",
@@ -12189,6 +12200,7 @@
         "express-winston": "^4.1.0",
         "http-errors": "^2.0.0",
         "joi": "^17.7.1",
+        "mixpanel": "^0.18.0",
         "node-fetch": "^2.6.9",
         "pg": "^8.5.1",
         "require-env-variable": "^3.1.2",
@@ -14652,7 +14664,7 @@
         "@aws-sdk/client-sns": "^3.370.0",
         "@fusionauth/typescript-client": "^1.42.0",
         "@mailchimp/mailchimp_marketing": "^3.0.80",
-        "@mailchimp/mailchimp_transactional": "^1.0.57",
+        "@mailchimp/mailchimp_transactional": "1.0.57",
         "@sentry/node": "^7.57.0",
         "@stela/logger": "^1.0.0",
         "@types/http-errors": "^2.0.1",
@@ -14663,6 +14675,7 @@
         "express-winston": "^4.1.0",
         "http-errors": "^2.0.0",
         "joi": "^17.7.1",
+        "mixpanel": "^0.18.0",
         "node-fetch": "^2.6.9",
         "pg": "^8.5.1",
         "require-env-variable": "^3.1.2",
@@ -19250,6 +19263,14 @@
             "is-plain-object": "^2.0.4"
           }
         }
+      }
+    },
+    "mixpanel": {
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/mixpanel/-/mixpanel-0.18.0.tgz",
+      "integrity": "sha512-VyUoiLB/S/7abYYHGD5x0LijeuJCUabG8Hb+FvYU3Y99xHf1Qh+s4/pH9lt50fRitAHncWbU1FE01EknUfVVjQ==",
+      "requires": {
+        "https-proxy-agent": "5.0.0"
       }
     },
     "mkdirp": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -50,6 +50,7 @@
     "express-winston": "^4.1.0",
     "http-errors": "^2.0.0",
     "joi": "^17.7.1",
+    "mixpanel": "^0.18.0",
     "node-fetch": "^2.6.9",
     "pg": "^8.5.1",
     "require-env-variable": "^3.1.2",

--- a/packages/api/src/database_util.ts
+++ b/packages/api/src/database_util.ts
@@ -13,7 +13,7 @@ export const getInvalidValueFromInvalidEnumMessage = (
 ): string =>
   // These error messages take the form:
   // invalid input value for enum <SPECIFIC_ENUM>: "<OFFENDING_VALUE>"
-  (message.split(": ")[1] ?? "").replace('"', "");
+  (message.split(": ")[1] ?? "").replaceAll('"', "");
 
 export const isMissingStewardAccountError = (
   err: unknown

--- a/packages/api/src/env.ts
+++ b/packages/api/src/env.ts
@@ -16,3 +16,4 @@ requireEnv("MAILCHIMP_COMMUNITY_LIST_ID");
 requireEnv("SENTRY_DSN");
 requireEnv("AWS_REGION");
 requireEnv("LOW_PRIORITY_TOPIC_ARN");
+requireEnv("MIXPANEL_TOKEN");

--- a/packages/api/src/event/controller.test.ts
+++ b/packages/api/src/event/controller.test.ts
@@ -1,0 +1,511 @@
+import request from "supertest";
+import type { NextFunction } from "express";
+import createError from "http-errors";
+import { db } from "../database";
+import { mixpanelClient } from "../mixpanel";
+import { app } from "../app";
+import { verifyUserOrAdminAuthentication, extractIp } from "../middleware";
+import type { CreateEventRequest } from "./models";
+
+jest.mock("../database");
+jest.mock("../middleware");
+jest.mock("../mixpanel");
+
+const testSubject = "fcb2b59b-df07-4e79-ad20-bf7f067a965e";
+
+const clearDatabase = async (): Promise<void> => {
+  await db.query("TRUNCATE event CASCADE");
+};
+
+describe("POST /event", () => {
+  const agent = request(app);
+
+  beforeEach(async () => {
+    (verifyUserOrAdminAuthentication as jest.Mock).mockImplementation(
+      (req: Request, __, next: NextFunction) => {
+        (req.body as unknown as CreateEventRequest).userSubjectFromAuthToken =
+          testSubject;
+        next();
+      }
+    );
+    (extractIp as jest.Mock).mockImplementation(
+      (req: Request, __, next: NextFunction) => {
+        (req.body as unknown as CreateEventRequest).ip = "192.168.0.1";
+        next();
+      }
+    );
+    await clearDatabase();
+  });
+
+  afterEach(async () => {
+    await clearDatabase();
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+  });
+
+  test("should return 401 if unauthenticated", async () => {
+    (verifyUserOrAdminAuthentication as jest.Mock).mockImplementation(
+      (_: Request, __, next: NextFunction) => {
+        next(new createError.Unauthorized("You aren't logged in"));
+      }
+    );
+    await agent.post("/api/v2/event").expect(401);
+  });
+
+  test("should have actorType user if authenticated as user", async () => {
+    await agent
+      .post("/api/v2/event")
+      .send({
+        entity: "account",
+        action: "create",
+        version: 1,
+        entityId: "123",
+        body: {},
+      })
+      .expect(200);
+
+    const result = await db.query<{ actorType: string }>(
+      'SELECT actor_type AS "actorType" FROM event WHERE actor_id = :actorId',
+      {
+        actorId: testSubject,
+      }
+    );
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]?.actorType).toBe("user");
+  });
+
+  test("should record actor type admin if authenticated as an admin", async () => {
+    (verifyUserOrAdminAuthentication as jest.Mock).mockImplementation(
+      (req: Request, __, next: NextFunction) => {
+        (req.body as unknown as CreateEventRequest).adminSubjectFromAuthToken =
+          testSubject;
+        next();
+      }
+    );
+    await agent
+      .post("/api/v2/event")
+      .send({
+        entity: "account",
+        action: "create",
+        version: 1,
+        entityId: "123",
+        body: {},
+      })
+      .expect(200);
+
+    const result = await db.query<{ actorType: string }>(
+      'SELECT actor_type AS "actorType" FROM event WHERE actor_id = :actorId',
+      {
+        actorId: testSubject,
+      }
+    );
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]?.actorType).toBe("admin");
+  });
+
+  test("should return 400 if no subject from auth token", async () => {
+    (verifyUserOrAdminAuthentication as jest.Mock).mockImplementation(
+      (_: Request, __, next: NextFunction) => {
+        next();
+      }
+    );
+    await agent.post("/api/v2/event").expect(400);
+  });
+
+  test("should return 400 if user subject from auth token not a string", async () => {
+    (verifyUserOrAdminAuthentication as jest.Mock).mockImplementation(
+      (req: Request, __, next: NextFunction) => {
+        (
+          req.body as unknown as { userSubjectFromAuthToken: number }
+        ).userSubjectFromAuthToken = 1;
+        next();
+      }
+    );
+    await agent.post("/api/v2/event").expect(400);
+  });
+
+  test("should return 400 if user subject from auth token not a uuid", async () => {
+    (verifyUserOrAdminAuthentication as jest.Mock).mockImplementation(
+      (req: Request, __, next: NextFunction) => {
+        (req.body as unknown as CreateEventRequest).userSubjectFromAuthToken =
+          "not_a_uuid";
+        next();
+      }
+    );
+    await agent.post("/api/v2/event").expect(400);
+  });
+
+  test("should return 400 if admin subject from auth token not a string", async () => {
+    (verifyUserOrAdminAuthentication as jest.Mock).mockImplementation(
+      (req: Request, __, next: NextFunction) => {
+        (
+          req.body as unknown as { adminSubjectFromAuthToken: number }
+        ).adminSubjectFromAuthToken = 1;
+        next();
+      }
+    );
+    await agent.post("/api/v2/event").expect(400);
+  });
+
+  test("should return 400 if admin subject from auth token not a uuid", async () => {
+    (verifyUserOrAdminAuthentication as jest.Mock).mockImplementation(
+      (req: Request, __, next: NextFunction) => {
+        (req.body as unknown as CreateEventRequest).adminSubjectFromAuthToken =
+          "not_a_uuid";
+        next();
+      }
+    );
+    await agent.post("/api/v2/event").expect(400);
+  });
+
+  test("should return 400 if entity is missing", async () => {
+    await agent
+      .post("/api/v2/event")
+      .send({ action: "create", version: 1, entityId: "123", body: {} })
+      .expect(400);
+  });
+
+  test("should return 400 if entity is not a string", async () => {
+    await agent
+      .post("/api/v2/event")
+      .send({
+        entity: 1,
+        action: "create",
+        version: 1,
+        entityId: "123",
+        body: {},
+      })
+      .expect(400);
+  });
+
+  test("should return 400 if action is missing", async () => {
+    await agent
+      .post("/api/v2/event")
+      .send({ entity: "account", version: 1, entityId: "123", body: {} })
+      .expect(400);
+  });
+
+  test("should return 400 if action is not a string", async () => {
+    await agent
+      .post("/api/v2/event")
+      .send({
+        entity: "account",
+        action: 1,
+        version: 1,
+        entityId: "123",
+        body: {},
+      })
+      .expect(400);
+  });
+
+  test("should return 400 if version is missing", async () => {
+    await agent
+      .post("/api/v2/event")
+      .send({ entity: "account", action: "create", entityId: "123", body: {} })
+      .expect(400);
+  });
+
+  test("should return 400 if version is not a number", async () => {
+    await agent
+      .post("/api/v2/event")
+      .send({
+        entity: "account",
+        action: "create",
+        version: "not_a_number",
+        entityId: "123",
+        body: {},
+      })
+      .expect(400);
+  });
+
+  test("should return 400 if entityId is missing", async () => {
+    await agent
+      .post("/api/v2/event")
+      .send({ entity: "account", action: "create", version: 1, body: {} })
+      .expect(400);
+  });
+
+  test("should return 400 if entityId is not a string", async () => {
+    await agent
+      .post("/api/v2/event")
+      .send({
+        entity: "account",
+        action: "create",
+        version: 1,
+        entityId: 123,
+        body: {},
+      })
+      .expect(400);
+  });
+
+  test("should return 400 if ip is not an ip", async () => {
+    (extractIp as jest.Mock).mockImplementation(
+      (req: Request, __, next: NextFunction) => {
+        (req.body as unknown as CreateEventRequest).ip = "not_an_ip;";
+        next();
+      }
+    );
+    await agent
+      .post("/api/v2/event")
+      .send({
+        entity: "account",
+        action: "create",
+        version: 1,
+        entityId: "123",
+        body: {},
+      })
+      .expect(400);
+  });
+
+  test("should return 400 if userAgent is not a string", async () => {
+    await agent
+      .post("/api/v2/event")
+      .send({
+        entity: "account",
+        action: "create",
+        version: 1,
+        entityId: "123",
+        userAgent: 1,
+        body: {},
+      })
+      .expect(400);
+  });
+
+  test("should return 400 if body is missing", async () => {
+    await agent
+      .post("/api/v2/event")
+      .send({
+        entity: "account",
+        action: "create",
+        version: 1,
+        entityId: "123",
+      })
+      .expect(400);
+  });
+
+  test("should return 400 if body is not an object", async () => {
+    await agent
+      .post("/api/v2/event")
+      .send({
+        entity: "account",
+        action: "create",
+        version: 1,
+        entityId: "123",
+        body: "not_an_object",
+      })
+      .expect(400);
+  });
+
+  test("should return 400 if body includes analytics object with no event", async () => {
+    await agent
+      .post("/api/v2/event")
+      .send({
+        entity: "account",
+        action: "create",
+        version: 1,
+        entityId: "123",
+        body: {
+          analytics: { data: {}, distinctId: "local:123" },
+        },
+      })
+      .expect(400);
+  });
+
+  test("should return 400 if body includes analytics object with non-string event", async () => {
+    await agent
+      .post("/api/v2/event")
+      .send({
+        entity: "account",
+        action: "create",
+        version: 1,
+        entityId: "123",
+        body: {
+          analytics: { event: 1, data: {}, distinctId: "local:123" },
+        },
+      })
+      .expect(400);
+  });
+
+  test("should return 400 if body includes analytics object with no data", async () => {
+    await agent
+      .post("/api/v2/event")
+      .send({
+        entity: "account",
+        action: "create",
+        version: 1,
+        entityId: "123",
+        body: {
+          analytics: { event: "test", distinctId: "local:123" },
+        },
+      })
+      .expect(400);
+  });
+
+  test("should return 400 if body includes analytics object with non-object data", async () => {
+    await agent
+      .post("/api/v2/event")
+      .send({
+        entity: "account",
+        action: "create",
+        version: 1,
+        entityId: "123",
+        body: {
+          analytics: {
+            event: "test",
+            distinctId: "local:123",
+            data: "not_an_object",
+          },
+        },
+      })
+      .expect(400);
+  });
+
+  test("should return 400 if body includes analytics object missing distinctId", async () => {
+    await agent
+      .post("/api/v2/event")
+      .send({
+        entity: "account",
+        action: "create",
+        version: 1,
+        entityId: "123",
+        body: {
+          analytics: { event: "test", data: {} },
+        },
+      })
+      .expect(400);
+  });
+
+  test("should return 400 if body includes analytics object and distinctId not a string", async () => {
+    await agent
+      .post("/api/v2/event")
+      .send({
+        entity: "account",
+        action: "create",
+        version: 1,
+        entityId: "123",
+        body: {
+          analytics: { event: "test", data: {}, distinct_id: 1 },
+        },
+      })
+      .expect(400);
+  });
+
+  test("should record the event in the database", async () => {
+    await agent
+      .post("/api/v2/event")
+      .send({
+        entity: "account",
+        action: "create",
+        version: 1,
+        entityId: "123",
+        body: {},
+      })
+      .expect(200);
+
+    const result = await db.query(
+      "SELECT id FROM event WHERE actor_id = :actorId",
+      {
+        actorId: testSubject,
+      }
+    );
+
+    expect(result.rows).toHaveLength(1);
+  });
+
+  test("should send Mixpanel event if body includes analytics", async () => {
+    await agent
+      .post("/api/v2/event")
+      .send({
+        entity: "account",
+        action: "create",
+        version: 1,
+        entityId: "123",
+        body: {
+          analytics: {
+            event: "Sign Up",
+            distinctId: "local:123",
+            data: {
+              accountId: "123",
+              email: "test+sign_up@permanent.org",
+            },
+          },
+        },
+      })
+      .expect(200);
+
+    expect(mixpanelClient.track).toHaveBeenCalledWith("Sign Up", {
+      distinct_id: "local:123",
+      accountId: "123",
+      email: "test+sign_up@permanent.org",
+    });
+  });
+
+  test("should return 500 error if Mixpanel call fails", async () => {
+    (mixpanelClient.track as jest.Mock).mockImplementation(() => {
+      throw new Error("Mixpanel error");
+    });
+    await agent
+      .post("/api/v2/event")
+      .send({
+        entity: "account",
+        action: "create",
+        version: 1,
+        entityId: "123",
+        body: {
+          analytics: {
+            event: "Sign Up",
+            distinctId: "local:123",
+            data: {
+              accountId: "123",
+              email: "test+sign_up@permanent.org",
+            },
+          },
+        },
+      })
+      .expect(500);
+  });
+
+  test("should return 500 error if database call fails", async () => {
+    jest.spyOn(db, "sql").mockImplementation(() => {
+      throw new Error("SQL error");
+    });
+    await agent
+      .post("/api/v2/event")
+      .send({
+        entity: "account",
+        action: "create",
+        version: 1,
+        entityId: "123",
+        body: {},
+      })
+      .expect(500);
+  });
+
+  test("should return 400 error if entity value is invalid", async () => {
+    await agent
+      .post("/api/v2/event")
+      .send({
+        entity: "not_an_entity",
+        action: "create",
+        version: 1,
+        entityId: "123",
+        body: {},
+      })
+      .expect(400);
+  });
+
+  test("should return 400 error if action value is invalid", async () => {
+    await agent
+      .post("/api/v2/event")
+      .send({
+        entity: "account",
+        action: "not_an_action",
+        version: 1,
+        entityId: "123",
+        body: {},
+      })
+      .expect(400);
+  });
+});

--- a/packages/api/src/event/controller.ts
+++ b/packages/api/src/event/controller.ts
@@ -1,0 +1,29 @@
+import { Router } from "express";
+import type { Request, Response, NextFunction } from "express";
+import { logger } from "@stela/logger";
+import { verifyUserOrAdminAuthentication, extractIp } from "../middleware";
+import { validateCreateEventRequest } from "./validators";
+import { isValidationError } from "../validators/validator_util";
+import { createEvent } from "./service";
+
+export const eventController = Router();
+
+eventController.post(
+  "/",
+  verifyUserOrAdminAuthentication,
+  extractIp,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      validateCreateEventRequest(req.body);
+      await createEvent(req.body);
+      res.status(200).json({});
+    } catch (err) {
+      logger.error(err);
+      if (isValidationError(err)) {
+        res.status(400).json({ error: err.message });
+        return;
+      }
+      next(err);
+    }
+  }
+);

--- a/packages/api/src/event/index.ts
+++ b/packages/api/src/event/index.ts
@@ -1,0 +1,1 @@
+export { eventController } from "./controller";

--- a/packages/api/src/event/models.ts
+++ b/packages/api/src/event/models.ts
@@ -1,0 +1,18 @@
+export interface CreateEventRequest {
+  userSubjectFromAuthToken?: string;
+  adminSubjectFromAuthToken?: string;
+  entity: string;
+  action: string;
+  version: number;
+  entityId: string;
+  ip: string;
+  userAgent: string;
+  body: {
+    [key: string]: unknown;
+    analytics?: {
+      event: string;
+      distinctId: string;
+      data: Record<string, unknown>;
+    };
+  };
+}

--- a/packages/api/src/event/queries/create_event.sql
+++ b/packages/api/src/event/queries/create_event.sql
@@ -1,0 +1,22 @@
+INSERT INTO
+event (
+  entity,
+  action,
+  version,
+  actor_type,
+  actor_id,
+  entity_id,
+  ip,
+  user_agent,
+  body
+) VALUES (
+  :entity,
+  :action,
+  :version,
+  :actorType,
+  :actorId,
+  :entityId,
+  :ip,
+  :userAgent,
+  :body
+);

--- a/packages/api/src/event/service.ts
+++ b/packages/api/src/event/service.ts
@@ -1,0 +1,49 @@
+import createError from "http-errors";
+import { logger } from "@stela/logger";
+import { db } from "../database";
+import { mixpanelClient } from "../mixpanel";
+import type { CreateEventRequest } from "./models";
+import {
+  isInvalidEnumError,
+  getInvalidValueFromInvalidEnumMessage,
+} from "../database_util";
+
+export const createEvent = async (data: CreateEventRequest): Promise<void> => {
+  if (data.body.analytics) {
+    try {
+      const analyticsData: { [key: string]: unknown; distinct_id?: string } =
+        data.body.analytics.data;
+      analyticsData.distinct_id = data.body.analytics.distinctId;
+      mixpanelClient.track(data.body.analytics.event, analyticsData);
+    } catch (err) {
+      logger.error(err);
+      throw new createError.InternalServerError(
+        `Failed to track mixpanel event`
+      );
+    }
+  }
+  const actorType = data.userSubjectFromAuthToken ?? "" ? "user" : "admin";
+  await db
+    .sql("event.queries.create_event", {
+      entity: data.entity,
+      action: data.action,
+      version: data.version,
+      actorType,
+      actorId: data.userSubjectFromAuthToken ?? data.adminSubjectFromAuthToken,
+      entityId: data.entityId,
+      ip: data.ip,
+      userAgent: data.userAgent,
+      body: data.body,
+    })
+    .catch((err) => {
+      if (isInvalidEnumError(err)) {
+        const badValue = getInvalidValueFromInvalidEnumMessage(err.message);
+        const badKey = badValue === data.entity ? "entity" : "action";
+        throw new createError.BadRequest(
+          `${badValue} is not a valid value for ${badKey}`
+        );
+      }
+      logger.error(err);
+      throw new createError.InternalServerError(`Failed to create event`);
+    });
+};

--- a/packages/api/src/event/validators.ts
+++ b/packages/api/src/event/validators.ts
@@ -1,0 +1,33 @@
+import Joi from "joi";
+import type { CreateEventRequest } from "./models";
+
+export function validateCreateEventRequest(
+  data: unknown
+): asserts data is CreateEventRequest {
+  const validation = Joi.object()
+    .keys({
+      userSubjectFromAuthToken: Joi.string().uuid(),
+      adminSubjectFromAuthToken: Joi.string().uuid(),
+      entity: Joi.string().required(),
+      action: Joi.string().required(),
+      version: Joi.number().required(),
+      entityId: Joi.string().required(),
+      ip: Joi.string().ip().required(),
+      userAgent: Joi.string(),
+      body: Joi.object()
+        .keys({
+          analytics: Joi.object().keys({
+            event: Joi.string().required(),
+            distinctId: Joi.string().required(),
+            data: Joi.object().unknown(true).required(),
+          }),
+        })
+        .unknown(true)
+        .required(),
+    })
+    .or("userSubjectFromAuthToken", "adminSubjectFromAuthToken")
+    .validate(data);
+  if (validation.error) {
+    throw validation.error;
+  }
+}

--- a/packages/api/src/middleware/authentication.test.ts
+++ b/packages/api/src/middleware/authentication.test.ts
@@ -1,121 +1,256 @@
-import type { IntrospectResponse } from "@fusionauth/typescript-client";
-import ClientResponse from "@fusionauth/typescript-client/build/src/ClientResponse";
 import type { Request, Response } from "express";
-import { verifyUserAuthentication } from "./authentication";
+import {
+  verifyUserAuthentication,
+  verifyAdminAuthentication,
+  verifyUserOrAdminAuthentication,
+} from "./authentication";
 import { fusionAuthClient } from "../fusionauth";
 
 jest.mock("../fusionauth");
 
-const successfulIntrospectionResponse =
-  new ClientResponse<IntrospectResponse>();
-successfulIntrospectionResponse.statusCode = 200;
-successfulIntrospectionResponse.response = {
-  active: true,
-  email: "test@permanent.org",
+const testEmail = "test@permanent.org";
+const testSubject = "b2a6787c-f255-465a-8eb0-1583004d4a4f";
+
+const successfulIntrospectionResponse = {
+  statusCode: 200,
+  response: {
+    active: true as const,
+    email: testEmail,
+    sub: testSubject,
+    applicationId: "de3aba1d-314a-4aad-8ccd-192b78979678",
+    aud: "038b2813-afe9-4c0b-b175-6dfe1c8863cc",
+    auth_time: 1709591001,
+    authenticationType: "PASSWORD",
+    email_verified: true,
+    exp: 1709594601,
+    iat: 1709591001,
+    iss: "https://permanent-fake-test-issuer.io/",
+    jti: "38d2e43e-78f6-41c8-a321-5e9094c6d9d0",
+    roles: [],
+    tid: "93dd3515-b384-44d7-81bb-2cbf85e01c13",
+  },
+  exception: {},
   wasSuccessful: (): boolean => true,
 };
 
-const failedIntrospectionResponse = new ClientResponse<IntrospectResponse>();
-failedIntrospectionResponse.statusCode = 200;
-failedIntrospectionResponse.response = {
+const failedIntrospectionResponse = {
+  statusCode: 200,
   wasSuccessful: (): boolean => false,
-  exception: { message: "Out of Cheese Error. Redo From Start" },
+  response: {
+    active: false as const,
+  },
+  exception: {
+    name: "Out of Cheese",
+    message: "Out of Cheese Error. Redo From Start",
+  },
 };
 
-const expiredTokenIntrospectionResponse =
-  new ClientResponse<IntrospectResponse>();
-expiredTokenIntrospectionResponse.statusCode = 200;
-expiredTokenIntrospectionResponse.response = {
-  active: false,
+const expiredTokenIntrospectionResponse = {
+  statusCode: 200,
+  response: {
+    active: false as const,
+  },
+  exception: {},
   wasSuccessful: (): boolean => true,
 };
 
-const missingEmailIntrospectionResponse =
-  new ClientResponse<IntrospectResponse>();
-missingEmailIntrospectionResponse.statusCode = 200;
-missingEmailIntrospectionResponse.response = {
-  active: true,
+const missingEmailIntrospectionResponse = {
+  statusCode: 200,
+  response: {
+    active: true as const,
+    email: "",
+    sub: testSubject,
+    applicationId: "de3aba1d-314a-4aad-8ccd-192b78979678",
+    aud: "038b2813-afe9-4c0b-b175-6dfe1c8863cc",
+    auth_time: 1709591001,
+    authenticationType: "PASSWORD",
+    email_verified: true,
+    exp: 1709594601,
+    iat: 1709591001,
+    iss: "https://permanent-fake-test-issuer.io/",
+    jti: "38d2e43e-78f6-41c8-a321-5e9094c6d9d0",
+    roles: [],
+    tid: "93dd3515-b384-44d7-81bb-2cbf85e01c13",
+  },
+  exception: {},
   wasSuccessful: (): boolean => true,
 };
 
-test("should add the email to the request body if the token is valid", async () => {
-  const request = {
-    body: {},
-    get: (_: string) => "Bearer test",
-  } as Request<unknown, unknown, { emailFromAuthToken?: string }>;
-  jest
-    .spyOn(fusionAuthClient, "introspectAccessToken")
-    .mockImplementation(async () => successfulIntrospectionResponse);
-  await verifyUserAuthentication(request, {} as Response, () => {});
+describe("verifyUserAuthentication", () => {
+  test("should add the email to the request body if the token is valid", async () => {
+    const request = {
+      body: {},
+      get: (_: string) => "Bearer test",
+    } as Request<unknown, unknown, { emailFromAuthToken?: string }>;
+    jest
+      .spyOn(fusionAuthClient, "introspectAccessToken")
+      .mockImplementation(async () => successfulIntrospectionResponse);
+    await verifyUserAuthentication(request, {} as Response, () => {});
 
-  expect(request.body.emailFromAuthToken).toBe("test@permanent.org");
-});
+    expect(request.body.emailFromAuthToken).toBe(testEmail);
+  });
 
-test("should throw unauthorized if authorization header is missing", async () => {
-  const request = {
-    body: {},
-    get: (_: string): string | null => null,
-  } as Request;
-  jest
-    .spyOn(fusionAuthClient, "introspectAccessToken")
-    .mockImplementation(async () => successfulIntrospectionResponse);
-  await verifyUserAuthentication(request, {} as Response, (err) => {
-    expect((err as { statusCode: number }).statusCode).toBe(401);
+  test("should throw unauthorized if authorization header is missing", async () => {
+    const request = {
+      body: {},
+      get: (_: string): string | null => null,
+    } as Request<unknown, unknown, { emailFromAuthToken?: string }>;
+    jest
+      .spyOn(fusionAuthClient, "introspectAccessToken")
+      .mockImplementation(async () => successfulIntrospectionResponse);
+    await verifyUserAuthentication(request, {} as Response, (err) => {
+      expect((err as { statusCode: number }).statusCode).toBe(401);
+    });
+  });
+
+  test("should throw unauthorized if authorization header has the wrong number of words", async () => {
+    const request = {
+      body: {},
+      get: (_: string) => "test",
+    } as Request<unknown, unknown, { emailFromAuthToken?: string }>;
+    jest
+      .spyOn(fusionAuthClient, "introspectAccessToken")
+      .mockImplementation(async () => successfulIntrospectionResponse);
+    await verifyUserAuthentication(request, {} as Response, (err) => {
+      expect((err as { statusCode: number }).statusCode).toBe(401);
+    });
+  });
+
+  test("should throw unauthorized if authorization header doesn't start with Bearer", async () => {
+    const request = {
+      body: {},
+      get: (_: string) => "test test",
+    } as Request<unknown, unknown, { emailFromAuthToken?: string }>;
+    jest
+      .spyOn(fusionAuthClient, "introspectAccessToken")
+      .mockImplementation(async () => successfulIntrospectionResponse);
+    await verifyUserAuthentication(request, {} as Response, (err) => {
+      expect((err as { statusCode: number }).statusCode).toBe(401);
+    });
+  });
+
+  test("should throw unauthorized if token validation call fails", async () => {
+    const request = { body: {}, get: (_: string) => "Bearer test" } as Request<
+      unknown,
+      unknown,
+      { emailFromAuthToken?: string }
+    >;
+    jest
+      .spyOn(fusionAuthClient, "introspectAccessToken")
+      .mockImplementation(async () => failedIntrospectionResponse);
+    await verifyUserAuthentication(request, {} as Response, (err) => {
+      expect((err as { statusCode: number }).statusCode).toBe(401);
+    });
+  });
+
+  test("should throw unauthorized if token is expired", async () => {
+    const request = { body: {}, get: (_: string) => "Bearer test" } as Request<
+      unknown,
+      unknown,
+      { emailFromAuthToken?: string }
+    >;
+    jest
+      .spyOn(fusionAuthClient, "introspectAccessToken")
+      .mockImplementation(async () => expiredTokenIntrospectionResponse);
+    await verifyUserAuthentication(request, {} as Response, (err) => {
+      expect((err as { statusCode: number }).statusCode).toBe(401);
+    });
+  });
+
+  test("should throw unauthorized if token doesn't include an email", async () => {
+    const request = { body: {}, get: (_: string) => "Bearer test" } as Request<
+      unknown,
+      unknown,
+      { emailFromAuthToken?: string }
+    >;
+    jest
+      .spyOn(fusionAuthClient, "introspectAccessToken")
+      .mockImplementation(async () => missingEmailIntrospectionResponse);
+    await verifyUserAuthentication(request, {} as Response, (err) => {
+      expect((err as { statusCode: number }).statusCode).toBe(401);
+    });
   });
 });
 
-test("should throw unauthorized if authorization header has the wrong number of words", async () => {
-  const request = {
-    body: {},
-    get: (_: string) => "test",
-  } as Request;
-  jest
-    .spyOn(fusionAuthClient, "introspectAccessToken")
-    .mockImplementation(async () => successfulIntrospectionResponse);
-  await verifyUserAuthentication(request, {} as Response, (err) => {
-    expect((err as { statusCode: number }).statusCode).toBe(401);
+describe("verifyAdminAuthentication", () => {
+  test("should add the email to the request body if the token is valid", async () => {
+    const request = {
+      body: {},
+      get: (_: string) => "Bearer test",
+    } as Request<unknown, unknown, { emailFromAuthToken?: string }>;
+    jest
+      .spyOn(fusionAuthClient, "introspectAccessToken")
+      .mockImplementation(async () => successfulIntrospectionResponse);
+    await verifyAdminAuthentication(request, {} as Response, () => {});
+
+    expect(request.body.emailFromAuthToken).toBe(testEmail);
+  });
+
+  test("should throw unauthorized if authorization header is missing", async () => {
+    const request = {
+      body: {},
+      get: (_: string): string | null => null,
+    } as Request<unknown, unknown, { emailFromAuthToken?: string }>;
+    jest
+      .spyOn(fusionAuthClient, "introspectAccessToken")
+      .mockImplementation(async () => successfulIntrospectionResponse);
+    await verifyAdminAuthentication(request, {} as Response, (err) => {
+      expect((err as { statusCode: number }).statusCode).toBe(401);
+    });
   });
 });
 
-test("should throw unauthorized if authorization header doesn't start with Bearer", async () => {
-  const request = {
-    body: {},
-    get: (_: string) => "test test",
-  } as Request;
-  jest
-    .spyOn(fusionAuthClient, "introspectAccessToken")
-    .mockImplementation(async () => successfulIntrospectionResponse);
-  await verifyUserAuthentication(request, {} as Response, (err) => {
-    expect((err as { statusCode: number }).statusCode).toBe(401);
-  });
-});
+describe("verifyUserOrAdminAuthentication", () => {
+  test("should add email to the request body if user token is valid", async () => {
+    const request = {
+      body: {},
+      get: (_: string) => "Bearer test",
+    } as Request<
+      unknown,
+      unknown,
+      { userSubjectFromAuthToken?: string; adminSubjectFromAuthToken?: string }
+    >;
+    jest
+      .spyOn(fusionAuthClient, "introspectAccessToken")
+      .mockImplementation(async () => successfulIntrospectionResponse);
 
-test("should throw unauthorized if token validation call fails", async () => {
-  const request = { body: {}, get: (_: string) => "Bearer test" } as Request;
-  jest
-    .spyOn(fusionAuthClient, "introspectAccessToken")
-    .mockImplementation(async () => failedIntrospectionResponse);
-  await verifyUserAuthentication(request, {} as Response, (err) => {
-    expect((err as { statusCode: number }).statusCode).toBe(401);
+    await verifyUserOrAdminAuthentication(request, {} as Response, () => {});
+    expect(request.body.userSubjectFromAuthToken).toBe(testSubject);
   });
-});
 
-test("should throw unauthorized if token is expired", async () => {
-  const request = { body: {}, get: (_: string) => "Bearer test" } as Request;
-  jest
-    .spyOn(fusionAuthClient, "introspectAccessToken")
-    .mockImplementation(async () => expiredTokenIntrospectionResponse);
-  await verifyUserAuthentication(request, {} as Response, (err) => {
-    expect((err as { statusCode: number }).statusCode).toBe(401);
+  test("should add email to the request body if admin token is valid", async () => {
+    const request = {
+      body: {},
+      get: (_: string) => "Bearer test",
+    } as Request<
+      unknown,
+      unknown,
+      { userSubjectFromAuthToken?: string; adminSubjectFromAuthToken?: string }
+    >;
+    jest
+      .spyOn(fusionAuthClient, "introspectAccessToken")
+      .mockImplementationOnce(async () => expiredTokenIntrospectionResponse)
+      .mockImplementationOnce(async () => successfulIntrospectionResponse);
+
+    await verifyUserOrAdminAuthentication(request, {} as Response, () => {});
+    expect(request.body.adminSubjectFromAuthToken).toBe(testSubject);
   });
-});
 
-test("should throw unauthorized if token doesn't include an email", async () => {
-  const request = { body: {}, get: (_: string) => "Bearer test" } as Request;
-  jest
-    .spyOn(fusionAuthClient, "introspectAccessToken")
-    .mockImplementation(async () => missingEmailIntrospectionResponse);
-  await verifyUserAuthentication(request, {} as Response, (err) => {
-    expect((err as { statusCode: number }).statusCode).toBe(401);
+  test("should throw unauthorized if both tokens are invalid", async () => {
+    const request = {
+      body: {},
+      get: (_: string) => "Bearer test",
+    } as Request<
+      unknown,
+      unknown,
+      { userSubjectFromAuthToken?: string; adminSubjectFromAuthToken?: string }
+    >;
+    jest
+      .spyOn(fusionAuthClient, "introspectAccessToken")
+      .mockImplementation(async () => expiredTokenIntrospectionResponse);
+
+    await verifyUserOrAdminAuthentication(request, {} as Response, (err) => {
+      expect((err as { statusCode: number }).statusCode).toBe(401);
+    });
   });
 });

--- a/packages/api/src/middleware/extract_ip.test.ts
+++ b/packages/api/src/middleware/extract_ip.test.ts
@@ -1,0 +1,19 @@
+import type { Request, Response } from "express";
+import { extractIp } from "./extract_ip";
+
+describe("extractIp", () => {
+  test("should extract the IP from a request", () => {
+    const testIp = "192.168.0.1";
+    const request = {
+      body: {},
+      get: (_: string) => testIp,
+    } as Request as Request<
+      unknown,
+      unknown,
+      Record<string, string | undefined>
+    >;
+    extractIp(request, {} as Response, () => {});
+
+    expect(request.body["ip"]).toBe(testIp);
+  });
+});

--- a/packages/api/src/middleware/extract_ip.ts
+++ b/packages/api/src/middleware/extract_ip.ts
@@ -1,0 +1,10 @@
+import type { Request, Response, NextFunction } from "express";
+
+export const extractIp = (
+  req: Request<unknown, unknown, Record<string, string | undefined>>,
+  _: Response,
+  next: NextFunction
+): void => {
+  req.body["ip"] = req.get("x-forwarded-for") ?? req.connection.remoteAddress;
+  next();
+};

--- a/packages/api/src/middleware/index.ts
+++ b/packages/api/src/middleware/index.ts
@@ -1,4 +1,6 @@
 export {
   verifyUserAuthentication,
   verifyAdminAuthentication,
+  verifyUserOrAdminAuthentication,
 } from "./authentication";
+export { extractIp } from "./extract_ip";

--- a/packages/api/src/mixpanel.ts
+++ b/packages/api/src/mixpanel.ts
@@ -1,0 +1,7 @@
+import Mixpanel from "mixpanel";
+
+const mixpanelClient = Mixpanel.init(
+  process.env["MIXPANEL_TOKEN"] ?? "test_token"
+);
+
+export { mixpanelClient };

--- a/packages/api/src/routes/index.ts
+++ b/packages/api/src/routes/index.ts
@@ -6,6 +6,7 @@ import { accountController } from "../account";
 import { archiveController } from "../archive";
 import { adminController } from "../admin";
 import { billingController } from "../billing";
+import { eventController } from "../event";
 
 const apiRoutes = express.Router();
 apiRoutes.get("/health", healthController.getHealth);
@@ -15,5 +16,6 @@ apiRoutes.use("/account", accountController);
 apiRoutes.use("/archive", archiveController);
 apiRoutes.use("/admin", adminController);
 apiRoutes.use("/billing", billingController);
+apiRoutes.use("/event", eventController);
 
 export { apiRoutes };

--- a/packages/api/src/types/fusionauth.d.ts
+++ b/packages/api/src/types/fusionauth.d.ts
@@ -1,0 +1,36 @@
+declare module "@fusionauth/typescript-client" {
+  export interface Error {
+    code?: string;
+    data?: Record<string, string>;
+    message?: string;
+  }
+  export declare class FusionAuthClient {
+    public constructor(apiKey: string, host: string, tenantId: string);
+    public introspectAccessToken(
+      applicationId: string,
+      token: string
+    ): Promise<{
+      statusCode: number;
+      response:
+        | {
+            active: true;
+            applicationId: string;
+            aud: string;
+            auth_time: number;
+            authenticationType: string;
+            email: string;
+            email_verified: boolean;
+            exp: number;
+            iat: number;
+            iss: string;
+            jti: string;
+            roles: string[];
+            sub: string;
+            tid: string;
+          }
+        | { active: false };
+      exception: Error;
+      wasSuccessful: () => boolean;
+    }>;
+  }
+}

--- a/terraform/prod_cluster/secrets.tf
+++ b/terraform/prod_cluster/secrets.tf
@@ -13,5 +13,6 @@ resource "kubernetes_secret" "prod-secrets" {
     "AWS_ACCESS_KEY_ID"               = var.aws_access_key_id
     "AWS_SECRET_ACCESS_KEY"           = var.aws_secret_access_key
     "LOW_PRIORITY_TOPIC_ARN"          = var.low_priority_topic_arn
+    "MIXPANEL_TOKEN"                  = var.mixpanel_token
   }
 }

--- a/terraform/prod_cluster/stela_prod_deployment.tf
+++ b/terraform/prod_cluster/stela_prod_deployment.tf
@@ -169,6 +169,17 @@ resource "kubernetes_deployment" "stela_prod" {
             }
           }
 
+          env {
+            name = "MIXPANEL_TOKEN"
+            value_from {
+              secret_key_ref {
+                name     = "prod-secrets"
+                key      = "MIXPANEL_TOKEN"
+                optional = false
+              }
+            }
+          }
+
           port {
             container_port = 80
           }

--- a/terraform/prod_cluster/variables.tf
+++ b/terraform/prod_cluster/variables.tf
@@ -125,3 +125,8 @@ variable "low_priority_topic_arn" {
   description = "ARN of the SNS topic for 'low priority' messages"
   type        = string
 }
+
+variable "mixpanel_token" {
+  description = "Mixpanel token"
+  type        = string
+}

--- a/terraform/test_cluster/secrets.tf
+++ b/terraform/test_cluster/secrets.tf
@@ -13,6 +13,7 @@ resource "kubernetes_secret" "dev-secrets" {
     "AWS_ACCESS_KEY_ID"               = var.dev_aws_access_key_id
     "AWS_SECRET_ACCESS_KEY"           = var.dev_aws_secret_access_key
     "LOW_PRIORITY_TOPIC_ARN"          = var.dev_low_priority_topic_arn
+    "MIXPANEL_TOKEN"                  = var.dev_mixpanel_token
   }
 }
 
@@ -31,5 +32,6 @@ resource "kubernetes_secret" "staging-secrets" {
     "AWS_ACCESS_KEY_ID"               = var.staging_aws_access_key_id
     "AWS_SECRET_ACCESS_KEY"           = var.staging_aws_secret_access_key
     "LOW_PRIORITY_TOPIC_ARN"          = var.staging_low_priority_topic_arn
+    "MIXPANEL_TOKEN"                  = var.staging_mixpanel_token
   }
 }

--- a/terraform/test_cluster/stela_dev_deployment.tf
+++ b/terraform/test_cluster/stela_dev_deployment.tf
@@ -169,6 +169,17 @@ resource "kubernetes_deployment" "stela_dev" {
             }
           }
 
+          env {
+            name = "MIXPANEL_TOKEN"
+            value_from {
+              secret_key_ref {
+                name     = "dev-secrets"
+                key      = "MIXPANEL_TOKEN"
+                optional = false
+              }
+            }
+          }
+
           port {
             container_port = 80
           }

--- a/terraform/test_cluster/stela_staging_deployment.tf
+++ b/terraform/test_cluster/stela_staging_deployment.tf
@@ -169,6 +169,17 @@ resource "kubernetes_deployment" "stela_staging" {
             }
           }
 
+          env {
+            name = "MIXPANEL_TOKEN"
+            value_from {
+              secret_key_ref {
+                name     = "staging-secrets"
+                key      = "MIXPANEL_TOKEN"
+                optional = false
+              }
+            }
+          }
+
           port {
             container_port = 80
           }

--- a/terraform/test_cluster/variables.tf
+++ b/terraform/test_cluster/variables.tf
@@ -202,3 +202,13 @@ variable "staging_low_priority_topic_arn" {
   description = "ARN of the SNS topic for 'low priority' messages"
   type        = string
 }
+
+variable "dev_mixpanel_token" {
+  description = "Mixpanel token"
+  type        = string
+}
+
+variable "staging_mixpanel_token" {
+  description = "Mixpanel token"
+  type        = string
+}


### PR DESCRIPTION
To avoid to tight a coupling to Mixpanel, we want our own event tracking endpoint that records events in our database and, if desired, forwards corresponding events to Mixpanel. This commit adds that endpoint. It also refactors the authentication middleware to allow for endpoints that can be authenticated as either user or admin.