### PR TITLE
Fix passing of SSL public keys into docker image

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -20,7 +20,9 @@ jobs:
         env:
           AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Build Image
-        run: docker build -t $API_IMAGE_TAG --build-arg="AWS_RDS_CERT_BUNDLE=${{ secrets.AWS_RDS_CERT_BUNDLE }}" -f Dockerfile.api .
+        run: docker build -t $API_IMAGE_TAG --build-arg="AWS_RDS_CERT_BUNDLE=$AWS_RDS_CERT_BUNDLE" -f Dockerfile.api .
+        env:
+          AWS_RDS_CERT_BUNDLE: ${{ secrets.AWS_RDS_CERT_BUNDLE }}
       - name: AWS Login
         run: aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin 364159549467.dkr.ecr.$AWS_REGION.amazonaws.com
         env:

--- a/.github/workflows/full_test_deploy.yml
+++ b/.github/workflows/full_test_deploy.yml
@@ -17,7 +17,9 @@ jobs:
         env:
           AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Build Image
-        run: docker build -t $API_IMAGE_TAG -f Dockerfile.api .
+        run: docker build -t $API_IMAGE_TAG --build-arg="AWS_RDS_CERT_BUNDLE=$AWS_RDS_CERT_BUNDLE" -f Dockerfile.api .
+        env:
+          AWS_RDS_CERT_BUNDLE: ${{ secrets.AWS_RDS_CERT_BUNDLE }}
       - name: AWS Login
         run: aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin 364159549467.dkr.ecr.$AWS_REGION.amazonaws.com
         env:

--- a/.github/workflows/prod_deploy.yml
+++ b/.github/workflows/prod_deploy.yml
@@ -19,7 +19,9 @@ jobs:
         env:
           AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Build Image
-        run: docker build -t $API_IMAGE_TAG --build-arg="AWS_RDS_CERT_BUNDLE=${{ secrets.AWS_RDS_CERT_BUNDLE }}" -f Dockerfile.api .
+        run: docker build -t $API_IMAGE_TAG --build-arg="AWS_RDS_CERT_BUNDLE=$AWS_RDS_CERT_BUNDLE" -f Dockerfile.api .
+        env:
+          AWS_RDS_CERT_BUNDLE: ${{ secrets.AWS_RDS_CERT_BUNDLE }}
       - name: AWS Login
         run: aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin 364159549467.dkr.ecr.$AWS_REGION.amazonaws.com
         env:

--- a/.github/workflows/staging_deploy.yml
+++ b/.github/workflows/staging_deploy.yml
@@ -17,7 +17,9 @@ jobs:
         env:
           AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Build Image
-        run: docker build -t $API_IMAGE_TAG --build-arg="AWS_RDS_CERT_BUNDLE=${{ secrets.AWS_RDS_CERT_BUNDLE }}" -f Dockerfile.api .
+        run: docker build -t $API_IMAGE_TAG --build-arg="AWS_RDS_CERT_BUNDLE=$AWS_RDS_CERT_BUNDLE" -f Dockerfile.api .
+        env:
+          AWS_RDS_CERT_BUNDLE: ${{ secrets.AWS_RDS_CERT_BUNDLE }}
       - name: AWS Login
         run: aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin 364159549467.dkr.ecr.$AWS_REGION.amazonaws.com
         env:

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -1,5 +1,3 @@
-ARG AWS_RDS_CERT_BUNDLE
-
 FROM node:18-alpine AS builder
 WORKDIR /usr/local/apps/stela/
 
@@ -15,10 +13,14 @@ RUN npm install -ws
 RUN npm run build -ws
 
 FROM node:18-alpine AS final
+
+ARG AWS_RDS_CERT_BUNDLE
+
 WORKDIR /usr/local/apps/stela/
 
 RUN mkdir /etc/ca-certificates
-RUN echo $AWS_RDS_CERT_BUNDLE > /etc/ca-certificates/rds-us-west-2-ca-bundle.pem
+RUN echo -e $AWS_RDS_CERT_BUNDLE > /etc/ca-certificates/rds-us-west-2-ca-bundle.pem
+
 COPY --from=builder /usr/local/apps/stela/packages/api/dist ./packages/api/dist
 COPY --from=builder /usr/local/apps/stela/packages/api/package.json ./packages/api/package.json
 COPY --from=builder /usr/local/apps/stela/packages/logger/dist ./packages/logger/dist


### PR DESCRIPTION
Currently, we try to pass the public SSL keys needed to connect to our databases to the stela API docker image via a build variable, but this build variable is defined too early in the file for it to be accessible to the deployment image. This commit moves it later so it becomes accessible to that image. It also adds the -e flag to the echo command when we write the keys to a file, so newlines are preserved.