### PR TITLE
Update EKS clusters

### DIFF
--- a/terraform/prod_cluster/eks-cluster.tf
+++ b/terraform/prod_cluster/eks-cluster.tf
@@ -3,7 +3,7 @@ module "eks" {
   version = "19.0.4"
 
   cluster_name    = local.cluster_name
-  cluster_version = "1.26"
+  cluster_version = "1.30"
 
   vpc_id                         = var.vpc_id
   subnet_ids                     = var.subnet_ids

--- a/terraform/test_cluster/eks-cluster.tf
+++ b/terraform/test_cluster/eks-cluster.tf
@@ -3,7 +3,7 @@ module "eks" {
   version = "19.0.4"
 
   cluster_name    = local.cluster_name
-  cluster_version = "1.26"
+  cluster_version = "1.30"
 
   vpc_id                         = var.vpc_id
   subnet_ids                     = var.subnet_ids


### PR DESCRIPTION
Kubernetes v1.26 is already on extended support in EKS, which costs more. To avoid that extra cost, this commit updates the clusters to v1.30, the latest Kubernetes version.