### PR TITLE
Add /events/checklist endpoint

### DIFF
--- a/API.md
+++ b/API.md
@@ -464,6 +464,20 @@ MixPanel](https://permanent.atlassian.net/wiki/spaces/EN/pages/2086862849/Mixpan
 {}
 ```
 
+### GET `/event/checklist`
+
+- Headers: Authorization: Bearer \<JWT from FusionAuth>
+- Response
+```
+[
+  {
+    id: string // an identifier for the checklist item
+    title: string // the display text for the checklist item in the UI
+    completed: boolean
+  }
+]
+```
+
 ## Promo
 
 ### POST `/promo`

--- a/packages/api/src/event/models.ts
+++ b/packages/api/src/event/models.ts
@@ -16,3 +16,9 @@ export interface CreateEventRequest {
     };
   };
 }
+
+export interface ChecklistItem {
+  id: string;
+  title: string;
+  completed: boolean;
+}

--- a/packages/api/src/event/queries/get_checklist_events.sql
+++ b/packages/api/src/event/queries/get_checklist_events.sql
@@ -1,0 +1,107 @@
+WITH account_events AS (
+  SELECT event.*
+  FROM
+    event
+  INNER JOIN
+    account
+    ON
+      account.subject::uuid = event.actor_id
+  WHERE
+    account.primaryemail = :email
+)
+
+SELECT
+  EXISTS(
+    SELECT 1
+    FROM
+      account_events
+    WHERE
+      account_events.actor_type = 'user'
+      AND account_events.entity = 'archive'
+      AND account_events.action = 'create'
+  ) AS "archiveCreated",
+  EXISTS(
+    SELECT 1
+    FROM
+      account_events
+    WHERE
+      account_events.actor_type = 'user'
+      AND account_events.entity = 'account'
+      AND account_events.action = 'submit_promo'
+  ) AS "storageRedeemed",
+  EXISTS(
+    SELECT 1
+    FROM
+      account_events
+    WHERE
+      account_events.actor_type = 'user'
+      AND account_events.entity = 'legacy_contact'
+      AND account_events.action = 'create'
+  ) AS "legacyContact",
+  EXISTS(
+    SELECT 1
+    FROM
+      account_events
+    WHERE
+      account_events.actor_type = 'user'
+      AND account_events.entity = 'directive'
+      AND account_events.action = 'create'
+  ) AS "archiveSteward",
+  EXISTS(
+    SELECT 1
+    FROM
+      account_events
+    WHERE
+      account_events.actor_type = 'user'
+      AND account_events.entity = 'profile_item'
+      AND account_events.action = 'update'
+  ) AS "archiveProfile",
+  EXISTS(
+    SELECT 1
+    FROM
+      account_events
+    WHERE
+      account_events.actor_type = 'user'
+      AND account_events.entity = 'record'
+      AND account_events.action = 'submit'
+  ) AS "firstUpload",
+  EXISTS(
+    SELECT 1
+    FROM
+      account_events
+    WHERE
+      account_events.actor_type = 'user'
+      AND (
+        (
+          account_events.entity = 'record'
+          AND account_events.action = 'submit'
+          AND (account_events.body ->> 'public')::boolean
+        )
+        OR
+        (
+          account_events.entity = 'record'
+          AND account_events.action = 'move'
+          AND (account_events.body ->> 'public')::boolean
+        )
+        OR
+        (
+          account_events.entity = 'record'
+          AND account_events.action = 'copy'
+          AND (account_events.body ->> 'public')::boolean
+        )
+        OR
+        (
+          account_events.entity = 'folder'
+          AND account_events.action = 'move'
+          AND (account_events.body ->> 'public')::boolean
+          AND (account_events.body ->> 'hasRecords')::boolean
+        )
+        OR
+        (
+          account_events.entity = 'folder'
+          AND account_events.action = 'copy'
+          AND (account_events.body ->> 'public')::boolean
+          AND (account_events.body ->> 'hasRecords')::boolean
+        )
+      )
+  ) AS "publishContent";

--- a/packages/api/src/fixtures/create_test_events.sql
+++ b/packages/api/src/fixtures/create_test_events.sql
@@ -1,0 +1,73 @@
+INSERT INTO
+event (
+  entity,
+  action,
+  version,
+  actor_type,
+  actor_id,
+  entity_id,
+  body
+)
+VALUES (
+  'archive',
+  'create',
+  1,
+  'user',
+  '553f3cb8-b753-43ce-83af-4443a404741b',
+  1,
+  '{}'
+),
+(
+  'account',
+  'submit_promo',
+  1,
+  'user',
+  '553f3cb8-b753-43ce-83af-4443a404741b',
+  3,
+  '{"promoCode": "TellYourStory"}'
+),
+(
+  'legacy_contact',
+  'create',
+  1,
+  'user',
+  '553f3cb8-b753-43ce-83af-4443a404741b',
+  1,
+  '{}'
+),
+(
+  'directive',
+  'create',
+  1,
+  'user',
+  '553f3cb8-b753-43ce-83af-4443a404741b',
+  1,
+  '{}'
+),
+(
+  'profile_item',
+  'update',
+  1,
+  'user',
+  '553f3cb8-b753-43ce-83af-4443a404741b',
+  1,
+  '{}'
+),
+(
+  'record',
+  'submit',
+  1,
+  'user',
+  '553f3cb8-b753-43ce-83af-4443a404741b',
+  1,
+  '{}'
+),
+(
+  'folder',
+  'move',
+  1,
+  'user',
+  '553f3cb8-b753-43ce-83af-4443a404741b',
+  1,
+  '{"public": true, "hasRecords": true}'
+);


### PR DESCRIPTION
We are working on a checklist to guide users through the initial steps of setting up and using Permanent. This commit adds an endpoint at /events/checklist to return, for each item on the checklist, whether that item has been completed.