### PR TITLE
Expect Admin Subject on Promo endpoints

### DIFF
--- a/packages/api/src/admin/controller.test.ts
+++ b/packages/api/src/admin/controller.test.ts
@@ -26,13 +26,14 @@ describe("recalculateFolderThumbnails", () => {
   beforeEach(async () => {
     (verifyAdminAuthentication as jest.Mock).mockImplementation(
       (req: Request, __, next: NextFunction) => {
-        (
-          req.body as {
-            beginTimestamp: Date;
-            endTimestamp: Date;
-            emailFromAuthToken: string;
-          }
-        ).emailFromAuthToken = "test@permanent.org";
+        const body = req.body as {
+          beginTimestamp: Date;
+          endTimestamp: Date;
+          emailFromAuthToken: string;
+          adminSubjectFromAuthToken: string;
+        };
+        body.emailFromAuthToken = "test@permanent.org";
+        body.adminSubjectFromAuthToken = "5c3473b6-cf2e-4c55-a80e-8db51d1bc5fd";
         next();
       }
     );
@@ -133,13 +134,12 @@ describe("set_null_subjects", () => {
   beforeEach(async () => {
     (verifyAdminAuthentication as jest.Mock).mockImplementation(
       (req: Request, __, next: NextFunction) => {
-        (
-          req.body as {
-            beginTimestamp: Date;
-            endTimestamp: Date;
-            emailFromAuthToken: string;
-          }
-        ).emailFromAuthToken = "test@permanent.org";
+        const body = req.body as {
+          emailFromAuthToken: string;
+          adminSubjectFromAuthToken: string;
+        };
+        body.emailFromAuthToken = "test@permanent.org";
+        body.adminSubjectFromAuthToken = "5c3473b6-cf2e-4c55-a80e-8db51d1bc5fd";
         next();
       }
     );
@@ -399,13 +399,14 @@ describe("/record/:recordId/recalculate_thumbnail", () => {
   beforeEach(async () => {
     (verifyAdminAuthentication as jest.Mock).mockImplementation(
       (req: Request, __, next: NextFunction) => {
-        (
-          req.body as {
-            beginTimestamp: Date;
-            endTimestamp: Date;
-            emailFromAuthToken: string;
-          }
-        ).emailFromAuthToken = "test@permanent.org";
+        const body = req.body as {
+          beginTimestamp: Date;
+          endTimestamp: Date;
+          emailFromAuthToken: string;
+          adminSubjectFromAuthToken: string;
+        };
+        body.emailFromAuthToken = "test@permanent.org";
+        body.adminSubjectFromAuthToken = "5c3473b6-cf2e-4c55-a80e-8db51d1bc5fd";
         next();
       }
     );

--- a/packages/api/src/admin/validators.test.ts
+++ b/packages/api/src/admin/validators.test.ts
@@ -1,11 +1,14 @@
 import { validateRecalculateFolderThumbnailsRequest } from "./validators";
 
+const adminSubjectFromAuthToken = "fcb2b59b-df07-4e79-ad20-bf7f067a965e";
+
 describe("validateRecalculateFolderThumbnailsRequest", () => {
   test("should not error if the request is valid", () => {
     let error = null;
     try {
       validateRecalculateFolderThumbnailsRequest({
         emailFromAuthToken: "test@permanent.org",
+        adminSubjectFromAuthToken,
         beginTimestamp: "2023-07-30",
         endTimestamp: "2023-07-31",
       });
@@ -16,135 +19,118 @@ describe("validateRecalculateFolderThumbnailsRequest", () => {
     }
   });
 
-  test("should error if emailFromAuthToken is missing", () => {
+  const expectErrorForRequestObject = (request: unknown): void => {
     let error = null;
     try {
-      validateRecalculateFolderThumbnailsRequest({
-        beginTimestamp: "2023-07-30",
-        endTimestamp: "2023-07-31",
-      });
+      validateRecalculateFolderThumbnailsRequest(request);
     } catch (err) {
       error = err;
     } finally {
       expect(error).not.toBeNull();
     }
+  };
+
+  test("should error if emailFromAuthToken is missing", () => {
+    expectErrorForRequestObject({
+      adminSubjectFromAuthToken,
+      beginTimestamp: "2023-07-30",
+      endTimestamp: "2023-07-31",
+    });
   });
 
   test("should error if emailFromAuthToken is wrong type", () => {
-    let error = null;
-    try {
-      validateRecalculateFolderThumbnailsRequest({
-        emailFromAuthToken: 123,
-        beginTimestamp: "2023-07-30",
-        endTimestamp: "2023-07-31",
-      });
-    } catch (err) {
-      error = err;
-    } finally {
-      expect(error).not.toBeNull();
-    }
+    expectErrorForRequestObject({
+      emailFromAuthToken: 123,
+      adminSubjectFromAuthToken,
+      beginTimestamp: "2023-07-30",
+      endTimestamp: "2023-07-31",
+    });
   });
 
   test("should error if emailFromAuthToken is wrong format", () => {
-    let error = null;
-    try {
-      validateRecalculateFolderThumbnailsRequest({
-        emailFromAuthToken: "not_an_email",
-        beginTimestamp: "2023-07-30",
-        endTimestamp: "2023-07-31",
-      });
-    } catch (err) {
-      error = err;
-    } finally {
-      expect(error).not.toBeNull();
-    }
+    expectErrorForRequestObject({
+      emailFromAuthToken: "not_an_email",
+      adminSubjectFromAuthToken,
+      beginTimestamp: "2023-07-30",
+      endTimestamp: "2023-07-31",
+    });
+  });
+
+  test("should error if adminSubjectFromAuthToken is missing", () => {
+    expectErrorForRequestObject({
+      emailFromAuthToken: "test@permanent.org",
+      beginTimestamp: "2023-07-30",
+      endTimestamp: "2023-07-31",
+    });
+  });
+
+  test("should error if adminSubjectFromAuthToken is wrong type", () => {
+    expectErrorForRequestObject({
+      adminSubjectFromAuthToken: 12345,
+      emailFromAuthToken: "test@permanent.org",
+      beginTimestamp: "2023-07-30",
+      endTimestamp: "2023-07-31",
+    });
+  });
+
+  test("should error if adminSubjectFromAuthToken is wrong format", () => {
+    expectErrorForRequestObject({
+      adminSubjectFromAuthToken: "not a uuid",
+      emailFromAuthToken: "test@permanent.org",
+      beginTimestamp: "2023-07-30",
+      endTimestamp: "2023-07-31",
+    });
   });
 
   test("should error if beginTimestamp is missing", () => {
-    let error = null;
-    try {
-      validateRecalculateFolderThumbnailsRequest({
-        emailFromAuthToken: "test@permanent.org",
-        endTimestamp: "2023-07-31",
-      });
-    } catch (err) {
-      error = err;
-    } finally {
-      expect(error).not.toBeNull();
-    }
+    expectErrorForRequestObject({
+      adminSubjectFromAuthToken,
+      emailFromAuthToken: "test@permanent.org",
+      endTimestamp: "2023-07-31",
+    });
   });
 
   test("should error if beginTimestamp is wrong type", () => {
-    let error = null;
-    try {
-      validateRecalculateFolderThumbnailsRequest({
-        emailFromAuthToken: "test@permanent.org",
-        beginTimestamp: "not_a_date",
-        endTimestamp: "2023-07-31",
-      });
-    } catch (err) {
-      error = err;
-    } finally {
-      expect(error).not.toBeNull();
-    }
+    expectErrorForRequestObject({
+      adminSubjectFromAuthToken,
+      emailFromAuthToken: "test@permanent.org",
+      beginTimestamp: "not_a_date",
+      endTimestamp: "2023-07-31",
+    });
   });
 
   test("should error if beginTimestamp is wrong format", () => {
-    let error = null;
-    try {
-      validateRecalculateFolderThumbnailsRequest({
-        emailFromAuthToken: "test@permanent.org",
-        beginTimestamp: "07/31/23",
-        endTimestamp: "2023-07-31",
-      });
-    } catch (err) {
-      error = err;
-    } finally {
-      expect(error).not.toBeNull();
-    }
+    expectErrorForRequestObject({
+      adminSubjectFromAuthToken,
+      emailFromAuthToken: "test@permanent.org",
+      beginTimestamp: "07/31/23",
+      endTimestamp: "2023-07-31",
+    });
   });
 
   test("should error if endTimestamp is missing", () => {
-    let error = null;
-    try {
-      validateRecalculateFolderThumbnailsRequest({
-        emailFromAuthToken: "test@permanent.org",
-        beginTimestamp: "2023-07-30",
-      });
-    } catch (err) {
-      error = err;
-    } finally {
-      expect(error).not.toBeNull();
-    }
+    expectErrorForRequestObject({
+      adminSubjectFromAuthToken,
+      emailFromAuthToken: "test@permanent.org",
+      beginTimestamp: "2023-07-30",
+    });
   });
 
   test("should error if endTimestamp is wrong type", () => {
-    let error = null;
-    try {
-      validateRecalculateFolderThumbnailsRequest({
-        emailFromAuthToken: "test@permanent.org",
-        beginTimestamp: "2023-07-30",
-        endTimestamp: "not_a_date",
-      });
-    } catch (err) {
-      error = err;
-    } finally {
-      expect(error).not.toBeNull();
-    }
+    expectErrorForRequestObject({
+      adminSubjectFromAuthToken,
+      emailFromAuthToken: "test@permanent.org",
+      beginTimestamp: "2023-07-30",
+      endTimestamp: "not_a_date",
+    });
   });
 
   test("should error if endTimestamp is wrong format", () => {
-    let error = null;
-    try {
-      validateRecalculateFolderThumbnailsRequest({
-        emailFromAuthToken: "test@permanent.org",
-        beginTimestamp: "2023-07-30",
-        endTimestamp: "07/31/23",
-      });
-    } catch (err) {
-      error = err;
-    } finally {
-      expect(error).not.toBeNull();
-    }
+    expectErrorForRequestObject({
+      adminSubjectFromAuthToken,
+      emailFromAuthToken: "test@permanent.org",
+      beginTimestamp: "2023-07-30",
+      endTimestamp: "07/31/23",
+    });
   });
 });

--- a/packages/api/src/admin/validators.ts
+++ b/packages/api/src/admin/validators.ts
@@ -1,11 +1,12 @@
 import Joi from "joi";
+import { fieldsFromAdminAuthentication } from "../validators";
 
 export function validateRecalculateFolderThumbnailsRequest(
   data: unknown
 ): asserts data is { beginTimestamp: Date; endTimestamp: Date } {
   const validation = Joi.object()
     .keys({
-      emailFromAuthToken: Joi.string().email().required(),
+      ...fieldsFromAdminAuthentication,
       beginTimestamp: Joi.date().iso().required(),
       endTimestamp: Joi.date().iso().required(),
     })
@@ -20,7 +21,7 @@ export function validateAccountSetNullSubjectsRequest(
 ): asserts data is { accounts: { email: string; subject: string }[] } {
   const validation = Joi.object()
     .keys({
-      emailFromAuthToken: Joi.string().email().required(),
+      ...fieldsFromAdminAuthentication,
       accounts: Joi.array()
         .items(
           Joi.object({

--- a/packages/api/src/directive/validators.test.ts
+++ b/packages/api/src/directive/validators.test.ts
@@ -364,12 +364,96 @@ describe("validateTriggerAdminDirectivesParams", () => {
     let error = null;
     try {
       validateTriggerAdminDirectivesParams({
+        emailFromAuthToken: "test@permanent.org",
+        adminSubjectFromAuthToken: "5c3473b6-cf2e-4c55-a80e-8db51d1bc5fd",
         accountId: "1",
       });
     } catch (err) {
       error = err;
     } finally {
       expect(error).toBeNull();
+    }
+  });
+  test("should raise an error if emailFromAuthToken is missing", () => {
+    let error = null;
+    try {
+      validateTriggerAdminDirectivesParams({
+        adminSubjectFromAuthToken: "5c3473b6-cf2e-4c55-a80e-8db51d1bc5fd",
+        accountId: "1",
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+  test("should raise an error if emailFromAuthToken is wrong type", () => {
+    let error = null;
+    try {
+      validateTriggerAdminDirectivesParams({
+        emailFromAuthToken: 1234,
+        adminSubjectFromAuthToken: "5c3473b6-cf2e-4c55-a80e-8db51d1bc5fd",
+        accountId: "1",
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+  test("should raise an error if emailFromAuthToken is wrong format", () => {
+    let error = null;
+    try {
+      validateTriggerAdminDirectivesParams({
+        emailFromAuthToken: "not an email",
+        adminSubjectFromAuthToken: "5c3473b6-cf2e-4c55-a80e-8db51d1bc5fd",
+        accountId: "1",
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+  test("should raise an error if adminSubjectFromAuthToken is missing", () => {
+    let error = null;
+    try {
+      validateTriggerAdminDirectivesParams({
+        emailFromAuthToken: "test@permanent.org",
+        accountId: "1",
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+  test("should raise an error if adminSubjectFromAuthToken is the wrong type", () => {
+    let error = null;
+    try {
+      validateTriggerAdminDirectivesParams({
+        emailFromAuthToken: "test@permanent.org",
+        adminSubjectFromAuthToken: 12345,
+        accountId: "1",
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+  test("should raise an error if adminSubjectFromAuthToken is the wrong format", () => {
+    let error = null;
+    try {
+      validateTriggerAdminDirectivesParams({
+        emailFromAuthToken: "test@permanent.org",
+        adminSubjectFromAuthToken: "not a uuid",
+        accountId: "1",
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
     }
   });
   test("should raise an error if accountId is missing", () => {

--- a/packages/api/src/directive/validators.ts
+++ b/packages/api/src/directive/validators.ts
@@ -3,6 +3,7 @@ import type { CreateDirectiveRequest, UpdateDirectiveRequest } from "./model";
 import {
   validateBodyFromAuthentication,
   fieldsFromUserAuthentication,
+  fieldsFromAdminAuthentication,
 } from "../validators";
 
 export { validateBodyFromAuthentication };
@@ -77,6 +78,7 @@ export function validateTriggerAdminDirectivesParams(
 ): asserts data is { accountId: string } {
   const validation = Joi.object()
     .keys({
+      ...fieldsFromAdminAuthentication,
       accountId: Joi.string().required(),
     })
     .validate(data);

--- a/packages/api/src/middleware/authentication.test.ts
+++ b/packages/api/src/middleware/authentication.test.ts
@@ -220,6 +220,19 @@ describe("verifyAdminAuthentication", () => {
     expect(request.body.emailFromAuthToken).toBe(testEmail);
   });
 
+  test("should add the admin subject to the request body if the token is valid", async () => {
+    const request = {
+      body: {},
+      get: (_: string) => "Bearer test",
+    } as Request<unknown, unknown, { adminSubjectFromAuthToken?: string }>;
+    jest
+      .spyOn(fusionAuthClient, "introspectAccessToken")
+      .mockImplementation(async () => successfulIntrospectionResponse);
+    await verifyAdminAuthentication(request, {} as Response, () => {});
+
+    expect(request.body.adminSubjectFromAuthToken).toBe(testSubject);
+  });
+
   test("should throw unauthorized if authorization header is missing", async () => {
     const request = {
       body: {},

--- a/packages/api/src/middleware/authentication.ts
+++ b/packages/api/src/middleware/authentication.ts
@@ -127,7 +127,11 @@ const verifyUserAuthentication = async (
 };
 
 const verifyAdminAuthentication = async (
-  req: Request<unknown, unknown, { emailFromAuthToken?: string }>,
+  req: Request<
+    unknown,
+    unknown,
+    { emailFromAuthToken?: string; adminSubjectFromAuthToken?: string }
+  >,
   _: Response,
   next: NextFunction
 ): Promise<void> => {
@@ -136,12 +140,12 @@ const verifyAdminAuthentication = async (
     if (authenticationToken === "") {
       throw new createError.Unauthorized("Invalid Authorization header format");
     }
-    const email = await getValueFromAuthToken(
+    const { email, subject } = await getValuesFromAuthToken(
       authenticationToken,
-      emailKey,
       process.env["FUSIONAUTH_ADMIN_APPLICATION_ID"] ?? ""
     );
     req.body.emailFromAuthToken = email;
+    req.body.adminSubjectFromAuthToken = subject;
     next();
   } catch (err) {
     next(err);

--- a/packages/api/src/promo/controller.test.ts
+++ b/packages/api/src/promo/controller.test.ts
@@ -25,7 +25,7 @@ describe("POST /promo", () => {
       (req: Request, __, next: NextFunction) => {
         (req.body as CreatePromoRequest).emailFromAuthToken =
           "test@permanent.org";
-        (req.body as CreatePromoRequest).userSubjectFromAuthToken =
+        (req.body as CreatePromoRequest).adminSubjectFromAuthToken =
           "6b640c73-4963-47de-a096-4a05ff8dc5f5";
         next();
       }
@@ -65,7 +65,7 @@ describe("POST /promo", () => {
   test("should respond with 400 status code if missing emailFromAuthToken", async () => {
     (verifyAdminAuthentication as jest.Mock).mockImplementation(
       (req: Request, __, next: NextFunction) => {
-        (req.body as CreatePromoRequest).userSubjectFromAuthToken =
+        (req.body as CreatePromoRequest).adminSubjectFromAuthToken =
           "6b640c73-4963-47de-a096-4a05ff8dc5f5";
         next();
       }
@@ -85,7 +85,7 @@ describe("POST /promo", () => {
     (verifyAdminAuthentication as jest.Mock).mockImplementation(
       (req: Request, __, next: NextFunction) => {
         (req.body as { emailFromAuthToken: number }).emailFromAuthToken = 123;
-        (req.body as CreatePromoRequest).userSubjectFromAuthToken =
+        (req.body as CreatePromoRequest).adminSubjectFromAuthToken =
           "6b640c73-4963-47de-a096-4a05ff8dc5f5";
         next();
       }
@@ -105,7 +105,7 @@ describe("POST /promo", () => {
     (verifyAdminAuthentication as jest.Mock).mockImplementation(
       (req: Request, __, next: NextFunction) => {
         (req.body as CreatePromoRequest).emailFromAuthToken = "not_an_email";
-        (req.body as CreatePromoRequest).userSubjectFromAuthToken =
+        (req.body as CreatePromoRequest).adminSubjectFromAuthToken =
           "6b640c73-4963-47de-a096-4a05ff8dc5f5";
         next();
       }
@@ -121,7 +121,7 @@ describe("POST /promo", () => {
       .expect(400);
   });
 
-  test("should respond with 400 status code if missing userSubjectFromAuthToken", async () => {
+  test("should respond with 400 status code if missing adminSubjectFromAuthToken", async () => {
     (verifyAdminAuthentication as jest.Mock).mockImplementation(
       (req: Request, __, next: NextFunction) => {
         (req.body as CreatePromoRequest).emailFromAuthToken =
@@ -140,14 +140,14 @@ describe("POST /promo", () => {
       .expect(400);
   });
 
-  test("should respond with 400 status code if userSubjectFromAuthToken is not a string", async () => {
+  test("should respond with 400 status code if adminSubjectFromAuthToken is not a string", async () => {
     (verifyAdminAuthentication as jest.Mock).mockImplementation(
       (req: Request, __, next: NextFunction) => {
         (req.body as CreatePromoRequest).emailFromAuthToken =
           "test@permanent.org";
         (
-          req.body as { userSubjectFromAuthToken: number }
-        ).userSubjectFromAuthToken = 123;
+          req.body as { adminSubjectFromAuthToken: number }
+        ).adminSubjectFromAuthToken = 123;
         next();
       }
     );
@@ -162,12 +162,12 @@ describe("POST /promo", () => {
       .expect(400);
   });
 
-  test("should respond with 400 status code if userSubjectFromAuthToken is not a uuid", async () => {
+  test("should respond with 400 status code if adminSubjectFromAuthToken is not a uuid", async () => {
     (verifyAdminAuthentication as jest.Mock).mockImplementation(
       (req: Request, __, next: NextFunction) => {
         (req.body as CreatePromoRequest).emailFromAuthToken =
           "test@permanent.org";
-        (req.body as CreatePromoRequest).userSubjectFromAuthToken =
+        (req.body as CreatePromoRequest).adminSubjectFromAuthToken =
           "not_a_uuid";
         next();
       }

--- a/packages/api/src/promo/models.ts
+++ b/packages/api/src/promo/models.ts
@@ -1,6 +1,6 @@
 export interface CreatePromoRequest {
   emailFromAuthToken: string;
-  userSubjectFromAuthToken: string;
+  adminSubjectFromAuthToken: string;
   code: string;
   storageInMB: number;
   expirationTimestamp: string;

--- a/packages/api/src/promo/validators.ts
+++ b/packages/api/src/promo/validators.ts
@@ -1,13 +1,13 @@
 import Joi from "joi";
 import type { CreatePromoRequest } from "./models";
-import { fieldsFromUserAuthentication } from "../validators";
+import { fieldsFromAdminAuthentication } from "../validators";
 
 export function validateCreatePromoRequest(
   data: unknown
 ): asserts data is CreatePromoRequest {
   const validation = Joi.object()
     .keys({
-      ...fieldsFromUserAuthentication,
+      ...fieldsFromAdminAuthentication,
       code: Joi.string().required(),
       storageInMB: Joi.number().integer().min(1).required(),
       expirationTimestamp: Joi.date().iso().greater("now").required(),

--- a/packages/api/src/validators/index.ts
+++ b/packages/api/src/validators/index.ts
@@ -1,6 +1,5 @@
-import {
+export {
+  fieldsFromAdminAuthentication,
   fieldsFromUserAuthentication,
   validateBodyFromAuthentication,
 } from "./shared";
-
-export { fieldsFromUserAuthentication, validateBodyFromAuthentication };

--- a/packages/api/src/validators/shared.ts
+++ b/packages/api/src/validators/shared.ts
@@ -5,6 +5,11 @@ export const fieldsFromUserAuthentication = {
   userSubjectFromAuthToken: Joi.string().uuid().required(),
 };
 
+export const fieldsFromAdminAuthentication = {
+  emailFromAuthToken: Joi.string().email().required(),
+  adminSubjectFromAuthToken: Joi.string().uuid().required(),
+};
+
 export function validateBodyFromAuthentication(data: unknown): asserts data is {
   emailFromAuthToken: string;
   userSubjectFromAuthToken: string;


### PR DESCRIPTION
Previously these endpoints were configured to expect a `userSubjectFromAuthToken`, which is not assigned because these are admin endpoints. Eventually we want to get admin subjects in some endpoints, so add `adminSubjectFromAuthToken` in admin verification middleware and shared admin authentication fields.

It doesn't seem like this issue affects other endpoints as far as I can tell, but I'd appreciate another check during review.
