### PR TITLE
Parse list of IPs properly in `extractIp`

### DIFF
--- a/packages/api/src/middleware/extract_ip.test.ts
+++ b/packages/api/src/middleware/extract_ip.test.ts
@@ -2,11 +2,42 @@ import type { Request, Response } from "express";
 import { extractIp } from "./extract_ip";
 
 describe("extractIp", () => {
-  test("should extract the IP from a request", () => {
+  test("should extract the IP from X-Forwarded-For header", () => {
     const testIp = "192.168.0.1";
     const request = {
       body: {},
-      get: (_: string) => testIp,
+      get: (str: string) => (str === "X-Forwarded-For" ? testIp : undefined),
+    } as Request as Request<
+      unknown,
+      unknown,
+      Record<string, string | undefined>
+    >;
+    extractIp(request, {} as Response, () => {});
+
+    expect(request.body["ip"]).toBe(testIp);
+  });
+  test("should extract IP from the remoteAddress if not forwarded", () => {
+    const testIp = "192.168.0.1";
+    const request = {
+      body: {},
+      connection: {
+        remoteAddress: testIp,
+      },
+      get: (_: string) => undefined,
+    } as unknown as Request<
+      unknown,
+      unknown,
+      Record<string, string | undefined>
+    >;
+    extractIp(request, {} as Response, () => {});
+
+    expect(request.body["ip"]).toBe(testIp);
+  });
+  test("should extract the client IP from X-Forwarded-For header with multiple proxies", () => {
+    const testIp = "192.168.0.1";
+    const request = {
+      body: {},
+      get: (_: string) => `${testIp},192.168.0.2,192.168.0.3`,
     } as Request as Request<
       unknown,
       unknown,

--- a/packages/api/src/middleware/extract_ip.ts
+++ b/packages/api/src/middleware/extract_ip.ts
@@ -1,10 +1,23 @@
 import type { Request, Response, NextFunction } from "express";
 
+const extractClientIpFromProxyList = (
+  list: string | undefined
+): string | undefined => {
+  if (typeof list !== "undefined") {
+    if (list.includes(",")) {
+      return list.split(",").shift()?.trim();
+    }
+  }
+  return list;
+};
+
 export const extractIp = (
   req: Request<unknown, unknown, Record<string, string | undefined>>,
   _: Response,
   next: NextFunction
 ): void => {
-  req.body["ip"] = req.get("x-forwarded-for") ?? req.connection.remoteAddress;
+  req.body["ip"] =
+    extractClientIpFromProxyList(req.get("X-Forwarded-For")) ??
+    req.connection.remoteAddress;
   next();
 };


### PR DESCRIPTION
The back-end will pass a list of proxies from the X-Forwarded-For header, [if needed](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Forwarded-For#syntax
). The `extractIp` middleware was not written to expect this format, and so would cause validation errors when passed a list of proxy IPs. Update this middleware function to handle a proxy IP list by extracting out the client IP from the list.

Resolves PER-9651: "Publish archive" does not get checked off in checklist