### PR TITLE
PER-9743: Add build stage to Dockerfile for local dev env

### DIFF
--- a/packages/api/Dockerfile.dev
+++ b/packages/api/Dockerfile.dev
@@ -12,9 +12,10 @@ COPY .env ./
 
 RUN npm install -g npm@9.5.0
 RUN npm cache clean --force
-RUN npm install
-RUN npm install --dev
-RUN npm install -ws
+RUN npm install \
+    && npm install --dev \
+    && npm install -ws
+RUN npm run build -ws
 ENV PATH=/usr/local/apps/stela/node_modules/.bin:$PATH
 
 EXPOSE 8080


### PR DESCRIPTION
Included `npm run build -ws` step because the running api package references files in the dist folders of the other packages.