### PR TITLE
Add script to clean up the Archivematica dashboard

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -28,3 +28,6 @@ AWS_REGION="us-west-2"
 # Set to your local low priority SNS topic ARN (you may have to create this topic) if testing
 # thumbnail regeneration
 LOW_PRIORITY_TOPIC_ARN=test
+
+ARCHIVEMATICA_BASE_URL=<URL here>
+ARCHIVEMATICA_API_KEY=<Archivematica username>:<Archivematica API key>

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ npm install -ws
 | AWS_SECRET_ACCESS_KEY             | none                                                  | The same one you use in `devenv`                                                                                                           |
 | LOW_PRIORITY_TOPIC_ARN            | test                                                  | Doesn't need to be set to a real ARN unless your work touches it specifically                                                              |
 | MIXPANEL_TOKEN                    | none                                                  | Found in Mixpanel at Settings > Project Settings > Project Token                                                                           |
+| ARCHIVEMATICA_BASE_URL            | none                                                  | Found in EC2, not needed unless you're running the cleanup cron                                                                            |
+| ARCHIVEMATICA_API_KEY             | none                                                  | Found in Bitwarden, not needed unless you're running the cleanup cron                                                                      |
 
 ## Linting
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "stela",
   "version": "0.0.0",
   "description": "A monolithic backend for Permanent.org",
-  "workspaces": ["./packages/logger", "./packages/api"],
+  "workspaces": ["./packages/logger", "./packages/api", "./packages/archivematica_cleanup"],
   "repository": {
     "type": "git",
     "url": "git+https://github.com/PermanentOrg/stela.git"

--- a/packages/archivematica_cleanup/jest.config.js
+++ b/packages/archivematica_cleanup/jest.config.js
@@ -1,0 +1,7 @@
+sharedConfig = require("../../jest.config");
+module.exports = {
+  ...sharedConfig,
+  moduleNameMapper: {
+    "^@stela/(.*)$": "<rootDir>/../$1/src",
+  },
+};

--- a/packages/archivematica_cleanup/package-lock.json
+++ b/packages/archivematica_cleanup/package-lock.json
@@ -1,0 +1,161 @@
+{
+  "name": "@stela/archivematica_cleanup",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@stela/archivematica_cleanup",
+      "version": "1.0.0",
+      "license": "AGPL-3.0",
+      "dependencies": {
+        "@sentry/node": "^7.57.0",
+        "dotenv": "^8.2.0",
+        "node-fetch": "^2.6.9"
+      },
+      "engines": {
+        "node": ">=18.0"
+      }
+    },
+    "node_modules/@sentry-internal/tracing": {
+      "version": "7.113.0",
+      "resolved": "https://registry.npmjs.org/@sentry-internal/tracing/-/tracing-7.113.0.tgz",
+      "integrity": "sha512-8MDnYENRMnEfQjvN4gkFYFaaBSiMFSU/6SQZfY9pLI3V105z6JQ4D0PGMAUVowXilwNZVpKNYohE7XByuhEC7Q==",
+      "dependencies": {
+        "@sentry/core": "7.113.0",
+        "@sentry/types": "7.113.0",
+        "@sentry/utils": "7.113.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/core": {
+      "version": "7.113.0",
+      "resolved": "https://registry.npmjs.org/@sentry/core/-/core-7.113.0.tgz",
+      "integrity": "sha512-pg75y3C5PG2+ur27A0Re37YTCEnX0liiEU7EOxWDGutH17x3ySwlYqLQmZsFZTSnvzv7t3MGsNZ8nT5O0746YA==",
+      "dependencies": {
+        "@sentry/types": "7.113.0",
+        "@sentry/utils": "7.113.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/integrations": {
+      "version": "7.113.0",
+      "resolved": "https://registry.npmjs.org/@sentry/integrations/-/integrations-7.113.0.tgz",
+      "integrity": "sha512-w0sspGBQ+6+V/9bgCkpuM3CGwTYoQEVeTW6iNebFKbtN7MrM3XsGAM9I2cW1jVxFZROqCBPFtd2cs5n0j14aAg==",
+      "dependencies": {
+        "@sentry/core": "7.113.0",
+        "@sentry/types": "7.113.0",
+        "@sentry/utils": "7.113.0",
+        "localforage": "^1.8.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/node": {
+      "version": "7.113.0",
+      "resolved": "https://registry.npmjs.org/@sentry/node/-/node-7.113.0.tgz",
+      "integrity": "sha512-Vam4Ia0I9fhVw8GJOzcLP7MiiHJSKl8L9LzLMMLG3+2/dFnDQOyS7sOfk3GqgpwzqPiusP9vFu7CFSX7EMQbTg==",
+      "dependencies": {
+        "@sentry-internal/tracing": "7.113.0",
+        "@sentry/core": "7.113.0",
+        "@sentry/integrations": "7.113.0",
+        "@sentry/types": "7.113.0",
+        "@sentry/utils": "7.113.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/types": {
+      "version": "7.113.0",
+      "resolved": "https://registry.npmjs.org/@sentry/types/-/types-7.113.0.tgz",
+      "integrity": "sha512-PJbTbvkcPu/LuRwwXB1He8m+GjDDLKBtu3lWg5xOZaF5IRdXQU2xwtdXXsjge4PZR00tF7MO7X8ZynTgWbYaew==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@sentry/utils": {
+      "version": "7.113.0",
+      "resolved": "https://registry.npmjs.org/@sentry/utils/-/utils-7.113.0.tgz",
+      "integrity": "sha512-nzKsErwmze1mmEsbW2AwL2oB+I5v6cDEJY4sdfLekA4qZbYZ8pV5iWza6IRl4XfzGTE1qpkZmEjPU9eyo0yvYw==",
+      "dependencies": {
+        "@sentry/types": "7.113.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-8.6.0.tgz",
+      "integrity": "sha512-IrPdXQsk2BbzvCBGBOTmmSH5SodmqZNt4ERAZDmW4CT+tL8VtvinqywuANaFu4bOMWki16nqf0e4oC0QIaDr/g==",
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/immediate": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
+      "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ=="
+    },
+    "node_modules/lie": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/lie/-/lie-3.1.1.tgz",
+      "integrity": "sha512-RiNhHysUjhrDQntfYSfY4MU24coXXdEOgw9WGcKHNeEwffDYbF//u87M1EWaMGzuFoSbqW0C9C6lEEhDOAswfw==",
+      "dependencies": {
+        "immediate": "~3.0.5"
+      }
+    },
+    "node_modules/localforage": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/localforage/-/localforage-1.10.0.tgz",
+      "integrity": "sha512-14/H1aX7hzBBmmh7sGPd+AOMkkIrHM3Z1PAyGgZigA1H1p5O5ANnMyWzvpAETtG68/dC4pC0ncy3+PPGzXZHPg==",
+      "dependencies": {
+        "lie": "3.1.1"
+      }
+    },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw=="
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ=="
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    }
+  }
+}

--- a/packages/archivematica_cleanup/package.json
+++ b/packages/archivematica_cleanup/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@stela/archivematica_cleanup",
+  "version": "1.0.0",
+  "description": "A tool to automatically delete completed jobs from the Archivematica dashboard",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/PermanentOrg/stela.git"
+  },
+  "author": "Permanent.org",
+  "license": "AGPL-3.0",
+  "bugs": {
+    "url": "https://github.com/PermanentOrg/stela/issues"
+  },
+  "homepage": "https://permanent.org",
+  "engines": {
+    "node": ">=18.0"
+  },
+  "main": "dist/index.js",
+  "scripts": {
+    "check-types": "tsc --noEmit",
+    "check-format": "prettier --check src",
+    "eslint": "eslint --max-warnings 0 ./src --ext .ts",
+    "lint": "npm run check-format && npm run check-types && npm run eslint",
+    "build": "rm -rf dist/* && tsc -p tsconfig.build.json && tscp -p tsconfig.tscp.json",
+    "start": "node dist/index.js",
+    "test": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js -i --silent=false"
+  },
+  "dependencies": {
+    "@sentry/node": "^7.57.0",
+    "dotenv": "^8.2.0",
+    "node-fetch": "^2.6.9",
+    "require-env-variable": "^3.1.2"
+  }
+}

--- a/packages/archivematica_cleanup/src/env.ts
+++ b/packages/archivematica_cleanup/src/env.ts
@@ -1,0 +1,9 @@
+import { config } from "dotenv";
+import { requireEnv } from "require-env-variable";
+
+config({ path: "../../.env" });
+
+requireEnv("ARCHIVEMATICA_BASE_URL");
+requireEnv("ARCHIVEMATICA_API_KEY");
+requireEnv("SENTRY_DSN");
+requireEnv("ENV");

--- a/packages/archivematica_cleanup/src/index.test.ts
+++ b/packages/archivematica_cleanup/src/index.test.ts
@@ -1,0 +1,83 @@
+import * as Sentry from "@sentry/node";
+import { cleanupDashboard } from "./index";
+
+jest.mock("@sentry/node");
+
+describe("cleanupDashboard", () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+    jest.resetAllMocks();
+  });
+  test("should call fetch with the correct arguments", async () => {
+    global.fetch = jest.fn(async () =>
+      Promise.resolve({
+        ok: true,
+      } as Response)
+    ) as jest.Mock;
+
+    await cleanupDashboard();
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      1,
+      `${process.env["ARCHIVEMATICA_BASE_URL"] ?? ""}/api/transfer/delete`,
+      {
+        method: "DELETE",
+        headers: {
+          Authorization: `ApiKey ${process.env["ARCHIVEMATICA_API_KEY"] ?? ""}`,
+        },
+      }
+    );
+    expect(global.fetch).toHaveBeenNthCalledWith(
+      2,
+      `${process.env["ARCHIVEMATICA_BASE_URL"] ?? ""}/api/ingest/delete`,
+      {
+        method: "DELETE",
+        headers: {
+          Authorization: `ApiKey ${process.env["ARCHIVEMATICA_API_KEY"] ?? ""}`,
+        },
+      }
+    );
+  });
+
+  test("should log an error to sentry if the transfer deletion fails", async () => {
+    const errorText = "500 Internal Server Error";
+    global.fetch = jest.fn(async () =>
+      Promise.resolve({
+        ok: false,
+        text: async () => Promise.resolve(errorText),
+      } as Response)
+    ) as jest.Mock;
+
+    await cleanupDashboard();
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(errorText);
+  });
+
+  test("should log an error to sentry if the ingest deletion fails", async () => {
+    const errorText = "500 Internal Server Error";
+    global.fetch = jest
+      .fn()
+      .mockImplementationOnce(async () =>
+        Promise.resolve({
+          ok: true,
+        } as Response)
+      )
+      .mockImplementationOnce(async () =>
+        Promise.resolve({
+          ok: false,
+          text: async () => Promise.resolve(errorText),
+        } as Response)
+      );
+
+    await cleanupDashboard();
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(errorText);
+  });
+
+  test("should log an error to sentry if an exception is thrown", async () => {
+    const error = new Error("Out of cheese - Redo from start");
+    global.fetch = jest
+      .fn()
+      .mockImplementationOnce(async () => Promise.reject(error));
+
+    await cleanupDashboard();
+    expect(Sentry.captureException).toHaveBeenCalledWith(error);
+  });
+});

--- a/packages/archivematica_cleanup/src/index.ts
+++ b/packages/archivematica_cleanup/src/index.ts
@@ -1,0 +1,51 @@
+import * as Sentry from "@sentry/node";
+import "./env";
+
+const env = process.env["ENV"] ?? "";
+Sentry.init({
+  dsn: process.env["SENTRY_DSN"] ?? "",
+  tracesSampleRate: 1.0,
+  environment: env === "local" ? `local-${process.env["DEV_NAME"] ?? ""}` : env,
+});
+
+export const cleanupDashboard = async (): Promise<void> => {
+  try {
+    const transferDeleteResponse = await fetch(
+      `${process.env["ARCHIVEMATICA_BASE_URL"] ?? ""}/api/transfer/delete`,
+      {
+        method: "DELETE",
+        headers: {
+          Authorization: `ApiKey ${process.env["ARCHIVEMATICA_API_KEY"] ?? ""}`,
+        },
+      }
+    );
+    if (!transferDeleteResponse.ok) {
+      Sentry.captureMessage(await transferDeleteResponse.text());
+      return;
+    }
+    const ingestDeleteResponse = await fetch(
+      `${process.env["ARCHIVEMATICA_BASE_URL"] ?? ""}/api/ingest/delete`,
+      {
+        method: "DELETE",
+        headers: {
+          Authorization: `ApiKey ${process.env["ARCHIVEMATICA_API_KEY"] ?? ""}`,
+        },
+      }
+    );
+    if (!ingestDeleteResponse.ok) {
+      Sentry.captureMessage(await ingestDeleteResponse.text());
+      return;
+    }
+  } catch (error) {
+    Sentry.captureException(error);
+  }
+};
+
+cleanupDashboard()
+  .then(() => {
+    process.exit(0);
+  })
+  .catch((error) => {
+    Sentry.captureException(error);
+    process.exit(1);
+  });

--- a/packages/archivematica_cleanup/tsconfig.build.json
+++ b/packages/archivematica_cleanup/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "./dist/",
+    "typeRoots": ["../../node_modules/@types", "src/types"]
+  },
+  "include": ["./src"]
+}

--- a/packages/archivematica_cleanup/tsconfig.json
+++ b/packages/archivematica_cleanup/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "exclude": ["node_modules", "packages/*/dist"],
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "outDir": "./dist/",
+    "typeRoots": ["../../node_modules/@types", "src/types"]
+  },
+  "include": ["./src"]
+}

--- a/packages/archivematica_cleanup/tsconfig.tscp.json
+++ b/packages/archivematica_cleanup/tsconfig.tscp.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.build.json",
+  "compilerOptions": {
+    "rootDir": "./src/",
+    "outDir": "./dist",
+    "typeRoots": ["../../node_modules/@types", "src/types"]
+  },
+  "include": ["./src"]
+}


### PR DESCRIPTION
Once we start processing files with Archivematica, we will need to periodically clean out the Archivematica dashboard, to prevent it from being unusably slow if we ever log in to debug something or update configuration. This commit adds a script that cleans out all completed jobs from the dashboard. A future commit will set up this script to run on a Kubernetes CronJob workload.