### PR TITLE
Add /idpuser/disable-two-factor endpoint

### DIFF
--- a/packages/api/src/idpuser/controller.ts
+++ b/packages/api/src/idpuser/controller.ts
@@ -11,12 +11,14 @@ import {
   validateSendEnableCodeRequest,
   validateSendDisableCodeRequest,
   validateCreateTwoFactorMethodRequest,
+  validateDisableTwoFactorRequest,
 } from "./validators";
 import {
   getTwoFactorMethods,
   sendEnableCode,
   addTwoFactorMethod,
   sendDisableCode,
+  removeTwoFactorMethod,
 } from "./service";
 
 export const idpUserController = Router();
@@ -83,6 +85,24 @@ idpUserController.post(
     try {
       validateSendDisableCodeRequest(req.body);
       await sendDisableCode(req.body);
+      res.send(200);
+    } catch (err) {
+      if (isValidationError(err)) {
+        res.status(400).json({ error: err });
+        return;
+      }
+      next(err);
+    }
+  }
+);
+
+idpUserController.post(
+  "/disable-two-factor",
+  verifyUserAuthentication,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      validateDisableTwoFactorRequest(req.body);
+      await removeTwoFactorMethod(req.body);
       res.send(200);
     } catch (err) {
       if (isValidationError(err)) {

--- a/packages/api/src/idpuser/models.ts
+++ b/packages/api/src/idpuser/models.ts
@@ -22,6 +22,12 @@ export interface SendDisableCodeRequest {
   methodId: string;
 }
 
+export interface DisableTwoFactorRequest {
+  emailFromAuthToken: string;
+  methodId: string;
+  code: string;
+}
+
 export enum TwoFactorMethod {
   Email = "email",
   Sms = "sms",

--- a/packages/api/src/idpuser/validators.ts
+++ b/packages/api/src/idpuser/validators.ts
@@ -3,6 +3,7 @@ import type {
   SendEnableCodeRequest,
   SendDisableCodeRequest,
   CreateTwoFactorMethodRequest,
+  DisableTwoFactorRequest,
 } from "./models";
 
 export function validateSendEnableCodeRequest(
@@ -49,6 +50,21 @@ export function validateSendDisableCodeRequest(
     .keys({
       emailFromAuthToken: Joi.string().email().required(),
       methodId: Joi.string().required(),
+    })
+    .validate(data);
+  if (validation.error) {
+    throw validation.error;
+  }
+}
+
+export function validateDisableTwoFactorRequest(
+  data: unknown
+): asserts data is DisableTwoFactorRequest {
+  const validation = Joi.object()
+    .keys({
+      emailFromAuthToken: Joi.string().email().required(),
+      methodId: Joi.string().required(),
+      code: Joi.string().required(),
     })
     .validate(data);
   if (validation.error) {

--- a/packages/api/src/types/fusionauth.d.ts
+++ b/packages/api/src/types/fusionauth.d.ts
@@ -78,5 +78,14 @@ declare module "@fusionauth/typescript-client" {
       exception: Error;
       wasSuccessful: () => boolean;
     }>;
+    public disableTwoFactor(
+      userId: string,
+      methodId: string,
+      code: string
+    ): Promise<{
+      statusCode: number;
+      exception: Error;
+      wasSuccessful: () => boolean;
+    }>;
   }
 }


### PR DESCRIPTION
We want our users to be able to manage their MFA through the Permanent clients, so we need an endpoint that removes an MFA method from an account. This commit adds that endpoint.