### PR TITLE
Added Archivematica cleanup cron job to deployment

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -9,18 +9,18 @@ jobs:
     uses: ./.github/workflows/test.yml
     secrets: inherit
 
-  build:
+  build_api:
     needs:
       - run_tests
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Generate Image Tag
-        run: echo "IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
+        run: echo "API_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:api-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
         env:
           AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Build Image
-        run: docker build -t $IMAGE_TAG -f Dockerfile.api .
+        run: docker build -t $API_IMAGE_TAG -f Dockerfile.api .
       - name: AWS Login
         run: aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin 364159549467.dkr.ecr.$AWS_REGION.amazonaws.com
         env:
@@ -28,10 +28,31 @@ jobs:
           AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - name: Publish Image to ECR
-        run: docker push $IMAGE_TAG
+        run: docker push $API_IMAGE_TAG
+  build_am_cleanup:
+    needs:
+      - run_tests
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Generate Image Tag
+        run: echo "AM_CLEANUP_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:am_cleanup-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
+        env:
+          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Build Image
+        run: docker build -t $AM_CLEANUP_IMAGE_TAG -f Dockerfile.am_cleanup .
+      - name: AWS Login
+        run: aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin 364159549467.dkr.ecr.$AWS_REGION.amazonaws.com
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: Publish Image to ECR
+        run: docker push $AM_CLEANUP_IMAGE_TAG
   deploy:
     needs:
-      - build
+      - build_api
+      - build_am_cleanup
     runs-on: ubuntu-20.04
     defaults:
       run:
@@ -42,8 +63,12 @@ jobs:
         uses: hashicorp/setup-terraform@v1
         with:
           cli_config_credentials_token: ${{ secrets.TERRAFORM_API_TOKEN }}
-      - name: Generate Image Tag
-        run: echo "IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
+      - name: Generate API Image Tag
+        run: echo "API_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:api-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
+        env:
+          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Generate Archivematica Cleanup Image Tag
+        run: echo "AM_CLEANUP_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:am_cleanup-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
         env:
           AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Terraform Init
@@ -52,10 +77,15 @@ jobs:
       - name: Terraform Validate
         id: validate
         run: terraform validate -no-color
-      # Note that while Terraform requires us to pass a value of stela_staging_image below, it won't be used because the
-      # -target option restricts terraform to just updating the dev deployment
-      - name: Terraform Plan
-        id: plan
-        run: terraform plan -no-color -input=false -var="stela_dev_image=$IMAGE_TAG" -var="stela_staging_image=$IMAGE_TAG" -target=kubernetes_deployment.stela_dev
-      - name: Terraform Apply
-        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$IMAGE_TAG" -var="stela_staging_image=$IMAGE_TAG" -target=kubernetes_deployment.stela_dev
+      # Note that while Terraform requires us to pass a values for the staging images below, they won't be used because
+      # the -target option restricts terraform to just updating the dev deployment
+      - name: Terraform Plan for API
+        id: plan_api
+        run: terraform plan -no-color -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -target=kubernetes_deployment.stela_dev
+      - name: Terraform Apply for API
+        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -target=kubernetes_deployment.stela_dev
+      - name: Terraform Plan for Archivematica cleanup
+        id: plan_am_cleanup
+        run: terraform plan -no-color -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -target=kubernetes_cron_job_v1.archivematica_cleanup_dev
+      - name: Terraform Apply for Archivematica cleanup
+        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -target=kubernetes_cron_job_v1.archivematica_cleanup_dev

--- a/.github/workflows/full_test_deploy.yml
+++ b/.github/workflows/full_test_deploy.yml
@@ -6,18 +6,18 @@ jobs:
     uses: ./.github/workflows/test.yml
     secrets: inherit
 
-  build:
+  build_api:
     needs:
       - run_tests
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Generate Image Tag
-        run: echo "IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
+        run: echo "API_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:api-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
         env:
           AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Build Image
-        run: docker build -t $IMAGE_TAG -f Dockerfile.api .
+        run: docker build -t $API_IMAGE_TAG -f Dockerfile.api .
       - name: AWS Login
         run: aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin 364159549467.dkr.ecr.$AWS_REGION.amazonaws.com
         env:
@@ -25,10 +25,31 @@ jobs:
           AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - name: Publish Image to ECR
-        run: docker push $IMAGE_TAG
+        run: docker push $API_IMAGE_TAG
+  build_am_cleanup:
+    needs:
+      - run_tests
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Generate Image Tag
+        run: echo "AM_CLEANUP_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:am_cleanup-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
+        env:
+          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Build Image
+        run: docker build -t $AM_CLEANUP_IMAGE_TAG -f Dockerfile.am_cleanup .
+      - name: AWS Login
+        run: aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin 364159549467.dkr.ecr.$AWS_REGION.amazonaws.com
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: Publish Image to ECR
+        run: docker push $AM_CLEANUP_IMAGE_TAG
   deploy:
     needs:
-      - build
+      - build_api
+      - build_am_cleanup
     runs-on: ubuntu-20.04
     defaults:
       run:
@@ -39,8 +60,12 @@ jobs:
         uses: hashicorp/setup-terraform@v1
         with:
           cli_config_credentials_token: ${{ secrets.TERRAFORM_API_TOKEN }}
-      - name: Generate Image Tag
-        run: echo "IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
+      - name: Generate API Image Tag
+        run: echo "API_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:api-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
+        env:
+          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Generate Archivematica Cleanup Image Tag
+        run: echo "AM_CLEANUP_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:am_cleanup-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
         env:
           AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Terraform Init
@@ -51,6 +76,6 @@ jobs:
         run: terraform validate -no-color
       - name: Terraform Plan
         id: plan
-        run: terraform plan -no-color -input=false -var="stela_dev_image=$IMAGE_TAG" -var="stela_staging_image=$IMAGE_TAG"
+        run: terraform plan -no-color -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG"
       - name: Terraform Apply
-        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$IMAGE_TAG" -var="stela_staging_image=$IMAGE_TAG"
+        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG"

--- a/.github/workflows/prod_deploy.yml
+++ b/.github/workflows/prod_deploy.yml
@@ -8,18 +8,18 @@ jobs:
     uses: ./.github/workflows/test.yml
     secrets: inherit
 
-  build:
+  build_api:
     needs:
       - run_tests
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Generate Image Tag
-        run: echo "IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
+        run: echo "API_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
         env:
           AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Build Image
-        run: docker build -t $IMAGE_TAG -f Dockerfile.api .
+        run: docker build -t $API_IMAGE_TAG -f Dockerfile.api .
       - name: AWS Login
         run: aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin 364159549467.dkr.ecr.$AWS_REGION.amazonaws.com
         env:
@@ -27,10 +27,31 @@ jobs:
           AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - name: Publish Image to ECR
-        run: docker push $IMAGE_TAG
+        run: docker push $API_IMAGE_TAG
+  build_am_cleanup:
+    needs:
+      - run_tests
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Generate Image Tag
+        run: echo "AM_CLEANUP_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:am_cleanup-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
+        env:
+          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Build Image
+        run: docker build -t $AM_CLEANUP_IMAGE_TAG -f Dockerfile.am_cleanup .
+      - name: AWS Login
+        run: aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin 364159549467.dkr.ecr.$AWS_REGION.amazonaws.com
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: Publish Image to ECR
+        run: docker push $AM_CLEANUP_IMAGE_TAG
   deploy_staging:
     needs:
-      - build
+      - build_api
+      - build_am_cleanup
     runs-on: ubuntu-20.04
     defaults:
       run:
@@ -41,8 +62,12 @@ jobs:
         uses: hashicorp/setup-terraform@v1
         with:
           cli_config_credentials_token: ${{ secrets.TERRAFORM_API_TOKEN }}
-      - name: Generate Image Tag
-        run: echo "IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
+      - name: Generate API Image Tag
+        run: echo "API_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:api-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
+        env:
+          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Generate Archivematica Cleanup Image Tag
+        run: echo "AM_CLEANUP_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:am_cleanup-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
         env:
           AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Terraform Init
@@ -53,14 +78,20 @@ jobs:
         run: terraform validate -no-color
       # Note that while Terraform requires us to pass a value of stela_dev_image below, it won't be used because the
       # -target option restricts terraform to just updating the staging deployment
-      - name: Terraform Plan
-        id: plan
-        run: terraform plan -no-color -input=false -var="stela_dev_image=$IMAGE_TAG" -var="stela_staging_image=$IMAGE_TAG" -target=kubernetes_deployment.stela_staging
-      - name: Terraform Apply
-        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$IMAGE_TAG" -var="stela_staging_image=$IMAGE_TAG" -target=kubernetes_deployment.stela_staging
+      - name: Terraform Plan for API
+        id: plan_api
+        run: terraform plan -no-color -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -target=kubernetes_deployment.stela_staging
+      - name: Terraform Apply for API
+        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -target=kubernetes_deployment.stela_staging
+      - name: Terraform Plan for Archivematica cleanup
+        id: plan_am_cleanup
+        run: terraform plan -no-color -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -target=kubernetes_cron_job.archivematica_cleanup_staging
+      - name: Terraform Apply for Archivematica cleanup
+        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -target=kubernetes_cron_job.archivematica_cleanup_staging
   deploy_prod:
     needs:
-      - build
+      - build_api
+      - build_am_cleanup
       - deploy_staging
     runs-on: ubuntu-20.04
     environment: prod
@@ -73,8 +104,12 @@ jobs:
         uses: hashicorp/setup-terraform@v1
         with:
           cli_config_credentials_token: ${{ secrets.TERRAFORM_API_TOKEN }}
-      - name: Generate Image Tag
-        run: echo "IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
+      - name: Generate API Image Tag
+        run: echo "API_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:api-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
+        env:
+          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Generate Archivematica Cleanup Image Tag
+        run: echo "AM_CLEANUP_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:am_cleanup-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
         env:
           AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Terraform Init
@@ -85,6 +120,6 @@ jobs:
         run: terraform validate -no-color
       - name: Terraform Plan
         id: plan
-        run: terraform plan -no-color -input=false -var="stela_image=$IMAGE_TAG"
+        run: terraform plan -no-color -input=false -var="stela_image=$API_IMAGE_TAG" -var "archivematica_cleanup_image=$AM_CLEANUP_IMAGE_TAG"
       - name: Terraform Apply
-        run: terraform apply -auto-approve -input=false -var="stela_image=$IMAGE_TAG"
+        run: terraform apply -auto-approve -input=false -var="stela_image=$API_IMAGE_TAG" -var "archivematica_cleanup_image=$AM_CLEANUP_IMAGE_TAG"

--- a/.github/workflows/staging_deploy.yml
+++ b/.github/workflows/staging_deploy.yml
@@ -6,18 +6,18 @@ jobs:
     uses: ./.github/workflows/test.yml
     secrets: inherit
 
-  build:
+  build_api:
     needs:
       - run_tests
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v3
       - name: Generate Image Tag
-        run: echo "IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
+        run: echo "API_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:api-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
         env:
           AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Build Image
-        run: docker build -t $IMAGE_TAG -f Dockerfile.api .
+        run: docker build -t $API_IMAGE_TAG -f Dockerfile.api .
       - name: AWS Login
         run: aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin 364159549467.dkr.ecr.$AWS_REGION.amazonaws.com
         env:
@@ -25,10 +25,31 @@ jobs:
           AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - name: Publish Image to ECR
-        run: docker push $IMAGE_TAG
+        run: docker push $API_IMAGE_TAG
+  build_am_cleanup:
+    needs:
+      - run_tests
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Generate Image Tag
+        run: echo "AM_CLEANUP_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:am_cleanup-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
+        env:
+          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Build Image
+        run: docker build -t $AM_CLEANUP_IMAGE_TAG -f Dockerfile.am_cleanup .
+      - name: AWS Login
+        run: aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin 364159549467.dkr.ecr.$AWS_REGION.amazonaws.com
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: Publish Image to ECR
+        run: docker push $AM_CLEANUP_IMAGE_TAG
   deploy:
     needs:
-      - build
+      - build_api
+      - build_am_cleanup
     runs-on: ubuntu-20.04
     defaults:
       run:
@@ -39,8 +60,12 @@ jobs:
         uses: hashicorp/setup-terraform@v1
         with:
           cli_config_credentials_token: ${{ secrets.TERRAFORM_API_TOKEN }}
-      - name: Generate Image Tag
-        run: echo "IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
+      - name: Generate API Image Tag
+        run: echo "API_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:api-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
+        env:
+          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Generate Archivematica Cleanup Image Tag
+        run: echo "AM_CLEANUP_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:am_cleanup-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
         env:
           AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Terraform Init
@@ -51,8 +76,13 @@ jobs:
         run: terraform validate -no-color
       # Note that while Terraform requires us to pass a value of stela_dev_image below, it won't be used because the
       # -target option restricts terraform to just updating the staging deployment
-      - name: Terraform Plan
-        id: plan
-        run: terraform plan -no-color -input=false -var="stela_dev_image=$IMAGE_TAG" -var="stela_staging_image=$IMAGE_TAG" -target=kubernetes_deployment.stela_staging
-      - name: Terraform Apply
-        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$IMAGE_TAG" -var="stela_staging_image=$IMAGE_TAG" -target=kubernetes_deployment.stela_staging
+      - name: Terraform Plan for API
+        id: plan_api
+        run: terraform plan -no-color -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -target=kubernetes_deployment.stela_staging
+      - name: Terraform Apply for API
+        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -target=kubernetes_deployment.stela_staging
+      - name: Terraform Plan for Archivematica cleanup
+        id: plan_am_cleanup
+        run: terraform plan -no-color -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -target=kubernetes_cron_job_v1.archivematica_cleanup_staging
+      - name: Terraform Apply for Archivematica cleanup
+        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -target=kubernetes_cron_job_v1.archivematica_cleanup_staging

--- a/Dockerfile.am_cleanup
+++ b/Dockerfile.am_cleanup
@@ -1,0 +1,28 @@
+FROM node:18-alpine AS builder
+WORKDIR /usr/local/apps/stela/
+
+COPY package.json ./
+COPY tsconfig.build.json ./
+COPY tsconfig.json ./
+COPY jest.config.js ./
+COPY packages ./packages
+
+RUN npm install -g npm@8.19.3
+RUN npm install
+RUN npm install -ws
+RUN npm run build -ws
+
+FROM node:18-alpine AS final
+WORKDIR /usr/local/apps/stela/
+
+COPY --from=builder /usr/local/apps/stela/packages/archivematica_cleanup/dist ./packages/archivematica_cleanup/dist
+COPY --from=builder /usr/local/apps/stela/packages/archivematica_cleanup/package.json ./packages/archivematica_cleanup/package.json
+COPY --from=builder /usr/local/apps/stela/packages/logger/dist ./packages/logger/dist
+COPY --from=builder /usr/local/apps/stela/packages/logger/package.json ./packages/logger/package.json
+COPY --from=builder /usr/local/apps/stela/package.json ./package.json
+COPY --from=builder /usr/local/apps/stela/package-lock.json ./package-lock.json
+
+RUN npm install -g npm@8.19.3
+RUN npm install --workspace @stela/archivematica_cleanup
+
+CMD node packages/archivematica_cleanup/dist/index.js

--- a/packages/archivematica_cleanup/package.json
+++ b/packages/archivematica_cleanup/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@sentry/node": "^7.57.0",
+    "@stela/logger": "^1.0.0",
     "dotenv": "^8.2.0",
     "node-fetch": "^2.6.9",
     "require-env-variable": "^3.1.2"

--- a/packages/archivematica_cleanup/src/index.ts
+++ b/packages/archivematica_cleanup/src/index.ts
@@ -1,4 +1,5 @@
 import * as Sentry from "@sentry/node";
+import { logger } from "@stela/logger";
 import "./env";
 
 const env = process.env["ENV"] ?? "";
@@ -20,6 +21,7 @@ export const cleanupDashboard = async (): Promise<void> => {
       }
     );
     if (!transferDeleteResponse.ok) {
+      logger.error(await transferDeleteResponse.text());
       Sentry.captureMessage(await transferDeleteResponse.text());
       return;
     }
@@ -33,10 +35,12 @@ export const cleanupDashboard = async (): Promise<void> => {
       }
     );
     if (!ingestDeleteResponse.ok) {
+      logger.error(await ingestDeleteResponse.text());
       Sentry.captureMessage(await ingestDeleteResponse.text());
       return;
     }
   } catch (error) {
+    logger.error(error);
     Sentry.captureException(error);
   }
 };

--- a/terraform/prod_cluster/am_cleanup_prod_cronjob.tf
+++ b/terraform/prod_cluster/am_cleanup_prod_cronjob.tf
@@ -1,0 +1,69 @@
+resource "kubernetes_cron_job_v1" "archivematica_cleanup_prod" {
+  metadata {
+    name = "archivematica-cleanup-prod"
+    labels = {
+      Environment = "prod"
+    }
+  }
+  spec {
+    concurrency_policy            = "Replace"
+    failed_jobs_history_limit     = 5
+    schedule                      = "0 * * * *"
+    starting_deadline_seconds     = 10
+    successful_jobs_history_limit = 10
+    job_template {
+      metadata {}
+      spec {
+        backoff_limit              = 2
+        ttl_seconds_after_finished = 10
+        template {
+          metadata {}
+          spec {
+            container {
+              name  = "archivematica-cleanup-prod"
+              image = var.archivematica_cleanup_image
+
+              env {
+                name  = "ENV"
+                value = var.env
+              }
+
+              env {
+                name = "ARCHIVEMATICA_BASE_URL"
+                value_from {
+                  secret_key_ref {
+                    name     = "prod-secrets"
+                    key      = "ARCHIVEMATICA_BASE_URL"
+                    optional = false
+                  }
+                }
+              }
+
+              env {
+                name = "ARCHIVEMATICA_API_KEY"
+                value_from {
+                  secret_key_ref {
+                    name     = "prod-secrets"
+                    key      = "ARCHIVEMATICA_API_KEY"
+                    optional = false
+                  }
+                }
+              }
+
+              env {
+                name = "SENTRY_DSN"
+                value_from {
+                  secret_key_ref {
+                    name     = "prod-secrets"
+                    key      = "SENTRY_DSN"
+                    optional = false
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/terraform/prod_cluster/secrets.tf
+++ b/terraform/prod_cluster/secrets.tf
@@ -14,5 +14,7 @@ resource "kubernetes_secret" "prod-secrets" {
     "AWS_SECRET_ACCESS_KEY"           = var.aws_secret_access_key
     "LOW_PRIORITY_TOPIC_ARN"          = var.low_priority_topic_arn
     "MIXPANEL_TOKEN"                  = var.mixpanel_token
+    "ARCHIVEMATICA_BASE_URL"          = var.archivematica_base_url
+    "ARCHIVEMATICA_API_KEY"           = var.archivematica_api_key
   }
 }

--- a/terraform/prod_cluster/variables.tf
+++ b/terraform/prod_cluster/variables.tf
@@ -28,7 +28,12 @@ variable "subnet_ids" {
 }
 
 variable "stela_image" {
-  description = "Tag of stela image to deploy"
+  description = "Tag of stela API image to deploy"
+  type        = string
+}
+
+variable "archivematica_cleanup_image" {
+  description = "Tag of Archivematica cleanup image to deploy"
   type        = string
 }
 
@@ -128,5 +133,15 @@ variable "low_priority_topic_arn" {
 
 variable "mixpanel_token" {
   description = "Mixpanel token"
+  type        = string
+}
+
+variable "archivematica_base_url" {
+  description = "Base URL for the Archivematica API"
+  type        = string
+}
+
+variable "archivematica_api_key" {
+  description = "API key
   type        = string
 }

--- a/terraform/test_cluster/am_cleanup_dev_cronjob.tf
+++ b/terraform/test_cluster/am_cleanup_dev_cronjob.tf
@@ -1,0 +1,69 @@
+resource "kubernetes_cron_job_v1" "archivematica_cleanup_dev" {
+  metadata {
+    name = "archivematica-cleanup-dev"
+    labels = {
+      Environment = "dev"
+    }
+  }
+  spec {
+    concurrency_policy            = "Replace"
+    failed_jobs_history_limit     = 5
+    schedule                      = "0 * * * *"
+    starting_deadline_seconds     = 10
+    successful_jobs_history_limit = 10
+    job_template {
+      metadata {}
+      spec {
+        backoff_limit              = 2
+        ttl_seconds_after_finished = 10
+        template {
+          metadata {}
+          spec {
+            container {
+              name  = "archivematica-cleanup-dev"
+              image = var.archivematica_cleanup_dev_image
+
+              env {
+                name  = "ENV"
+                value = var.dev_env
+              }
+
+              env {
+                name = "ARCHIVEMATICA_BASE_URL"
+                value_from {
+                  secret_key_ref {
+                    name     = "dev-secrets"
+                    key      = "ARCHIVEMATICA_BASE_URL"
+                    optional = false
+                  }
+                }
+              }
+
+              env {
+                name = "ARCHIVEMATICA_API_KEY"
+                value_from {
+                  secret_key_ref {
+                    name     = "dev-secrets"
+                    key      = "ARCHIVEMATICA_API_KEY"
+                    optional = false
+                  }
+                }
+              }
+
+              env {
+                name = "SENTRY_DSN"
+                value_from {
+                  secret_key_ref {
+                    name     = "dev-secrets"
+                    key      = "SENTRY_DSN"
+                    optional = false
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/terraform/test_cluster/am_cleanup_staging_cronjob.tf
+++ b/terraform/test_cluster/am_cleanup_staging_cronjob.tf
@@ -1,0 +1,69 @@
+resource "kubernetes_cron_job_v1" "archivematica_cleanup_staging" {
+  metadata {
+    name = "archivematica-cleanup-staging"
+    labels = {
+      Environment = "staging"
+    }
+  }
+  spec {
+    concurrency_policy            = "Replace"
+    failed_jobs_history_limit     = 5
+    schedule                      = "0 * * * *"
+    starting_deadline_seconds     = 10
+    successful_jobs_history_limit = 10
+    job_template {
+      metadata {}
+      spec {
+        backoff_limit              = 2
+        ttl_seconds_after_finished = 10
+        template {
+          metadata {}
+          spec {
+            container {
+              name  = "archivematica-cleanup-staging"
+              image = var.archivematica_cleanup_staging_image
+
+              env {
+                name  = "ENV"
+                value = var.staging_env
+              }
+
+              env {
+                name = "ARCHIVEMATICA_BASE_URL"
+                value_from {
+                  secret_key_ref {
+                    name     = "staging-secrets"
+                    key      = "ARCHIVEMATICA_BASE_URL"
+                    optional = false
+                  }
+                }
+              }
+
+              env {
+                name = "ARCHIVEMATICA_API_KEY"
+                value_from {
+                  secret_key_ref {
+                    name     = "staging-secrets"
+                    key      = "ARCHIVEMATICA_API_KEY"
+                    optional = false
+                  }
+                }
+              }
+
+              env {
+                name = "SENTRY_DSN"
+                value_from {
+                  secret_key_ref {
+                    name     = "staging-secrets"
+                    key      = "SENTRY_DSN"
+                    optional = false
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}

--- a/terraform/test_cluster/secrets.tf
+++ b/terraform/test_cluster/secrets.tf
@@ -14,6 +14,8 @@ resource "kubernetes_secret" "dev-secrets" {
     "AWS_SECRET_ACCESS_KEY"           = var.dev_aws_secret_access_key
     "LOW_PRIORITY_TOPIC_ARN"          = var.dev_low_priority_topic_arn
     "MIXPANEL_TOKEN"                  = var.dev_mixpanel_token
+    "ARCHIVEMATICA_BASE_URL"          = var.dev_archivematica_base_url
+    "ARCHIVEMATICA_API_KEY"           = var.dev_archivematica_api_key
   }
 }
 
@@ -33,5 +35,7 @@ resource "kubernetes_secret" "staging-secrets" {
     "AWS_SECRET_ACCESS_KEY"           = var.staging_aws_secret_access_key
     "LOW_PRIORITY_TOPIC_ARN"          = var.staging_low_priority_topic_arn
     "MIXPANEL_TOKEN"                  = var.staging_mixpanel_token
+    "ARCHIVEMATICA_BASE_URL"          = var.staging_archivematica_base_url
+    "ARCHIVEMATICA_API_KEY"           = var.staging_archivematica_api_key
   }
 }

--- a/terraform/test_cluster/variables.tf
+++ b/terraform/test_cluster/variables.tf
@@ -39,12 +39,22 @@ variable "subnet_ids" {
 }
 
 variable "stela_dev_image" {
-  description = "Tag of stela image to deploy to dev"
+  description = "Tag of stela API image to deploy to dev"
   type        = string
 }
 
 variable "stela_staging_image" {
-  description = "Tag of stela image to deploy to staging"
+  description = "Tag of stela API image to deploy to staging"
+  type        = string
+}
+
+variable "archivematica_cleanup_dev_image" {
+  description = "Tag of archivematica cleanup image to deploy to dev"
+  type        = string
+}
+
+variable "archivematica_cleanup_staging_image" {
+  description = "Tag of archivematica cleanup image to deploy to staging"
   type        = string
 }
 
@@ -210,5 +220,25 @@ variable "dev_mixpanel_token" {
 
 variable "staging_mixpanel_token" {
   description = "Mixpanel token"
+  type        = string
+}
+
+variable "dev_archivematica_base_url" {
+  description = "Base URL for the Archivematica API in the dev environment"
+  type        = string
+}
+
+variable "staging_archivematica_base_url" {
+  description = "Base URL for the Archivematica API in the staging environment"
+  type        = string
+}
+
+variable "dev_archivematica_api_key" {
+  description = "API key for the Archivematica API in the dev environment"
+  type        = string
+}
+
+variable "staging_archivematica_api_key" {
+  description = "API key for the Archivematica API in the staging environment"
   type        = string
 }


### PR DESCRIPTION
Once we start using Archivematica for file processing, we will need a cron process to periodically delete successfully completed jobs from the Archivematica dashboard. This commit creates a Dockerfile to run the Archivematica cleanup script, and updates the terraform configuration to create a Kubernetes CronJob to run that docker image each hour.