### PR TITLE
Add /idpuser/enable-two-factor endpoint

### DIFF
--- a/packages/api/src/idpuser/controller.ts
+++ b/packages/api/src/idpuser/controller.ts
@@ -7,8 +7,15 @@ import {
 import { verifyUserAuthentication } from "../middleware";
 import { isValidationError } from "../validators/validator_util";
 import { validateBodyFromAuthentication } from "../validators";
-import { validateSendEnableCodeRequest } from "./validators";
-import { getTwoFactorMethods, sendEnableCode } from "./service";
+import {
+  validateSendEnableCodeRequest,
+  validateCreateTwoFactorMethodRequest,
+} from "./validators";
+import {
+  getTwoFactorMethods,
+  sendEnableCode,
+  addTwoFactorMethod,
+} from "./service";
 
 export const idpUserController = Router();
 
@@ -39,6 +46,24 @@ idpUserController.post(
       validateSendEnableCodeRequest(req.body);
       await sendEnableCode(req.body);
       res.send(200);
+    } catch (err) {
+      if (isValidationError(err)) {
+        res.status(400).json({ error: err });
+        return;
+      }
+      next(err);
+    }
+  }
+);
+
+idpUserController.post(
+  "/enable-two-factor",
+  verifyUserAuthentication,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      validateCreateTwoFactorMethodRequest(req.body);
+      await addTwoFactorMethod(req.body);
+      res.status(200).send();
     } catch (err) {
       if (isValidationError(err)) {
         res.status(400).json({ error: err });

--- a/packages/api/src/idpuser/models.ts
+++ b/packages/api/src/idpuser/models.ts
@@ -10,6 +10,13 @@ export interface SendEnableCodeRequest {
   value: string;
 }
 
+export interface CreateTwoFactorMethodRequest {
+  emailFromAuthToken: string;
+  code: string;
+  method: TwoFactorMethod;
+  value: string;
+}
+
 export enum TwoFactorMethod {
   Email = "email",
   Sms = "sms",

--- a/packages/api/src/idpuser/validators.ts
+++ b/packages/api/src/idpuser/validators.ts
@@ -1,5 +1,8 @@
 import Joi from "joi";
-import type { SendEnableCodeRequest } from "./models";
+import type {
+  SendEnableCodeRequest,
+  CreateTwoFactorMethodRequest,
+} from "./models";
 
 export function validateSendEnableCodeRequest(
   data: unknown
@@ -7,6 +10,25 @@ export function validateSendEnableCodeRequest(
   const validation = Joi.object()
     .keys({
       emailFromAuthToken: Joi.string().email().required(),
+      method: Joi.string().valid("email", "sms").required(),
+      value: Joi.string().required().when("method", {
+        is: "email",
+        then: Joi.string().email(),
+      }),
+    })
+    .validate(data);
+  if (validation.error) {
+    throw validation.error;
+  }
+}
+
+export function validateCreateTwoFactorMethodRequest(
+  data: unknown
+): asserts data is CreateTwoFactorMethodRequest {
+  const validation = Joi.object()
+    .keys({
+      emailFromAuthToken: Joi.string().email().required(),
+      code: Joi.string().required(),
       method: Joi.string().valid("email", "sms").required(),
       value: Joi.string().required().when("method", {
         is: "email",

--- a/packages/api/src/types/fusionauth.d.ts
+++ b/packages/api/src/types/fusionauth.d.ts
@@ -45,6 +45,27 @@ declare module "@fusionauth/typescript-client" {
           };
         };
       };
+      exception: Error;
+      wasSuccessful: () => boolean;
+    }>;
+    public enableTwoFactor(
+      userId: string,
+      request: {
+        applicationId?: UUID;
+        code?: string;
+        email?: string;
+        method?: string;
+        mobilePhone?: string;
+        twoFactorId?: string;
+      }
+    ): Promise<{
+      statusCode: number;
+      response: {
+        code?: string;
+        recoveryCodes?: string[];
+      };
+      exception: Error;
+      wasSuccessful: () => boolean;
     }>;
     public sendTwoFactorCodeForEnableDisable(request: {
       email?: string;


### PR DESCRIPTION
We want to give users the ability to manage their 2FA settings via the Permanent clients. To that end, we need an endpoint for enabling 2FA. This commit adds such an endpoint.