### PR TITLE
Update EKS clusters to 1.26

### DIFF
--- a/terraform/prod_cluster/eks-cluster.tf
+++ b/terraform/prod_cluster/eks-cluster.tf
@@ -3,7 +3,7 @@ module "eks" {
   version = "19.0.4"
 
   cluster_name    = local.cluster_name
-  cluster_version = "1.25"
+  cluster_version = "1.26"
 
   vpc_id                         = var.vpc_id
   subnet_ids                     = var.subnet_ids

--- a/terraform/test_cluster/eks-cluster.tf
+++ b/terraform/test_cluster/eks-cluster.tf
@@ -3,7 +3,7 @@ module "eks" {
   version = "19.0.4"
 
   cluster_name    = local.cluster_name
-  cluster_version = "1.25"
+  cluster_version = "1.26"
 
   vpc_id                         = var.vpc_id
   subnet_ids                     = var.subnet_ids


### PR DESCRIPTION
Our EKS clusters are currently on version 1.25, which will pass out of standard support this May. To avoid increased costs from running a version outside standard support, this commit updates our clusters to 1.26.