### PR TITLE
Fix Sentry logging from Archivematica cleanup cron

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3273,9 +3273,9 @@
       }
     },
     "node_modules/@types/connect": {
-      "version": "3.4.33",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.33.tgz",
-      "integrity": "sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==",
+      "version": "3.4.36",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.36.tgz",
+      "integrity": "sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==",
       "dev": true,
       "dependencies": {
         "@types/node": "*"
@@ -5260,6 +5260,14 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw==",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-newline": {
@@ -10012,7 +10020,6 @@
       "version": "3.65.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.65.0.tgz",
       "integrity": "sha512-ThjYBfoDNr08AWx6hGaRbfPwxKV9kVzAzOzlLKbk2CuqXE2xnCh+cbAGnwM3t8Lq4v9rUB7VfondlkBckcJrVA==",
-      "optional": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -14008,6 +14015,7 @@
       "license": "AGPL-3.0",
       "dependencies": {
         "@sentry/node": "^7.57.0",
+        "@sentry/profiling-node": "^7.57.0",
         "@stela/logger": "^1.0.0",
         "dotenv": "^8.2.0",
         "node-fetch": "^2.6.9",
@@ -14015,6 +14023,22 @@
       },
       "engines": {
         "node": ">=18.0"
+      }
+    },
+    "packages/archivematica_cleanup/node_modules/@sentry/profiling-node": {
+      "version": "7.118.0",
+      "resolved": "https://registry.npmjs.org/@sentry/profiling-node/-/profiling-node-7.118.0.tgz",
+      "integrity": "sha512-CHxNwufyBJN44CrwFubYCj0g0h4CLQpx08mcny+b01TRgSdplJ0cMBChVLrQVsoL5i4nmifyyqpjuSRcvMMaiA==",
+      "hasInstallScript": true,
+      "dependencies": {
+        "detect-libc": "^2.0.2",
+        "node-abi": "^3.61.0"
+      },
+      "bin": {
+        "sentry-prune-profiler-binaries": "scripts/prune-profiler-binaries.js"
+      },
+      "engines": {
+        "node": ">=8.0.0"
       }
     },
     "packages/logger": {
@@ -16770,10 +16794,22 @@
       "version": "file:packages/archivematica_cleanup",
       "requires": {
         "@sentry/node": "^7.57.0",
+        "@sentry/profiling-node": "^7.57.0",
         "@stela/logger": "^1.0.0",
         "dotenv": "^8.2.0",
         "node-fetch": "^2.6.9",
         "require-env-variable": "^3.1.2"
+      },
+      "dependencies": {
+        "@sentry/profiling-node": {
+          "version": "7.118.0",
+          "resolved": "https://registry.npmjs.org/@sentry/profiling-node/-/profiling-node-7.118.0.tgz",
+          "integrity": "sha512-CHxNwufyBJN44CrwFubYCj0g0h4CLQpx08mcny+b01TRgSdplJ0cMBChVLrQVsoL5i4nmifyyqpjuSRcvMMaiA==",
+          "requires": {
+            "detect-libc": "^2.0.2",
+            "node-abi": "^3.61.0"
+          }
+        }
       }
     },
     "@stela/logger": {
@@ -16892,9 +16928,9 @@
       }
     },
     "@types/connect": {
-      "version": "3.4.33",
-      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.33.tgz",
-      "integrity": "sha512-2+FrkXY4zllzTNfJth7jOqEHC+enpLeGslEhpnTAkg21GkRrWV4SsAtqchtT4YS9/nODBU2/ZfsBY2X4J/dX7A==",
+      "version": "3.4.36",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.36.tgz",
+      "integrity": "sha512-P63Zd/JUGq+PdrM1lv0Wv5SBYeA2+CORvbrXbngriYY0jzLUWfQMQQxOhjONEz/wlHOAxOdY7CY65rgQdTjq2w==",
       "dev": true,
       "requires": {
         "@types/node": "*"
@@ -18422,6 +18458,11 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
       "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg=="
+    },
+    "detect-libc": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.3.tgz",
+      "integrity": "sha512-bwy0MGW55bG41VqxxypOsdSdGqLwXPI/focwgTYCFMbdUiBAxLg9CFzG08sz2aqzknwiX7Hkl0bQENjg8iLByw=="
     },
     "detect-newline": {
       "version": "3.1.0",
@@ -22045,7 +22086,6 @@
       "version": "3.65.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.65.0.tgz",
       "integrity": "sha512-ThjYBfoDNr08AWx6hGaRbfPwxKV9kVzAzOzlLKbk2CuqXE2xnCh+cbAGnwM3t8Lq4v9rUB7VfondlkBckcJrVA==",
-      "optional": true,
       "requires": {
         "semver": "^7.3.5"
       }

--- a/packages/archivematica_cleanup/package.json
+++ b/packages/archivematica_cleanup/package.json
@@ -27,6 +27,7 @@
   },
   "dependencies": {
     "@sentry/node": "^7.57.0",
+    "@sentry/profiling-node": "^7.57.0",
     "@stela/logger": "^1.0.0",
     "dotenv": "^8.2.0",
     "node-fetch": "^2.6.9",

--- a/packages/archivematica_cleanup/src/index.ts
+++ b/packages/archivematica_cleanup/src/index.ts
@@ -1,47 +1,44 @@
 import * as Sentry from "@sentry/node";
+import { nodeProfilingIntegration } from "@sentry/profiling-node";
 import { logger } from "@stela/logger";
 import "./env";
 
 const env = process.env["ENV"] ?? "";
 Sentry.init({
   dsn: process.env["SENTRY_DSN"] ?? "",
+  integrations: [nodeProfilingIntegration()],
   tracesSampleRate: 1.0,
+  profilesSampleRate: 1.0,
   environment: env === "local" ? `local-${process.env["DEV_NAME"] ?? ""}` : env,
 });
 
 export const cleanupDashboard = async (): Promise<void> => {
-  try {
-    const transferDeleteResponse = await fetch(
-      `${process.env["ARCHIVEMATICA_BASE_URL"] ?? ""}/api/transfer/delete`,
-      {
-        method: "DELETE",
-        headers: {
-          Authorization: `ApiKey ${process.env["ARCHIVEMATICA_API_KEY"] ?? ""}`,
-        },
-      }
-    );
-    if (!transferDeleteResponse.ok) {
-      logger.error(await transferDeleteResponse.text());
-      Sentry.captureMessage(await transferDeleteResponse.text());
-      return;
+  const transferDeleteResponse = await fetch(
+    `${process.env["ARCHIVEMATICA_BASE_URL"] ?? ""}/api/transfer/delete`,
+    {
+      method: "DELETE",
+      headers: {
+        Authorization: `ApiKey ${process.env["ARCHIVEMATICA_API_KEY"] ?? ""}`,
+      },
     }
-    const ingestDeleteResponse = await fetch(
-      `${process.env["ARCHIVEMATICA_BASE_URL"] ?? ""}/api/ingest/delete`,
-      {
-        method: "DELETE",
-        headers: {
-          Authorization: `ApiKey ${process.env["ARCHIVEMATICA_API_KEY"] ?? ""}`,
-        },
-      }
-    );
-    if (!ingestDeleteResponse.ok) {
-      logger.error(await ingestDeleteResponse.text());
-      Sentry.captureMessage(await ingestDeleteResponse.text());
-      return;
+  );
+  if (!transferDeleteResponse.ok) {
+    logger.error(await transferDeleteResponse.text());
+    Sentry.captureMessage(await transferDeleteResponse.text());
+    return;
+  }
+  const ingestDeleteResponse = await fetch(
+    `${process.env["ARCHIVEMATICA_BASE_URL"] ?? ""}/api/ingest/delete`,
+    {
+      method: "DELETE",
+      headers: {
+        Authorization: `ApiKey ${process.env["ARCHIVEMATICA_API_KEY"] ?? ""}`,
+      },
     }
-  } catch (error) {
-    logger.error(error);
-    Sentry.captureException(error);
+  );
+  if (!ingestDeleteResponse.ok) {
+    logger.error(await ingestDeleteResponse.text());
+    Sentry.captureMessage(await ingestDeleteResponse.text());
   }
 };
 
@@ -50,6 +47,7 @@ cleanupDashboard()
     process.exit(0);
   })
   .catch((error) => {
+    logger.error(error);
     Sentry.captureException(error);
     process.exit(1);
   });


### PR DESCRIPTION
The Archivematica cleanup cron is supposed to send error logs to Sentry, but it currently doesn't. This seems to be because we needed to include an extra Sentry package; this commit adds it.