### PR TITLE
Keep 3 failed cron pods for debugging

### DIFF
--- a/terraform/prod_cluster/am_cleanup_prod_cronjob.tf
+++ b/terraform/prod_cluster/am_cleanup_prod_cronjob.tf
@@ -7,15 +7,14 @@ resource "kubernetes_cron_job_v1" "archivematica_cleanup_prod" {
   }
   spec {
     concurrency_policy            = "Replace"
-    failed_jobs_history_limit     = 5
+    failed_jobs_history_limit     = 3
     schedule                      = "0 * * * *"
     starting_deadline_seconds     = 10
-    successful_jobs_history_limit = 10
+    successful_jobs_history_limit = 0
     job_template {
       metadata {}
       spec {
         backoff_limit              = 2
-        ttl_seconds_after_finished = 10
         template {
           metadata {}
           spec {

--- a/terraform/test_cluster/am_cleanup_dev_cronjob.tf
+++ b/terraform/test_cluster/am_cleanup_dev_cronjob.tf
@@ -7,15 +7,14 @@ resource "kubernetes_cron_job_v1" "archivematica_cleanup_dev" {
   }
   spec {
     concurrency_policy            = "Replace"
-    failed_jobs_history_limit     = 5
+    failed_jobs_history_limit     = 3
     schedule                      = "0 * * * *"
     starting_deadline_seconds     = 10
-    successful_jobs_history_limit = 10
+    successful_jobs_history_limit = 0
     job_template {
       metadata {}
       spec {
         backoff_limit              = 2
-        ttl_seconds_after_finished = 10
         template {
           metadata {}
           spec {

--- a/terraform/test_cluster/am_cleanup_staging_cronjob.tf
+++ b/terraform/test_cluster/am_cleanup_staging_cronjob.tf
@@ -7,15 +7,14 @@ resource "kubernetes_cron_job_v1" "archivematica_cleanup_staging" {
   }
   spec {
     concurrency_policy            = "Replace"
-    failed_jobs_history_limit     = 5
+    failed_jobs_history_limit     = 3
     schedule                      = "0 * * * *"
     starting_deadline_seconds     = 10
-    successful_jobs_history_limit = 10
+    successful_jobs_history_limit = 0
     job_template {
       metadata {}
       spec {
         backoff_limit              = 2
-        ttl_seconds_after_finished = 10
         template {
           metadata {}
           spec {


### PR DESCRIPTION
Currently, our cron pods are deleted 10 seconds after the job completes. This is good for conserving resources, but bad for debugging (particularly when one of the things in need of debugging is logs going to Sentry, as is presently the case). This commit improves the situation by removing the time-to-live for completed cron pods, but instructing kubernetes to keep up to 3 failed pods around so we can connect to them and see what happens, while discarding successful pods as soon as the job completes.