### PR TITLE
Fix syntax for docker build args

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -20,7 +20,7 @@ jobs:
         env:
           AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Build Image
-        run: docker build -t $API_IMAGE_TAG --build-arg AWS_RDS_CERT_BUNDLE=${{ secrets.AWS_RDS_CERT_BUNDLE }} -f Dockerfile.api .
+        run: docker build -t $API_IMAGE_TAG --build-arg="AWS_RDS_CERT_BUNDLE=${{ secrets.AWS_RDS_CERT_BUNDLE }}" -f Dockerfile.api .
       - name: AWS Login
         run: aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin 364159549467.dkr.ecr.$AWS_REGION.amazonaws.com
         env:

--- a/.github/workflows/prod_deploy.yml
+++ b/.github/workflows/prod_deploy.yml
@@ -19,7 +19,7 @@ jobs:
         env:
           AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Build Image
-        run: docker build -t $API_IMAGE_TAG --build-arg AWS_RDS_CERT_BUNDLE=${{ secrets.AWS_RDS_CERT_BUNDLE }} -f Dockerfile.api .
+        run: docker build -t $API_IMAGE_TAG --build-arg="AWS_RDS_CERT_BUNDLE=${{ secrets.AWS_RDS_CERT_BUNDLE }}" -f Dockerfile.api .
       - name: AWS Login
         run: aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin 364159549467.dkr.ecr.$AWS_REGION.amazonaws.com
         env:

--- a/.github/workflows/staging_deploy.yml
+++ b/.github/workflows/staging_deploy.yml
@@ -17,7 +17,7 @@ jobs:
         env:
           AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Build Image
-        run: docker build -t $API_IMAGE_TAG --build-arg AWS_RDS_CERT_BUNDLE=${{ secrets.AWS_RDS_CERT_BUNDLE }} -f Dockerfile.api .
+        run: docker build -t $API_IMAGE_TAG --build-arg="AWS_RDS_CERT_BUNDLE=${{ secrets.AWS_RDS_CERT_BUNDLE }}" -f Dockerfile.api .
       - name: AWS Login
         run: aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin 364159549467.dkr.ecr.$AWS_REGION.amazonaws.com
         env:

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -17,6 +17,7 @@ RUN npm run build -ws
 FROM node:18-alpine AS final
 WORKDIR /usr/local/apps/stela/
 
+RUN mkdir /etc/ca-certificates
 RUN echo $AWS_RDS_CERT_BUNDLE > /etc/ca-certificates/rds-us-west-2-ca-bundle.pem
 COPY --from=builder /usr/local/apps/stela/packages/api/dist ./packages/api/dist
 COPY --from=builder /usr/local/apps/stela/packages/api/package.json ./packages/api/package.json


### PR DESCRIPTION
Currently the some of the Github actions in this repo use the wrong syntax for passing a build arg to docker build; this commit corrects that.