### PR TITLE
Add infrastructure as code for record thumbnail lambda

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -9,16 +9,19 @@ jobs:
     uses: ./.github/workflows/test.yml
     secrets: inherit
 
+  generate_image_tags:
+    uses: ./.github/workflows/generate_image_tags.yml
+    secrets: inherit
+
   build_api:
     needs:
       - run_tests
+      - generate_image_tags
     runs-on: ubuntu-20.04
+    env:
+      API_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.API_IMAGE_TAG }}
     steps:
       - uses: actions/checkout@v3
-      - name: Generate Image Tag
-        run: echo "API_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:api-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
-        env:
-          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Build Image
         run: docker build -t $API_IMAGE_TAG --build-arg="AWS_RDS_CERT_BUNDLE=$AWS_RDS_CERT_BUNDLE" -f Dockerfile.api .
         env:
@@ -34,13 +37,12 @@ jobs:
   build_am_cleanup:
     needs:
       - run_tests
+      - generate_image_tags
     runs-on: ubuntu-20.04
+    env:
+      AM_CLEANUP_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.AM_CLEANUP_IMAGE_TAG }}
     steps:
       - uses: actions/checkout@v3
-      - name: Generate Image Tag
-        run: echo "AM_CLEANUP_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:am_cleanup-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
-        env:
-          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Build Image
         run: docker build -t $AM_CLEANUP_IMAGE_TAG -f Dockerfile.am_cleanup .
       - name: AWS Login
@@ -54,13 +56,12 @@ jobs:
   build_record_thumbnail_lambda:
     needs:
       - run_tests
+      - generate_image_tags
     runs-on: ubuntu-20.04
+    env:
+      RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG }}
     steps:
       - uses: actions/checkout@v3
-      - name: Generate Image Tag
-        run: echo "RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:record_thumbnail-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
-        env:
-          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Build Image
         run: docker build -t $RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG --build-arg="AWS_RDS_CERT_BUNDLE=$AWS_RDS_CERT_BUNDLE" -f Dockerfile.record_thumbnail_attacher .
         env:
@@ -78,7 +79,12 @@ jobs:
       - build_api
       - build_am_cleanup
       - build_record_thumbnail_lambda
+      - generate_image_tags
     runs-on: ubuntu-20.04
+    env:
+      API_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.API_IMAGE_TAG }}
+      AM_CLEANUP_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.AM_CLEANUP_IMAGE_TAG }}
+      RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG }}
     defaults:
       run:
         working-directory: ./terraform/test_cluster
@@ -88,18 +94,6 @@ jobs:
         uses: hashicorp/setup-terraform@v1
         with:
           cli_config_credentials_token: ${{ secrets.TERRAFORM_API_TOKEN }}
-      - name: Generate API Image Tag
-        run: echo "API_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:api-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
-        env:
-          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Generate Archivematica Cleanup Image Tag
-        run: echo "AM_CLEANUP_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:am_cleanup-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
-        env:
-          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Generate Record Thumbnail Image Tag
-        run: echo "RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:record_thumbnail-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
-        env:
-          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Terraform Init
         id: init
         run: terraform init

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -110,16 +110,64 @@ jobs:
       # the -target option restricts terraform to just updating the dev deployment
       - name: Terraform Plan for API
         id: plan_api
-        run: terraform plan -no-color -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -target=kubernetes_deployment.stela_dev
+        run: |
+          terraform plan -no-color -input=false \
+          -var="stela_dev_image=$API_IMAGE_TAG" \
+          -var="stela_staging_image=$API_IMAGE_TAG" \
+          -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -target=kubernetes_deployment.stela_dev
       - name: Terraform Apply for API
-        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -target=kubernetes_deployment.stela_dev
+        run: | 
+          terraform apply -auto-approve -input=false \
+          -var="stela_dev_image=$API_IMAGE_TAG" \
+          -var="stela_staging_image=$API_IMAGE_TAG" \
+          -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -target=kubernetes_deployment.stela_dev
       - name: Terraform Plan for Archivematica cleanup
         id: plan_am_cleanup
-        run: terraform plan -no-color -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -target=kubernetes_cron_job_v1.archivematica_cleanup_dev
+        run: |
+          terraform plan -no-color -input=false \
+          -var="stela_dev_image=$API_IMAGE_TAG" \
+          -var="stela_staging_image=$API_IMAGE_TAG" \
+          -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -target=kubernetes_cron_job_v1.archivematica_cleanup_dev
       - name: Terraform Apply for Archivematica cleanup
-        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -target=kubernetes_cron_job_v1.archivematica_cleanup_dev
+        run: |
+          terraform apply -auto-approve -input=false \
+          -var="stela_dev_image=$API_IMAGE_TAG" \
+          -var="stela_staging_image=$API_IMAGE_TAG" \
+          -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -target=kubernetes_cron_job_v1.archivematica_cleanup_dev
       - name: Terraform Plan for Record Thumbnail Lambda
         id: plan_record_thumbnail_lambda
-        run: terraform plan -no-color -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -target=aws_lambda_function.record_thumbnail_lambda
+        run: |
+          terraform plan -no-color -input=false \
+          -var="stela_dev_image=$API_IMAGE_TAG" \
+          -var="stela_staging_image=$API_IMAGE_TAG" \
+          -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -target=aws_lambda_function.record_thumbnail_lambda
       - name: Terraform Apply for Record Thumbnail Lambda
-        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -target=aws_lambda_function.record_thumbnail_lambda
+        run: |
+          terraform apply -auto-approve -input=false \
+          -var="stela_dev_image=$API_IMAGE_TAG" \
+          -var="stela_staging_image=$API_IMAGE_TAG" \
+          -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -target=aws_lambda_function.record_thumbnail_lambda

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -51,10 +51,33 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - name: Publish Image to ECR
         run: docker push $AM_CLEANUP_IMAGE_TAG
+  build_record_thumbnail_lambda:
+    needs:
+      - run_tests
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Generate Image Tag
+        run: echo "RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:record_thumbnail-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
+        env:
+          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Build Image
+        run: docker build -t $RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG --build-arg="AWS_RDS_CERT_BUNDLE=$AWS_RDS_CERT_BUNDLE" -f Dockerfile.record_thumbnail_attacher .
+        env:
+          AWS_RDS_CERT_BUNDLE: ${{ secrets.AWS_RDS_CERT_BUNDLE }}
+      - name: AWS Login
+        run: aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin 364159549467.dkr.ecr.$AWS_REGION.amazonaws.com
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: Publish Image to ECR
+        run: docker push $RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG
   deploy:
     needs:
       - build_api
       - build_am_cleanup
+      - build_record_thumbnail_lambda
     runs-on: ubuntu-20.04
     defaults:
       run:
@@ -73,6 +96,10 @@ jobs:
         run: echo "AM_CLEANUP_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:am_cleanup-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
         env:
           AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Generate Record Thumbnail Image Tag
+        run: echo "RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:record_thumbnail-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
+        env:
+          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Terraform Init
         id: init
         run: terraform init
@@ -83,11 +110,16 @@ jobs:
       # the -target option restricts terraform to just updating the dev deployment
       - name: Terraform Plan for API
         id: plan_api
-        run: terraform plan -no-color -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -target=kubernetes_deployment.stela_dev
+        run: terraform plan -no-color -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -target=kubernetes_deployment.stela_dev
       - name: Terraform Apply for API
-        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -target=kubernetes_deployment.stela_dev
+        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -target=kubernetes_deployment.stela_dev
       - name: Terraform Plan for Archivematica cleanup
         id: plan_am_cleanup
-        run: terraform plan -no-color -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -target=kubernetes_cron_job_v1.archivematica_cleanup_dev
+        run: terraform plan -no-color -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -target=kubernetes_cron_job_v1.archivematica_cleanup_dev
       - name: Terraform Apply for Archivematica cleanup
-        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -target=kubernetes_cron_job_v1.archivematica_cleanup_dev
+        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -target=kubernetes_cron_job_v1.archivematica_cleanup_dev
+      - name: Terraform Plan for Record Thumbnail Lambda
+        id: plan_record_thumbnail_lambda
+        run: terraform plan -no-color -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -target=aws_lambda_function.record_thumbnail_lambda
+      - name: Terraform Apply for Record Thumbnail Lambda
+        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -target=aws_lambda_function.record_thumbnail_lambda

--- a/.github/workflows/full_test_deploy.yml
+++ b/.github/workflows/full_test_deploy.yml
@@ -48,10 +48,33 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - name: Publish Image to ECR
         run: docker push $AM_CLEANUP_IMAGE_TAG
+  build_record_thumbnail_lambda:
+    needs:
+      - run_tests
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Generate Image Tag
+        run: echo "RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:record_thumbnail-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
+        env:
+          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Build Image
+        run: docker build -t $RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG --build-arg="AWS_RDS_CERT_BUNDLE=$AWS_RDS_CERT_BUNDLE" -f Dockerfile.record_thumbnail_attacher .
+        env:
+          AWS_RDS_CERT_BUNDLE: ${{ secrets.AWS_RDS_CERT_BUNDLE }}
+      - name: AWS Login
+        run: aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin 364159549467.dkr.ecr.$AWS_REGION.amazonaws.com
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: Publish Image to ECR
+        run: docker push $RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG
   deploy:
     needs:
       - build_api
       - build_am_cleanup
+      - build_record_thumbnail_lambda
     runs-on: ubuntu-20.04
     defaults:
       run:
@@ -70,6 +93,10 @@ jobs:
         run: echo "AM_CLEANUP_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:am_cleanup-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
         env:
           AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Generate Record Thumbnail Image Tag
+        run: echo "RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:record_thumbnail-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
+        env:
+          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Terraform Init
         id: init
         run: terraform init
@@ -78,6 +105,6 @@ jobs:
         run: terraform validate -no-color
       - name: Terraform Plan
         id: plan
-        run: terraform plan -no-color -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG"
+        run: terraform plan -no-color -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG"
       - name: Terraform Apply
-        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG"
+        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG"

--- a/.github/workflows/full_test_deploy.yml
+++ b/.github/workflows/full_test_deploy.yml
@@ -105,6 +105,20 @@ jobs:
         run: terraform validate -no-color
       - name: Terraform Plan
         id: plan
-        run: terraform plan -no-color -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG"
+        run: |
+          terraform plan -no-color -input=false \
+          -var="stela_dev_image=$API_IMAGE_TAG" \
+          -var="stela_staging_image=$API_IMAGE_TAG" \
+          -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG"
       - name: Terraform Apply
-        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG"
+        run: |
+          terraform apply -auto-approve -input=false \
+          -var="stela_dev_image=$API_IMAGE_TAG" \
+          -var="stela_staging_image=$API_IMAGE_TAG" \
+          -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG"

--- a/.github/workflows/full_test_deploy.yml
+++ b/.github/workflows/full_test_deploy.yml
@@ -6,16 +6,19 @@ jobs:
     uses: ./.github/workflows/test.yml
     secrets: inherit
 
+  generate_image_tags:
+    uses: ./.github/workflows/generate_image_tags.yml
+    secrets: inherit
+
   build_api:
     needs:
       - run_tests
+      - generate_image_tags
     runs-on: ubuntu-20.04
+    env:
+      API_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.API_IMAGE_TAG }}
     steps:
       - uses: actions/checkout@v3
-      - name: Generate Image Tag
-        run: echo "API_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:api-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
-        env:
-          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Build Image
         run: docker build -t $API_IMAGE_TAG --build-arg="AWS_RDS_CERT_BUNDLE=$AWS_RDS_CERT_BUNDLE" -f Dockerfile.api .
         env:
@@ -31,13 +34,12 @@ jobs:
   build_am_cleanup:
     needs:
       - run_tests
+      - generate_image_tags
     runs-on: ubuntu-20.04
+    env:
+      AM_CLEANUP_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.AM_CLEANUP_IMAGE_TAG }}
     steps:
       - uses: actions/checkout@v3
-      - name: Generate Image Tag
-        run: echo "AM_CLEANUP_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:am_cleanup-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
-        env:
-          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Build Image
         run: docker build -t $AM_CLEANUP_IMAGE_TAG -f Dockerfile.am_cleanup .
       - name: AWS Login
@@ -51,13 +53,12 @@ jobs:
   build_record_thumbnail_lambda:
     needs:
       - run_tests
+      - generate_image_tags
     runs-on: ubuntu-20.04
+    env:
+      RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG }}
     steps:
       - uses: actions/checkout@v3
-      - name: Generate Image Tag
-        run: echo "RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:record_thumbnail-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
-        env:
-          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Build Image
         run: docker build -t $RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG --build-arg="AWS_RDS_CERT_BUNDLE=$AWS_RDS_CERT_BUNDLE" -f Dockerfile.record_thumbnail_attacher .
         env:
@@ -75,7 +76,12 @@ jobs:
       - build_api
       - build_am_cleanup
       - build_record_thumbnail_lambda
+      - generate_image_tags
     runs-on: ubuntu-20.04
+    env:
+      API_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.API_IMAGE_TAG }}
+      AM_CLEANUP_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.AM_CLEANUP_IMAGE_TAG }}
+      RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG }}
     defaults:
       run:
         working-directory: ./terraform/test_cluster
@@ -85,18 +91,6 @@ jobs:
         uses: hashicorp/setup-terraform@v1
         with:
           cli_config_credentials_token: ${{ secrets.TERRAFORM_API_TOKEN }}
-      - name: Generate API Image Tag
-        run: echo "API_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:api-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
-        env:
-          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Generate Archivematica Cleanup Image Tag
-        run: echo "AM_CLEANUP_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:am_cleanup-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
-        env:
-          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Generate Record Thumbnail Image Tag
-        run: echo "RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:record_thumbnail-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
-        env:
-          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Terraform Init
         id: init
         run: terraform init

--- a/.github/workflows/generate_image_tags.yml
+++ b/.github/workflows/generate_image_tags.yml
@@ -17,18 +17,23 @@ jobs:
       RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG: ${{ steps.generate_record_thumbnail_lambda_image_tag.outputs.RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG }}
     steps:
       - uses: actions/checkout@v3
+      - name: Set ECR domain env var
+        id: set_ecr_domain
+        run: echo "ECR_DOMAIN=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com" >> "$GITHUB_ENV"
+        env:
+          AWS_REGION: ${{ vars.AWS_DEFAULT_REGION }}
+      - name: Set branch type env var
+        id: set_branch_type
+        run: echo "BRANCH_TYPE=$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)" >> "$GITHUB_ENV"
+      - name: Set abbreviated commit hash env var
+        id: set_abbreviated_commit_hash
+        run: echo "ABBREVIATED_COMMIT_HASH=$(git rev-parse --short $GITHUB_SHA)" >> "$GITHUB_ENV"
       - name: Generate API Image Tag
         id: generate_api_image_tag
-        run: echo "API_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:api-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> "$GITHUB_OUTPUT"
-        env:
-          AWS_REGION: ${{ vars.AWS_DEFAULT_REGION }}
+        run: echo "API_IMAGE_TAG=$ECR_DOMAIN/stela:api-$BRANCH_TYPE-$ABBREVIATED_COMMIT_HASH" >> "$GITHUB_OUTPUT"
       - name: Generate Archivematica Cleanup Image Tag
         id: generate_am_cleanup_image_tag
-        run: echo "AM_CLEANUP_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:am_cleanup-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> "$GITHUB_OUTPUT"
-        env:
-          AWS_REGION: ${{ vars.AWS_DEFAULT_REGION }}
+        run: echo "AM_CLEANUP_IMAGE_TAG=$ECR_DOMAIN/stela:am_cleanup-$BRANCH_TYPE-$ABBREVIATED_COMMIT_HASH" >> "$GITHUB_OUTPUT"
       - name: Generate Record Thumbnail Image Tag
         id: generate_record_thumbnail_lambda_image_tag
-        run: echo "RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:record_thumbnail-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> "$GITHUB_OUTPUT"
-        env:
-          AWS_REGION: ${{ vars.AWS_DEFAULT_REGION }}
+        run: echo "RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG=$ECR_DOMAIN/stela:record_thumbnail-$BRANCH_TYPE-$ABBREVIATED_COMMIT_HASH" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/generate_image_tags.yml
+++ b/.github/workflows/generate_image_tags.yml
@@ -21,14 +21,14 @@ jobs:
         id: generate_api_image_tag
         run: echo "API_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:api-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> "$GITHUB_OUTPUT"
         env:
-          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          AWS_REGION: ${{ vars.AWS_DEFAULT_REGION }}
       - name: Generate Archivematica Cleanup Image Tag
         id: generate_am_cleanup_image_tag
         run: echo "AM_CLEANUP_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:am_cleanup-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> "$GITHUB_OUTPUT"
         env:
-          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          AWS_REGION: ${{ vars.AWS_DEFAULT_REGION }}
       - name: Generate Record Thumbnail Image Tag
         id: generate_record_thumbnail_lambda_image_tag
         run: echo "RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:record_thumbnail-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> "$GITHUB_OUTPUT"
         env:
-          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          AWS_REGION: ${{ vars.AWS_DEFAULT_REGION }}

--- a/.github/workflows/generate_image_tags.yml
+++ b/.github/workflows/generate_image_tags.yml
@@ -1,0 +1,34 @@
+name: Generate Image Tags
+on:
+  workflow_call:
+    outputs:
+      API_IMAGE_TAG:
+        value: ${{ jobs.generate_image_tags.outputs.API_IMAGE_TAG }}
+      AM_CLEANUP_IMAGE_TAG:
+        value: ${{ jobs.generate_image_tags.outputs.AM_CLEANUP_IMAGE_TAG }}
+      RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG:
+        value: ${{ jobs.generate_image_tags.outputs.RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG }}
+jobs:
+  generate_image_tags:
+    runs-on: ubuntu-20.04
+    outputs:
+      API_IMAGE_TAG: ${{ steps.generate_api_image_tag.outputs.API_IMAGE_TAG }}
+      AM_CLEANUP_IMAGE_TAG: ${{ steps.generate_am_cleanup_image_tag.outputs.AM_CLEANUP_IMAGE_TAG }}
+      RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG: ${{ steps.generate_record_thumbnail_lambda_image_tag.outputs.RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG }}
+    steps:
+      - uses: actions/checkout@v3
+      - name: Generate API Image Tag
+        id: generate_api_image_tag
+        run: echo "API_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:api-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> "$GITHUB_OUTPUT"
+        env:
+          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Generate Archivematica Cleanup Image Tag
+        id: generate_am_cleanup_image_tag
+        run: echo "AM_CLEANUP_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:am_cleanup-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> "$GITHUB_OUTPUT"
+        env:
+          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Generate Record Thumbnail Image Tag
+        id: generate_record_thumbnail_lambda_image_tag
+        run: echo "RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:record_thumbnail-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> "$GITHUB_OUTPUT"
+        env:
+          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}

--- a/.github/workflows/prod_deploy.yml
+++ b/.github/workflows/prod_deploy.yml
@@ -50,10 +50,33 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - name: Publish Image to ECR
         run: docker push $AM_CLEANUP_IMAGE_TAG
+  build_record_thumbnail_lambda:
+    needs:
+      - run_tests
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Generate Image Tag
+        run: echo "RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:record_thumbnail-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
+        env:
+          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Build Image
+        run: docker build -t $RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG --build-arg="AWS_RDS_CERT_BUNDLE=$AWS_RDS_CERT_BUNDLE" -f Dockerfile.record_thumbnail_attacher .
+        env:
+          AWS_RDS_CERT_BUNDLE: ${{ secrets.AWS_RDS_CERT_BUNDLE }}
+      - name: AWS Login
+        run: aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin 364159549467.dkr.ecr.$AWS_REGION.amazonaws.com
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: Publish Image to ECR
+        run: docker push $RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG
   deploy_staging:
     needs:
       - build_api
       - build_am_cleanup
+      - build_record_thumbnail_lambda
     runs-on: ubuntu-20.04
     defaults:
       run:
@@ -72,6 +95,10 @@ jobs:
         run: echo "AM_CLEANUP_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:am_cleanup-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
         env:
           AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Generate Record Thumbnail Image Tag
+        run: echo "RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:record_thumbnail-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
+        env:
+          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Terraform Init
         id: init
         run: terraform init
@@ -82,14 +109,19 @@ jobs:
       # -target option restricts terraform to just updating the staging deployment
       - name: Terraform Plan for API
         id: plan_api
-        run: terraform plan -no-color -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -target=kubernetes_deployment.stela_staging
+        run: terraform plan -no-color -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -target=kubernetes_deployment.stela_staging
       - name: Terraform Apply for API
-        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -target=kubernetes_deployment.stela_staging
+        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -target=kubernetes_deployment.stela_staging
       - name: Terraform Plan for Archivematica cleanup
         id: plan_am_cleanup
-        run: terraform plan -no-color -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -target=kubernetes_cron_job.archivematica_cleanup_staging
+        run: terraform plan -no-color -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -target=kubernetes_cron_job_v1.archivematica_cleanup_staging
       - name: Terraform Apply for Archivematica cleanup
-        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -target=kubernetes_cron_job.archivematica_cleanup_staging
+        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -target=kubernetes_cron_job_v1.archivematica_cleanup_staging
+      - name: Terraform Plan for Record Thumbnail Lambda
+        id: plan_record_thumbnail_lambda
+        run: terraform plan -no-color -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -target=aws_lambda_function.record_thumbnail_lambda_staging
+      - name: Terraform Apply for Record Thumbnail Lambda
+        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -target=aws_lambda_function.record_thumbnail_lambda_staging
   deploy_prod:
     needs:
       - build_api
@@ -110,6 +142,10 @@ jobs:
         run: echo "API_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:api-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
         env:
           AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Generate Record Thumbnail Image Tag
+        run: echo "RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:record_thumbnail-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
+        env:
+          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Generate Archivematica Cleanup Image Tag
         run: echo "AM_CLEANUP_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:am_cleanup-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
         env:
@@ -122,6 +158,6 @@ jobs:
         run: terraform validate -no-color
       - name: Terraform Plan
         id: plan
-        run: terraform plan -no-color -input=false -var="stela_image=$API_IMAGE_TAG" -var "archivematica_cleanup_image=$AM_CLEANUP_IMAGE_TAG"
+        run: terraform plan -no-color -input=false -var="stela_image=$API_IMAGE_TAG" -var "archivematica_cleanup_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG"
       - name: Terraform Apply
-        run: terraform apply -auto-approve -input=false -var="stela_image=$API_IMAGE_TAG" -var "archivematica_cleanup_image=$AM_CLEANUP_IMAGE_TAG"
+        run: terraform apply -auto-approve -input=false -var="stela_image=$API_IMAGE_TAG" -var "archivematica_cleanup_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG"

--- a/.github/workflows/prod_deploy.yml
+++ b/.github/workflows/prod_deploy.yml
@@ -8,16 +8,19 @@ jobs:
     uses: ./.github/workflows/test.yml
     secrets: inherit
 
+  generate_image_tags:
+    uses: ./.github/workflows/generate_image_tags.yml
+    secrets: inherit
+
   build_api:
     needs:
       - run_tests
+      - generate_image_tags
     runs-on: ubuntu-20.04
+    env:
+      API_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.API_IMAGE_TAG }}
     steps:
       - uses: actions/checkout@v3
-      - name: Generate Image Tag
-        run: echo "API_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:api-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
-        env:
-          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Build Image
         run: docker build -t $API_IMAGE_TAG --build-arg="AWS_RDS_CERT_BUNDLE=$AWS_RDS_CERT_BUNDLE" -f Dockerfile.api .
         env:
@@ -33,13 +36,12 @@ jobs:
   build_am_cleanup:
     needs:
       - run_tests
+      - generate_image_tags
     runs-on: ubuntu-20.04
+    env:
+      AM_CLEANUP_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.AM_CLEANUP_IMAGE_TAG }}
     steps:
       - uses: actions/checkout@v3
-      - name: Generate Image Tag
-        run: echo "AM_CLEANUP_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:am_cleanup-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
-        env:
-          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Build Image
         run: docker build -t $AM_CLEANUP_IMAGE_TAG -f Dockerfile.am_cleanup .
       - name: AWS Login
@@ -53,13 +55,12 @@ jobs:
   build_record_thumbnail_lambda:
     needs:
       - run_tests
+      - generate_image_tags
     runs-on: ubuntu-20.04
+    env:
+      RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG }}
     steps:
       - uses: actions/checkout@v3
-      - name: Generate Image Tag
-        run: echo "RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:record_thumbnail-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
-        env:
-          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Build Image
         run: docker build -t $RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG --build-arg="AWS_RDS_CERT_BUNDLE=$AWS_RDS_CERT_BUNDLE" -f Dockerfile.record_thumbnail_attacher .
         env:
@@ -77,7 +78,12 @@ jobs:
       - build_api
       - build_am_cleanup
       - build_record_thumbnail_lambda
+      - generate_image_tags
     runs-on: ubuntu-20.04
+    env:
+      API_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.API_IMAGE_TAG }}
+      AM_CLEANUP_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.AM_CLEANUP_IMAGE_TAG }}
+      RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG }}
     defaults:
       run:
         working-directory: ./terraform/test_cluster
@@ -87,18 +93,6 @@ jobs:
         uses: hashicorp/setup-terraform@v1
         with:
           cli_config_credentials_token: ${{ secrets.TERRAFORM_API_TOKEN }}
-      - name: Generate API Image Tag
-        run: echo "API_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:api-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
-        env:
-          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Generate Archivematica Cleanup Image Tag
-        run: echo "AM_CLEANUP_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:am_cleanup-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
-        env:
-          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Generate Record Thumbnail Image Tag
-        run: echo "RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:record_thumbnail-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
-        env:
-          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Terraform Init
         id: init
         run: terraform init

--- a/.github/workflows/prod_deploy.yml
+++ b/.github/workflows/prod_deploy.yml
@@ -109,19 +109,67 @@ jobs:
       # -target option restricts terraform to just updating the staging deployment
       - name: Terraform Plan for API
         id: plan_api
-        run: terraform plan -no-color -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -target=kubernetes_deployment.stela_staging
+        run: |
+          terraform plan -no-color -input=false \
+          -var="stela_dev_image=$API_IMAGE_TAG" \
+          -var="stela_staging_image=$API_IMAGE_TAG" \
+          -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -target=kubernetes_deployment.stela_staging
       - name: Terraform Apply for API
-        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -target=kubernetes_deployment.stela_staging
+        run: |
+          terraform apply -auto-approve -input=false \
+          -var="stela_dev_image=$API_IMAGE_TAG" \
+          -var="stela_staging_image=$API_IMAGE_TAG" \
+          -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -target=kubernetes_deployment.stela_staging
       - name: Terraform Plan for Archivematica cleanup
         id: plan_am_cleanup
-        run: terraform plan -no-color -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -target=kubernetes_cron_job_v1.archivematica_cleanup_staging
+        run: |
+          terraform plan -no-color -input=false \
+          -var="stela_dev_image=$API_IMAGE_TAG" \
+          -var="stela_staging_image=$API_IMAGE_TAG" \
+          -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -target=kubernetes_cron_job_v1.archivematica_cleanup_staging
       - name: Terraform Apply for Archivematica cleanup
-        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -target=kubernetes_cron_job_v1.archivematica_cleanup_staging
+        run: |
+          terraform apply -auto-approve -input=false \
+          -var="stela_dev_image=$API_IMAGE_TAG" \
+          -var="stela_staging_image=$API_IMAGE_TAG" \
+          -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -target=kubernetes_cron_job_v1.archivematica_cleanup_staging
       - name: Terraform Plan for Record Thumbnail Lambda
         id: plan_record_thumbnail_lambda
-        run: terraform plan -no-color -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -target=aws_lambda_function.record_thumbnail_lambda_staging
+        run: |
+          terraform plan -no-color -input=false \
+          -var="stela_dev_image=$API_IMAGE_TAG" \
+          -var="stela_staging_image=$API_IMAGE_TAG" \
+          -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -target=aws_lambda_function.record_thumbnail_lambda_staging
       - name: Terraform Apply for Record Thumbnail Lambda
-        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -target=aws_lambda_function.record_thumbnail_lambda_staging
+        run: |
+          terraform apply -auto-approve -input=false \
+          -var="stela_dev_image=$API_IMAGE_TAG" \
+          -var="stela_staging_image=$API_IMAGE_TAG" \
+          -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -target=aws_lambda_function.record_thumbnail_lambda_staging
   deploy_prod:
     needs:
       - build_api
@@ -158,6 +206,14 @@ jobs:
         run: terraform validate -no-color
       - name: Terraform Plan
         id: plan
-        run: terraform plan -no-color -input=false -var="stela_image=$API_IMAGE_TAG" -var "archivematica_cleanup_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG"
+        run: |
+          terraform plan -no-color -input=false \
+          -var="stela_image=$API_IMAGE_TAG" \
+          -var="archivematica_cleanup_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="record_thumbnail_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG"
       - name: Terraform Apply
-        run: terraform apply -auto-approve -input=false -var="stela_image=$API_IMAGE_TAG" -var "archivematica_cleanup_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG"
+        run: |
+          terraform apply -auto-approve -input=false \
+          -var="stela_image=$API_IMAGE_TAG" \
+          -var="archivematica_cleanup_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="record_thumbnail_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG"

--- a/.github/workflows/staging_deploy.yml
+++ b/.github/workflows/staging_deploy.yml
@@ -107,16 +107,64 @@ jobs:
       # -target option restricts terraform to just updating the staging deployment
       - name: Terraform Plan for API
         id: plan_api
-        run: terraform plan -no-color -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -target=kubernetes_deployment.stela_staging
+        run: |
+          terraform plan -no-color -input=false \
+          -var="stela_dev_image=$API_IMAGE_TAG" \
+          -var="stela_staging_image=$API_IMAGE_TAG" \
+          -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -target=kubernetes_deployment.stela_staging
       - name: Terraform Apply for API
-        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -target=kubernetes_deployment.stela_staging
+        run: |
+          terraform apply -auto-approve -input=false \
+          -var="stela_dev_image=$API_IMAGE_TAG" \
+          -var="stela_staging_image=$API_IMAGE_TAG" \
+          -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -target=kubernetes_deployment.stela_staging
       - name: Terraform Plan for Archivematica cleanup
         id: plan_am_cleanup
-        run: terraform plan -no-color -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -target=kubernetes_cron_job_v1.archivematica_cleanup_staging
+        run: |
+          terraform plan -no-color -input=false \
+          -var="stela_dev_image=$API_IMAGE_TAG" \
+          -var="stela_staging_image=$API_IMAGE_TAG" \
+          -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -target=kubernetes_cron_job_v1.archivematica_cleanup_staging
       - name: Terraform Apply for Archivematica cleanup
-        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -target=kubernetes_cron_job_v1.archivematica_cleanup_staging
+        run: |
+          terraform apply -auto-approve -input=false \
+          -var="stela_dev_image=$API_IMAGE_TAG" \
+          -var="stela_staging_image=$API_IMAGE_TAG" \
+          -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -target=kubernetes_cron_job_v1.archivematica_cleanup_staging
       - name: Terraform Plan for Record Thumbnail Lambda
         id: plan_record_thumbnail_lambda
-        run: terraform plan -no-color -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -target=aws_lambda_function.record_thumbnail_lambda_staging
+        run: |
+          terraform plan -no-color -input=false \
+          -var="stela_dev_image=$API_IMAGE_TAG" \
+          -var="stela_staging_image=$API_IMAGE_TAG" \
+          -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -target=aws_lambda_function.record_thumbnail_lambda_staging
       - name: Terraform Apply for Record Thumbnail Lambda
-        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -target=aws_lambda_function.record_thumbnail_lambda_staging
+        run: |
+          terraform apply -auto-approve -input=false \
+          -var="stela_dev_image=$API_IMAGE_TAG" \
+          -var="stela_staging_image=$API_IMAGE_TAG" \
+          -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" \
+          -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
+          -target=aws_lambda_function.record_thumbnail_lambda_staging

--- a/.github/workflows/staging_deploy.yml
+++ b/.github/workflows/staging_deploy.yml
@@ -48,10 +48,33 @@ jobs:
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - name: Publish Image to ECR
         run: docker push $AM_CLEANUP_IMAGE_TAG
+  build_record_thumbnail_lambda:
+    needs:
+      - run_tests
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v3
+      - name: Generate Image Tag
+        run: echo "RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:record_thumbnail-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
+        env:
+          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Build Image
+        run: docker build -t $RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG --build-arg="AWS_RDS_CERT_BUNDLE=$AWS_RDS_CERT_BUNDLE" -f Dockerfile.record_thumbnail_attacher .
+        env:
+          AWS_RDS_CERT_BUNDLE: ${{ secrets.AWS_RDS_CERT_BUNDLE }}
+      - name: AWS Login
+        run: aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin 364159549467.dkr.ecr.$AWS_REGION.amazonaws.com
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: Publish Image to ECR
+        run: docker push $RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG
   deploy:
     needs:
       - build_api
       - build_am_cleanup
+      - build_record_thumbnail_lambda
     runs-on: ubuntu-20.04
     defaults:
       run:
@@ -70,6 +93,10 @@ jobs:
         run: echo "AM_CLEANUP_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:am_cleanup-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
         env:
           AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
+      - name: Generate Record Thumbnail Image Tag
+        run: echo "RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:record_thumbnail-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
+        env:
+          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Terraform Init
         id: init
         run: terraform init
@@ -80,11 +107,16 @@ jobs:
       # -target option restricts terraform to just updating the staging deployment
       - name: Terraform Plan for API
         id: plan_api
-        run: terraform plan -no-color -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -target=kubernetes_deployment.stela_staging
+        run: terraform plan -no-color -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -target=kubernetes_deployment.stela_staging
       - name: Terraform Apply for API
-        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -target=kubernetes_deployment.stela_staging
+        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -target=kubernetes_deployment.stela_staging
       - name: Terraform Plan for Archivematica cleanup
         id: plan_am_cleanup
-        run: terraform plan -no-color -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -target=kubernetes_cron_job_v1.archivematica_cleanup_staging
+        run: terraform plan -no-color -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -target=kubernetes_cron_job_v1.archivematica_cleanup_staging
       - name: Terraform Apply for Archivematica cleanup
-        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -target=kubernetes_cron_job_v1.archivematica_cleanup_staging
+        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -target=kubernetes_cron_job_v1.archivematica_cleanup_staging
+      - name: Terraform Plan for Record Thumbnail Lambda
+        id: plan_record_thumbnail_lambda
+        run: terraform plan -no-color -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -target=aws_lambda_function.record_thumbnail_lambda_staging
+      - name: Terraform Apply for Record Thumbnail Lambda
+        run: terraform apply -auto-approve -input=false -var="stela_dev_image=$API_IMAGE_TAG" -var="stela_staging_image=$API_IMAGE_TAG" -var="archivematica_cleanup_dev_image=$AM_CLEANUP_IMAGE_TAG" -var="archivematica_cleanup_staging_image=$AM_CLEANUP_IMAGE_TAG" -var="record_thumbnail_dev_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -var="record_thumbnail_staging_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" -target=aws_lambda_function.record_thumbnail_lambda_staging

--- a/.github/workflows/staging_deploy.yml
+++ b/.github/workflows/staging_deploy.yml
@@ -6,16 +6,19 @@ jobs:
     uses: ./.github/workflows/test.yml
     secrets: inherit
 
+  generate_image_tags:
+    uses: ./.github/workflows/generate_image_tags.yml
+    secrets: inherit
+
   build_api:
     needs:
       - run_tests
+      - generate_image_tags
     runs-on: ubuntu-20.04
+    env:
+      API_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.API_IMAGE_TAG }}
     steps:
       - uses: actions/checkout@v3
-      - name: Generate Image Tag
-        run: echo "API_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:api-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
-        env:
-          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Build Image
         run: docker build -t $API_IMAGE_TAG --build-arg="AWS_RDS_CERT_BUNDLE=$AWS_RDS_CERT_BUNDLE" -f Dockerfile.api .
         env:
@@ -31,13 +34,12 @@ jobs:
   build_am_cleanup:
     needs:
       - run_tests
+      - generate_image_tags
     runs-on: ubuntu-20.04
+    env:
+      AM_CLEANUP_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.AM_CLEANUP_IMAGE_TAG }}
     steps:
       - uses: actions/checkout@v3
-      - name: Generate Image Tag
-        run: echo "AM_CLEANUP_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:am_cleanup-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
-        env:
-          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Build Image
         run: docker build -t $AM_CLEANUP_IMAGE_TAG -f Dockerfile.am_cleanup .
       - name: AWS Login
@@ -51,13 +53,12 @@ jobs:
   build_record_thumbnail_lambda:
     needs:
       - run_tests
+      - generate_image_tags
     runs-on: ubuntu-20.04
+    env:
+      RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG }}
     steps:
       - uses: actions/checkout@v3
-      - name: Generate Image Tag
-        run: echo "RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:record_thumbnail-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
-        env:
-          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Build Image
         run: docker build -t $RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG --build-arg="AWS_RDS_CERT_BUNDLE=$AWS_RDS_CERT_BUNDLE" -f Dockerfile.record_thumbnail_attacher .
         env:
@@ -75,7 +76,13 @@ jobs:
       - build_api
       - build_am_cleanup
       - build_record_thumbnail_lambda
+      - generate_image_tags
     runs-on: ubuntu-20.04
+    env:
+      API_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.API_IMAGE_TAG }}
+      AM_CLEANUP_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.AM_CLEANUP_IMAGE_TAG }}
+      RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG }}
+
     defaults:
       run:
         working-directory: ./terraform/test_cluster
@@ -85,18 +92,6 @@ jobs:
         uses: hashicorp/setup-terraform@v1
         with:
           cli_config_credentials_token: ${{ secrets.TERRAFORM_API_TOKEN }}
-      - name: Generate API Image Tag
-        run: echo "API_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:api-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
-        env:
-          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Generate Archivematica Cleanup Image Tag
-        run: echo "AM_CLEANUP_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:am_cleanup-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
-        env:
-          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
-      - name: Generate Record Thumbnail Image Tag
-        run: echo "RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG=364159549467.dkr.ecr.$AWS_REGION.amazonaws.com/stela:record_thumbnail-$([[ ${GITHUB_REF##*/} = main ]] && echo main || echo feature)-$(git rev-parse --short $GITHUB_SHA)" >> $GITHUB_ENV
-        env:
-          AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
       - name: Terraform Init
         id: init
         run: terraform init

--- a/Dockerfile.record_thumbnail_attacher
+++ b/Dockerfile.record_thumbnail_attacher
@@ -14,7 +14,13 @@ RUN npm run build -ws
 
 
 FROM public.ecr.aws/lambda/nodejs:18 as final
+
+ARG AWS_RDS_CERT_BUNDLE
+
 WORKDIR ${LAMBDA_TASK_ROOT}
+
+RUN mkdir /etc/ca-certificates
+RUN echo -e $AWS_RDS_CERT_BUNDLE > /etc/ca-certificates/rds-us-west-2-ca-bundle.pem
 
 COPY --from=builder /usr/local/apps/stela/packages/record_thumbnail_attacher/dist ./packages/record_thumbnail_attacher/dist
 COPY --from=builder /usr/local/apps/stela/packages/record_thumbnail_attacher/package.json ./packages/record_thumbnail_attacher/package.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -10583,8 +10583,9 @@
       }
     },
     "node_modules/pg-connection-string": {
-      "version": "2.4.0",
-      "license": "MIT"
+      "version": "2.6.4",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.4.tgz",
+      "integrity": "sha512-v+Z7W/0EO707aNMaAEfiGnGL9sxxumwLl2fJvCQtMn9Fxsg+lPpPkdcyBSv/KFgpGdYkMfn+EI1Or2EHjpgLCA=="
     },
     "node_modules/pg-format": {
       "version": "1.0.4",
@@ -13715,7 +13716,7 @@
         "mixpanel": "^0.18.0",
         "newrelic": "^11.22.0",
         "node-fetch": "^2.6.9",
-        "pg": "^8.5.1",
+        "pg": "8.5.1",
         "require-env-variable": "^3.1.2",
         "tinypg": "^7.0.0",
         "ts-md5": "^1.3.1",
@@ -13785,6 +13786,7 @@
         "ajv": "^8.17.1",
         "aws-cloudfront-sign": "^3.0.2",
         "dotenv": "^8.2.0",
+        "pg-connection-string": "^2.6.4",
         "require-env-variable": "^3.1.2",
         "tinypg": "^7.0.0"
       },

--- a/packages/record_thumbnail_attacher/src/index.test.ts
+++ b/packages/record_thumbnail_attacher/src/index.test.ts
@@ -48,11 +48,17 @@ describe("handler", () => {
           messageId: "1",
           receiptHandle: "1",
           body: JSON.stringify({
-            s3: {
-              object: {
-                key: "_Liam/access_copies/e38e/8582/b417/430c/953d/5c7e/8040/1ae2/2_upload-cb45fa84-f0ea-4a9e-b1da-309e485a4f4a/object/710a1def-caf8-48f2-8eee-0848b4cfda10.jpg",
-              },
-            },
+            Message: JSON.stringify({
+              Records: [
+                {
+                  s3: {
+                    object: {
+                      key: "_Liam/access_copies/b38e/8582/b417/430c/953d/5c7e/8040/1ae2/2_upload-cb45fa84-f0ea-4a9e-b1da-309e485a4f4a/object/710a1def-caf8-48f2-8eee-0848b4cfda10.jpg",
+                    },
+                  },
+                },
+              ],
+            }),
           }),
           attributes: {
             ApproximateReceiveCount: "1",
@@ -122,7 +128,19 @@ describe("handler", () => {
         {
           messageId: "1",
           receiptHandle: "1",
-          body: JSON.stringify({ s3: { object: { key: "1" } } }),
+          body: JSON.stringify({
+            Message: JSON.stringify({
+              Records: [
+                {
+                  s3: {
+                    object: {
+                      key: "_Liam/access_copies/e38e/8582/b417/430c/953d/5c7e/8040/1ae2/2_upload-cb45fa84-f0ea-4a9e-b1da-309e485a4f4a/object/710a1def-caf8-48f2-8eee-0848b4cfda10.jpg",
+                    },
+                  },
+                },
+              ],
+            }),
+          }),
           attributes: {
             ApproximateReceiveCount: "1",
             SentTimestamp: "1",
@@ -169,11 +187,17 @@ describe("handler", () => {
           messageId: "1",
           receiptHandle: "1",
           body: JSON.stringify({
-            s3: {
-              object: {
-                key: "_Liam/access_copies/e38e/8582/b417/430c/953d/5c7e/8040/1ae2/2_load-cb45fa84-f0ea-4a9e-b1da-309e485a4f4a/thumbnails/710a1def-caf8-48f2-8eee-0848b4cfda10.jpg",
-              },
-            },
+            Message: JSON.stringify({
+              Records: [
+                {
+                  s3: {
+                    object: {
+                      key: "_Liam/access_copies/e38e/8582/b417/430c/953d/5c7e/8040/1ae2/thumbnails/2_load-cb45fa84-f0ea-4a9e-b1da-309e485a4f4a/object/710a1def-caf8-48f2-8eee-0848b4cfda10.jpg",
+                    },
+                  },
+                },
+              ],
+            }),
           }),
           attributes: {
             ApproximateReceiveCount: "1",
@@ -212,11 +236,17 @@ describe("handler", () => {
           messageId: "1",
           receiptHandle: "1",
           body: JSON.stringify({
-            s3: {
-              object: {
-                key: testKey,
-              },
-            },
+            Message: JSON.stringify({
+              Records: [
+                {
+                  s3: {
+                    object: {
+                      key: testKey,
+                    },
+                  },
+                },
+              ],
+            }),
           }),
           attributes: {
             ApproximateReceiveCount: "1",
@@ -303,11 +333,17 @@ describe("handler", () => {
           messageId: "1",
           receiptHandle: "1",
           body: JSON.stringify({
-            s3: {
-              object: {
-                key: testKey,
-              },
-            },
+            Message: JSON.stringify({
+              Records: [
+                {
+                  s3: {
+                    object: {
+                      key: testKey,
+                    },
+                  },
+                },
+              ],
+            }),
           }),
           attributes: {
             ApproximateReceiveCount: "1",
@@ -365,11 +401,17 @@ describe("handler", () => {
           messageId: "1",
           receiptHandle: "1",
           body: JSON.stringify({
-            s3: {
-              object: {
-                key: testKey,
-              },
-            },
+            Message: JSON.stringify({
+              Records: [
+                {
+                  s3: {
+                    object: {
+                      key: testKey,
+                    },
+                  },
+                },
+              ],
+            }),
           }),
           attributes: {
             ApproximateReceiveCount: "1",

--- a/packages/record_thumbnail_attacher/src/validators.ts
+++ b/packages/record_thumbnail_attacher/src/validators.ts
@@ -3,35 +3,61 @@ import type { JSONSchemaType } from "ajv";
 
 const ajv = new Ajv({ coerceTypes: true });
 
-interface NewDisseminationPackageJpgEvent {
-  s3: {
-    object: {
-      key: string;
-    };
-  };
+interface SQSMessage {
+  Message: string;
 }
 
+const sqsMessageSchema: JSONSchemaType<SQSMessage> = {
+  type: "object",
+  properties: {
+    Message: { type: "string" },
+  },
+  required: ["Message"],
+  additionalProperties: true,
+};
+
+export const validateSqsMessage = ajv.compile(sqsMessageSchema);
+
+interface NewDisseminationPackageJpgEvent {
+  Records: {
+    s3: {
+      object: {
+        key: string;
+      };
+    };
+  }[];
+}
 const newDisseminationPackageJpgEventSchema: JSONSchemaType<NewDisseminationPackageJpgEvent> =
   {
     type: "object",
     properties: {
-      s3: {
-        type: "object",
-        properties: {
-          object: {
-            type: "object",
-            properties: {
-              key: { type: "string" },
+      Records: {
+        type: "array",
+        items: {
+          type: "object",
+          properties: {
+            s3: {
+              type: "object",
+              properties: {
+                object: {
+                  type: "object",
+                  properties: {
+                    key: { type: "string" },
+                  },
+                  required: ["key"],
+                  additionalProperties: true,
+                },
+              },
+              required: ["object"],
+              additionalProperties: true,
             },
-            required: ["key"],
-            additionalProperties: true,
           },
+          required: ["s3"],
+          additionalProperties: true,
         },
-        required: ["object"],
-        additionalProperties: true,
       },
     },
-    required: ["s3"],
+    required: ["Records"],
     additionalProperties: true,
   };
 

--- a/terraform/prod_cluster/record_thumbnail_lambda.tf
+++ b/terraform/prod_cluster/record_thumbnail_lambda.tf
@@ -1,0 +1,139 @@
+resource "aws_sns_topic" "record_thumbnail_topic" {
+  name = "record-thumbnail-topic"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Service = "s3.amazonaws.com"
+        },
+        Action = "sns:Publish",
+        Resource = "*",
+        Condition = {
+          StringEquals = {
+            "AWS:SourceAccount" = var.aws_account_id
+          }
+          ArnLike = {
+            "AWS:SourceArn" = "arn:aws:s3:*:*:permanent-prod"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_sqs_queue" "record_thumbnail_deadletter_queue" {
+  name = "record-thumbnail-deadletter-queue"
+}
+
+resource "aws_sqs_queue" "record_thumbnail_queue" {
+  name = "record-thumbnail-queue"
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.record_thumbnail_deadletter_queue.arn
+    maxReceiveCount     = 3
+  })
+}
+
+resource "aws_sqs_queue_policy" "record_thumbnail_queue_policy" {
+  queue_url = aws_sqs_queue.record_thumbnail_queue.id
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect    = "Allow",
+        Principal = {
+          Service = "sns.amazonaws.com"
+        },
+        Action    = "sqs:SendMessage",
+        Resource  = aws_sqs_queue.record_thumbnail_queue.arn,
+        Condition = {
+          ArnEquals = {
+            "aws:SourceArn" = aws_sns_topic.record_thumbnail_topic.arn
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_sns_topic_subscription" "record_thumbnail_subscription" {
+  topic_arn = aws_sns_topic.record_thumbnail_topic.arn
+  protocol  = "sqs"
+  endpoint  = aws_sqs_queue.record_thumbnail_queue.arn
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "record_thumbnail_lambda_role" {
+  name               = "record-thumbnail-lambda-role"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
+
+resource "aws_iam_role_policy" "record_thumbnail_lambda_policy" {
+  name = "record-thumbnail-lambda-policy"
+  role = aws_iam_role.record_thumbnail_lambda_role.name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "ec2:CreateNetworkInterface",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DeleteNetworkInterface",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeSubnets",
+          "sqs:ReceiveMessage",
+          "sqs:DeleteMessage",
+          "sqs:GetQueueAttributes",
+        ]
+        Effect   = "Allow"
+        Resource = ["*", aws_sqs_queue.record_thumbnail_queue.arn]
+      },
+    ]
+  })
+}
+
+resource "aws_lambda_function" "record_thumbnail_lambda" {
+  package_type  = "Image"
+  image_uri     = var.record_thumbnail_lambda_image
+  function_name = "record-thumbnail-lambda"
+  role          = aws_iam_role.record_thumbnail_lambda_role.arn
+  timeout       = 30
+
+  vpc_config {
+    security_group_ids = [var.prod_security_group_id]
+    subnet_ids         = var.subnet_ids
+  }
+
+  environment {
+    variables = {
+      ENV                    = var.prod_env
+      SENTRY_DSN             = var.sentry_dsn
+      DATABASE_URL           = var.prod_database_url
+      CLOUDFRONT_URL         = var.prod_cloudfront_url
+      CLOUDFRONT_KEY_PAIR_ID = var.cloudfront_key_pair_id
+      CLOUDFRONT_PRIVATE_KEY = var.cloudfront_private_key
+    }
+  }
+}
+
+resource "aws_lambda_event_source_mapping" "record_thumbnail_event_source_mapping" {
+  event_source_arn                   = aws_sqs_queue.record_thumbnail_queue.arn
+  function_name                      = aws_lambda_function.record_thumbnail_lambda.arn
+  batch_size                         = 10
+  maximum_batching_window_in_seconds = 0
+}

--- a/terraform/prod_cluster/variables.tf
+++ b/terraform/prod_cluster/variables.tf
@@ -37,6 +37,11 @@ variable "archivematica_cleanup_image" {
   type        = string
 }
 
+variable "record_thumbnail_lambda_image" {
+  description = "Tag of record thumbnail lambda image to deploy"
+  type        = string
+}
+
 variable "prod_security_group_id" {
   description = "ID of the Production security group"
   type        = string
@@ -155,4 +160,24 @@ variable "new_relic_app_name" {
   description = "New Relic app name for the dev environment"
   type        = string
   default     = "stela-api-prod"
+}
+
+variable "cloudfront_url" {
+  description = "URL of the Cloudfront distribution for the prod environment"
+  type        = string
+}
+
+variable "cloudfront_key_pair_id" {
+  description = "ID of the CloudFront key pair"
+  type        = string
+}
+
+variable "cloudfront_private_key" {
+  description = "Private key for signing CloudFront URLs"
+  type        = string
+}
+
+variable "aws_account_id" {
+  description = "AWS account ID"
+  type        = string
 }

--- a/terraform/test_cluster/record_thumbnail_dev_lambda.tf
+++ b/terraform/test_cluster/record_thumbnail_dev_lambda.tf
@@ -1,0 +1,139 @@
+resource "aws_sns_topic" "record_thumbnail_dev_topic" {
+  name = "record-thumbnail-dev-topic"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Service = "s3.amazonaws.com"
+        },
+        Action = "sns:Publish",
+        Resource = "*",
+        Condition = {
+          StringEquals = {
+            "AWS:SourceAccount" = var.aws_account_id
+          }
+          ArnLike = {
+            "AWS:SourceArn" = "arn:aws:s3:*:*:permanent-dev"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_sqs_queue" "record_thumbnail_dev_deadletter_queue" {
+  name = "record-thumbnail-dev-deadletter-queue"
+}
+
+resource "aws_sqs_queue" "record_thumbnail_dev_queue" {
+  name = "record-thumbnail-dev-queue"
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.record_thumbnail_dev_deadletter_queue.arn
+    maxReceiveCount     = 3
+  })
+}
+
+resource "aws_sqs_queue_policy" "record_thumbnail_dev_queue_policy" {
+  queue_url = aws_sqs_queue.record_thumbnail_dev_queue.id
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect    = "Allow",
+        Principal = {
+          Service = "sns.amazonaws.com"
+        },
+        Action    = "sqs:SendMessage",
+        Resource  = aws_sqs_queue.record_thumbnail_dev_queue.arn,
+        Condition = {
+          ArnEquals = {
+            "aws:SourceArn" = aws_sns_topic.record_thumbnail_dev_topic.arn
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_sns_topic_subscription" "record_thumbnail_dev_subscription" {
+  topic_arn = aws_sns_topic.record_thumbnail_dev_topic.arn
+  protocol  = "sqs"
+  endpoint  = aws_sqs_queue.record_thumbnail_dev_queue.arn
+}
+
+data "aws_iam_policy_document" "assume_role" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "record_thumbnail_lambda_role" {
+  name               = "record-thumbnail-lambda-role"
+  assume_role_policy = data.aws_iam_policy_document.assume_role.json
+}
+
+resource "aws_iam_role_policy" "record_thumbnail_lambda_policy" {
+  name = "record-thumbnail-lambda-policy"
+  role = aws_iam_role.record_thumbnail_lambda_role.name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "ec2:CreateNetworkInterface",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DeleteNetworkInterface",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeSubnets",
+          "sqs:ReceiveMessage",
+          "sqs:DeleteMessage",
+          "sqs:GetQueueAttributes",
+        ]
+        Effect   = "Allow"
+        Resource = ["*", aws_sqs_queue.record_thumbnail_dev_queue.arn]
+      },
+    ]
+  })
+}
+
+resource "aws_lambda_function" "record_thumbnail_lambda" {
+  package_type  = "Image"
+  image_uri     = var.record_thumbnail_dev_lambda_image
+  function_name = "record-thumbnail-dev-lambda"
+  role          = aws_iam_role.record_thumbnail_lambda_role.arn
+  timeout       = 30
+
+  vpc_config {
+    security_group_ids = [var.dev_security_group_id]
+    subnet_ids         = var.subnet_ids
+  }
+
+  environment {
+    variables = {
+      ENV                    = var.dev_env
+      SENTRY_DSN             = var.sentry_dsn
+      DATABASE_URL           = var.dev_database_url
+      CLOUDFRONT_URL         = var.dev_cloudfront_url
+      CLOUDFRONT_KEY_PAIR_ID = var.cloudfront_key_pair_id
+      CLOUDFRONT_PRIVATE_KEY = var.cloudfront_private_key
+    }
+  }
+}
+
+resource "aws_lambda_event_source_mapping" "record_thumbnail_dev_event_source_mapping" {
+  event_source_arn                   = aws_sqs_queue.record_thumbnail_dev_queue.arn
+  function_name                      = aws_lambda_function.record_thumbnail_lambda.arn
+  batch_size                         = 10
+  maximum_batching_window_in_seconds = 0
+}

--- a/terraform/test_cluster/record_thumbnail_staging_lambda.tf
+++ b/terraform/test_cluster/record_thumbnail_staging_lambda.tf
@@ -1,0 +1,139 @@
+resource "aws_sns_topic" "record_thumbnail_staging_topic" {
+  name = "record-thumbnail-staging-topic"
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Service = "s3.amazonaws.com"
+        },
+        Action = "sns:Publish",
+        Resource = "*",
+        Condition = {
+          StringEquals = {
+            "AWS:SourceAccount" = var.aws_account_id
+          }
+          ArnLike = {
+            "AWS:SourceArn" = "arn:aws:s3:*:*:permanent-staging"
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_sqs_queue" "record_thumbnail_staging_deadletter_queue" {
+  name = "record-thumbnail-staging-deadletter-queue"
+}
+
+resource "aws_sqs_queue" "record_thumbnail_staging_queue" {
+  name = "record-thumbnail-staging-queue"
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.record_thumbnail_staging_deadletter_queue.arn
+    maxReceiveCount     = 3
+  })
+}
+
+resource "aws_sqs_queue_policy" "record_thumbnail_staging_queue_policy" {
+  queue_url = aws_sqs_queue.record_thumbnail_staging_queue.id
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect    = "Allow",
+        Principal = {
+          Service = "sns.amazonaws.com"
+        },
+        Action    = "sqs:SendMessage",
+        Resource  = aws_sqs_queue.record_thumbnail_staging_queue.arn,
+        Condition = {
+          ArnEquals = {
+            "aws:SourceArn" = aws_sns_topic.record_thumbnail_staging_topic.arn
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_sns_topic_subscription" "record_thumbnail_staging_subscription" {
+  topic_arn = aws_sns_topic.record_thumbnail_staging_topic.arn
+  protocol  = "sqs"
+  endpoint  = aws_sqs_queue.record_thumbnail_staging_queue.arn
+}
+
+data "aws_iam_policy_document" "assume_role_staging" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "record_thumbnail_lambda_staging_role" {
+  name               = "record-thumbnail-lambda-staging-role"
+  assume_role_policy = data.aws_iam_policy_document.assume_role_staging.json
+}
+
+resource "aws_iam_role_policy" "record_thumbnail_lambda_staging_policy" {
+  name = "record-thumbnail-lambda-staging-policy"
+  role = aws_iam_role.record_thumbnail_lambda_staging_role.name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "ec2:CreateNetworkInterface",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DeleteNetworkInterface",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeSubnets",
+          "sqs:ReceiveMessage",
+          "sqs:DeleteMessage",
+          "sqs:GetQueueAttributes",
+        ]
+        Effect   = "Allow"
+        Resource = ["*", aws_sqs_queue.record_thumbnail_staging_queue.arn]
+      },
+    ]
+  })
+}
+
+resource "aws_lambda_function" "record_thumbnail_lambda_staging" {
+  package_type  = "Image"
+  image_uri     = var.record_thumbnail_staging_lambda_image
+  function_name = "record-thumbnail-staging-lambda"
+  role          = aws_iam_role.record_thumbnail_lambda_staging_role.arn
+  timeout       = 30
+
+  vpc_config {
+    security_group_ids = [var.staging_security_group_id]
+    subnet_ids         = var.subnet_ids
+  }
+
+  environment {
+    variables = {
+      ENV                    = var.staging_env
+      SENTRY_DSN             = var.sentry_dsn
+      DATABASE_URL           = var.staging_database_url
+      CLOUDFRONT_URL         = var.staging_cloudfront_url
+      CLOUDFRONT_KEY_PAIR_ID = var.cloudfront_key_pair_id
+      CLOUDFRONT_PRIVATE_KEY = var.cloudfront_private_key
+    }
+  }
+}
+
+resource "aws_lambda_event_source_mapping" "record_thumbnail_staging_event_source_mapping" {
+  event_source_arn                   = aws_sqs_queue.record_thumbnail_staging_queue.arn
+  function_name                      = aws_lambda_function.record_thumbnail_lambda_staging.arn
+  batch_size                         = 10
+  maximum_batching_window_in_seconds = 0
+}

--- a/terraform/test_cluster/variables.tf
+++ b/terraform/test_cluster/variables.tf
@@ -58,6 +58,16 @@ variable "archivematica_cleanup_staging_image" {
   type        = string
 }
 
+variable "record_thumbnail_dev_lambda_image" {
+  description = "Tag of record thumbnail lambda image to deploy to dev"
+  type        = string
+}
+
+variable "record_thumbnail_staging_lambda_image" {
+  description = "Tag of record thumbnail lambda image to deploy to staging"
+  type        = string
+}
+
 variable "dev_security_group_id" {
   description = "ID of the Development security group"
   type        = string
@@ -263,4 +273,29 @@ variable "staging_new_relic_app_name" {
   description = "New Relic app name for the dev environment"
   type        = string
   default     = "stela-api-staging"
+}
+
+variable "dev_cloudfront_url" {
+  description = "URL of the CloudFront distribution for the dev environment"
+  type        = string
+}
+
+variable "staging_cloudfront_url" {
+  description = "URL of the CloudFront distribution for the staging environment"
+  type        = string
+}
+
+variable "cloudfront_key_pair_id" {
+  description = "ID of the CloudFront key pair"
+  type        = string
+}
+
+variable "cloudfront_private_key" {
+  description = "Private key for signing CloudFront URLs"
+  type        = string
+}
+
+variable "aws_account_id" {
+  description = "AWS account ID"
+  type        = string
 }


### PR DESCRIPTION
Because upload volume is highly variable, we would like to use a lambda to attach thumbnails created by Archivematica to new records in our database. This commit adds the necessary terraform configuration to deploy such a lambda, and updates the deploy actions of the repo to include the lambda in deploys. It also updates the lambda handler to correctly reflect the format of the messages that will trigger the lambda.