### PR TITLE
Include device data in Mixpanel events

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3142,6 +3142,12 @@
         "@types/superagent": "*"
       }
     },
+    "node_modules/@types/ua-parser-js": {
+      "version": "0.7.39",
+      "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.39.tgz",
+      "integrity": "sha512-P/oDfpofrdtF5xw433SPALpdSchtJmY7nsJItf8h3KXqOslkbySh8zq4dSWXH2oTjRvJ5PczVEoCZPow6GicLg==",
+      "dev": true
+    },
     "node_modules/@types/yargs": {
       "version": "15.0.5",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.5.tgz",
@@ -11565,6 +11571,28 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/ua-parser-js": {
+      "version": "1.0.37",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.37.tgz",
+      "integrity": "sha512-bhTyI94tZofjo+Dn8SN6Zv8nBDvyXTymAdM3LDI/0IboIUwTu1rEhW7v2TfiVsoYWgkQ4kOVqnI8APUFbIQIFQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/ua-parser-js"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/faisalman"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/faisalman"
+        }
+      ],
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/unbox-primitive": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/unbox-primitive/-/unbox-primitive-1.0.2.tgz",
@@ -12157,9 +12185,11 @@
         "require-env-variable": "^3.1.2",
         "tinypg": "^7.0.0",
         "ts-md5": "^1.3.1",
+        "ua-parser-js": "^1.0.37",
         "uuid": "^9.0.0"
       },
       "devDependencies": {
+        "@types/ua-parser-js": "^0.7.39",
         "supertest": "^5.0.0"
       },
       "engines": {
@@ -14619,6 +14649,7 @@
         "@sentry/node": "^7.57.0",
         "@stela/logger": "^1.0.0",
         "@types/http-errors": "^2.0.1",
+        "@types/ua-parser-js": "^0.7.39",
         "body-parser": "^1.19.0",
         "cors": "^2.8.5",
         "dotenv": "^8.2.0",
@@ -14633,6 +14664,7 @@
         "supertest": "^5.0.0",
         "tinypg": "^7.0.0",
         "ts-md5": "^1.3.1",
+        "ua-parser-js": "^1.0.37",
         "uuid": "^9.0.0"
       }
     },
@@ -14966,6 +14998,12 @@
       "requires": {
         "@types/superagent": "*"
       }
+    },
+    "@types/ua-parser-js": {
+      "version": "0.7.39",
+      "resolved": "https://registry.npmjs.org/@types/ua-parser-js/-/ua-parser-js-0.7.39.tgz",
+      "integrity": "sha512-P/oDfpofrdtF5xw433SPALpdSchtJmY7nsJItf8h3KXqOslkbySh8zq4dSWXH2oTjRvJ5PczVEoCZPow6GicLg==",
+      "dev": true
     },
     "@types/yargs": {
       "version": "15.0.5",
@@ -21315,6 +21353,11 @@
           }
         }
       }
+    },
+    "ua-parser-js": {
+      "version": "1.0.37",
+      "resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-1.0.37.tgz",
+      "integrity": "sha512-bhTyI94tZofjo+Dn8SN6Zv8nBDvyXTymAdM3LDI/0IboIUwTu1rEhW7v2TfiVsoYWgkQ4kOVqnI8APUFbIQIFQ=="
     },
     "unbox-primitive": {
       "version": "1.0.2",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -56,9 +56,11 @@
     "require-env-variable": "^3.1.2",
     "tinypg": "^7.0.0",
     "ts-md5": "^1.3.1",
+    "ua-parser-js": "^1.0.37",
     "uuid": "^9.0.0"
   },
   "devDependencies": {
+    "@types/ua-parser-js": "^0.7.39",
     "supertest": "^5.0.0"
   }
 }

--- a/packages/api/src/event/controller.test.ts
+++ b/packages/api/src/event/controller.test.ts
@@ -423,6 +423,10 @@ describe("POST /event", () => {
   test("should send Mixpanel event if body includes analytics", async () => {
     await agent
       .post("/api/v2/event")
+      .set(
+        "User-Agent",
+        "Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/125.0.6422.33 Mobile/15E148 Safari/604.1"
+      )
       .send({
         entity: "account",
         action: "create",
@@ -445,6 +449,9 @@ describe("POST /event", () => {
       distinct_id: "local:123",
       accountId: "123",
       email: "test+sign_up@permanent.org",
+      $browser: "Chrome",
+      $device: "mobile",
+      $os: "iOS",
     });
   });
 

--- a/packages/api/src/event/controller.ts
+++ b/packages/api/src/event/controller.ts
@@ -20,6 +20,10 @@ eventController.post(
   async (req: Request, res: Response, next: NextFunction) => {
     try {
       validateCreateEventRequest(req.body);
+      const userAgent = req.body.userAgent ?? req.headers["user-agent"];
+      if (userAgent !== undefined) {
+        req.body.userAgent = userAgent;
+      }
       await createEvent(req.body);
       res.status(200).json({});
     } catch (err) {

--- a/packages/api/src/event/models.ts
+++ b/packages/api/src/event/models.ts
@@ -6,7 +6,7 @@ export interface CreateEventRequest {
   version: number;
   entityId: string;
   ip: string;
-  userAgent: string;
+  userAgent?: string;
   body: {
     [key: string]: unknown;
     analytics?: {

--- a/packages/api/src/event/service.ts
+++ b/packages/api/src/event/service.ts
@@ -1,4 +1,5 @@
 import createError from "http-errors";
+import { UAParser } from "ua-parser-js";
 import { logger } from "@stela/logger";
 import { db } from "../database";
 import { mixpanelClient } from "../mixpanel";
@@ -10,10 +11,14 @@ import {
 
 export const createEvent = async (data: CreateEventRequest): Promise<void> => {
   if (data.body.analytics) {
+    const { browser, os, device } = UAParser(data.userAgent);
     try {
       const analyticsData: { [key: string]: unknown; distinct_id?: string } =
         data.body.analytics.data;
       analyticsData.distinct_id = data.body.analytics.distinctId;
+      analyticsData["$browser"] = browser.name;
+      analyticsData["$os"] = os.name;
+      analyticsData["$device"] = device.type;
       mixpanelClient.track(data.body.analytics.event, analyticsData);
     } catch (err) {
       logger.error(err);


### PR DESCRIPTION
The experience team wants to be able to segment Mixpanel events by device properties (mobile vs. desktop, browser, OS), so this commit updates POST /event to extract these properties from the user agent and include them in the Mixpanel event.