### PR TITLE
Add admin endpoint to recalculate record thumbnails

### DIFF
--- a/API.md
+++ b/API.md
@@ -72,6 +72,24 @@ account's status is `status.auth.ok` and its current `subject` is `null`
 }
 ```
 
+### POST `/admin/record/:recordId/recalculate_thumbnail
+
+Queues a thumbnail regeneration task for the record given by `recordId`
+
+- Headers: Authorization: Bearer \<JWT from FusionAuth>
+
+- Request
+
+```
+{}
+```
+
+- Response
+
+```
+{}
+```
+
 ## Directives
 
 ### POST `/directive`
@@ -402,6 +420,7 @@ account's status is `status.auth.ok` and its current `subject` is `null`
   alreadyInvited: [string]
 }
 ```
+
 ## Events
 
 ### POST `/event`

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -32,7 +32,7 @@
     "clear-database-ci": "psql postgresql://postgres:permanent@database:5432 -c 'DROP DATABASE IF EXISTS test_permanent;'",
     "create-database-ci": "psql postgresql://postgres:permanent@database:5432 -c 'CREATE DATABASE test_permanent;'",
     "set-up-database-ci": "pg_dump postgresql://postgres:permanent@database:5432/permanent --schema-only | psql postgresql://postgres:permanent@database:5432/test_permanent",
-    "test": "npm run start-containers && npm run clear-database && npm run create-database && npm run set-up-database && (cd ../..; docker compose run stela node --experimental-vm-modules ../../node_modules/jest/bin/jest.js -i)",
+    "test": "npm run start-containers && npm run clear-database && npm run create-database && npm run set-up-database && (cd ../..; docker compose run stela node --experimental-vm-modules ../../node_modules/jest/bin/jest.js -i --silent=false)",
     "test-ci": "npm run clear-database-ci && npm run create-database-ci && npm run set-up-database-ci && node --experimental-vm-modules ../../node_modules/jest/bin/jest.js -i --coverage"
   },
   "dependencies": {

--- a/packages/api/src/admin/controller.ts
+++ b/packages/api/src/admin/controller.ts
@@ -4,6 +4,7 @@ import { adminService } from "./service";
 import { verifyAdminAuthentication } from "../middleware";
 import {
   validateRecalculateFolderThumbnailsRequest,
+  validateRecalculateRecordThumbnailRequest,
   validateAccountSetNullSubjectsRequest,
 } from "./validators";
 import { isValidationError } from "../validators/validator_util";
@@ -49,6 +50,23 @@ adminController.post(
         res.status(400).json({ error: err });
         return;
       }
+      next(err);
+    }
+  }
+);
+
+adminController.post(
+  "/record/:recordId/recalculate_thumbnail",
+  verifyAdminAuthentication,
+  async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+    try {
+      // You couldn't actually call this endpoint with invalid params,
+      // because the route would not match. We validate solely to make the type checker happy.
+      // This is why there is no error handling for validation errors.
+      validateRecalculateRecordThumbnailRequest(req.params);
+      await adminService.recalculateRecordThumbnail(req.params.recordId);
+      res.status(200).json({});
+    } catch (err) {
       next(err);
     }
   }

--- a/packages/api/src/admin/models.ts
+++ b/packages/api/src/admin/models.ts
@@ -2,3 +2,9 @@ export interface Folder {
   folderId: string;
   archiveId: string;
 }
+
+export interface ArchiveRecord {
+  recordId: string;
+  parentFolderId: string;
+  archiveId: string;
+}

--- a/packages/api/src/admin/queries/get_record.sql
+++ b/packages/api/src/admin/queries/get_record.sql
@@ -1,0 +1,11 @@
+SELECT
+  record.recordid AS "recordId",
+  record.archiveid AS "archiveId",
+  folder_link.parentfolderid AS "parentFolderId"
+FROM
+  record
+INNER JOIN
+  folder_link
+  ON record.recordid = folder_link.recordid
+WHERE
+  record.recordid = :recordId;

--- a/packages/api/src/admin/validators.ts
+++ b/packages/api/src/admin/validators.ts
@@ -35,3 +35,16 @@ export function validateAccountSetNullSubjectsRequest(
     throw validation.error;
   }
 }
+
+export function validateRecalculateRecordThumbnailRequest(
+  data: unknown
+): asserts data is { recordId: string } {
+  const validation = Joi.object()
+    .keys({
+      recordId: Joi.string().required(),
+    })
+    .validate(data);
+  if (validation.error) {
+    throw validation.error;
+  }
+}

--- a/packages/api/src/fixtures/create_test_folder_links.sql
+++ b/packages/api/src/fixtures/create_test_folder_links.sql
@@ -1,0 +1,20 @@
+INSERT INTO
+folder_link (
+  recordid,
+  parentfolderid,
+  archiveid,
+  position,
+  accessrole,
+  status,
+  type
+)
+VALUES
+(
+  1,
+  2,
+  1,
+  1,
+  'access.role.owner',
+  'status.generic.ok',
+  'type.folder_link.private'
+);


### PR DESCRIPTION
We have some records in our database with thumbnail urls in an outdated format. We'd like to force the regeneration of those urls. This commit adds an admin endpoint that does that for a given record ID.