### PR TITLE
Add SSL certificates for AWS RDS to deployed containers

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -20,7 +20,7 @@ jobs:
         env:
           AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Build Image
-        run: docker build -t $API_IMAGE_TAG -f Dockerfile.api .
+        run: docker build -t $API_IMAGE_TAG --build-arg AWS_RDS_CERT_BUNDLE=${{ secrets.AWS_RDS_CERT_BUNDLE }} -f Dockerfile.api .
       - name: AWS Login
         run: aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin 364159549467.dkr.ecr.$AWS_REGION.amazonaws.com
         env:

--- a/.github/workflows/prod_deploy.yml
+++ b/.github/workflows/prod_deploy.yml
@@ -19,7 +19,7 @@ jobs:
         env:
           AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Build Image
-        run: docker build -t $API_IMAGE_TAG -f Dockerfile.api .
+        run: docker build -t $API_IMAGE_TAG --build-arg AWS_RDS_CERT_BUNDLE=${{ secrets.AWS_RDS_CERT_BUNDLE }} -f Dockerfile.api .
       - name: AWS Login
         run: aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin 364159549467.dkr.ecr.$AWS_REGION.amazonaws.com
         env:

--- a/.github/workflows/staging_deploy.yml
+++ b/.github/workflows/staging_deploy.yml
@@ -17,7 +17,7 @@ jobs:
         env:
           AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Build Image
-        run: docker build -t $API_IMAGE_TAG -f Dockerfile.api .
+        run: docker build -t $API_IMAGE_TAG --build-arg AWS_RDS_CERT_BUNDLE=${{ secrets.AWS_RDS_CERT_BUNDLE }} -f Dockerfile.api .
       - name: AWS Login
         run: aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin 364159549467.dkr.ecr.$AWS_REGION.amazonaws.com
         env:

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,3 +1,5 @@
+ARG AWS_RDS_CERT_BUNDLE
+
 FROM node:18-alpine AS builder
 WORKDIR /usr/local/apps/stela/
 
@@ -15,6 +17,7 @@ RUN npm run build -ws
 FROM node:18-alpine AS final
 WORKDIR /usr/local/apps/stela/
 
+RUN echo $AWS_RDS_CERT_BUNDLE > /etc/ca-certificates/rds-us-west-2-ca-bundle.pem
 COPY --from=builder /usr/local/apps/stela/packages/api/dist ./packages/api/dist
 COPY --from=builder /usr/local/apps/stela/packages/api/package.json ./packages/api/package.json
 COPY --from=builder /usr/local/apps/stela/packages/logger/dist ./packages/logger/dist


### PR DESCRIPTION
Presently, we don't use SSL in our database connections. This is a security best practice, so we should. This commit adds the public key certificates for the us-west-2 RDS signing authorities to the deployed API containers, so they can be specified as trusted signing authorities when we connect to the database.