### PR TITLE
Add missing variable to staging deploy during prod deploy

### DIFF
--- a/.github/workflows/prod_deploy.yml
+++ b/.github/workflows/prod_deploy.yml
@@ -106,6 +106,7 @@ jobs:
       API_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.API_IMAGE_TAG }}
       AM_CLEANUP_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.AM_CLEANUP_IMAGE_TAG }}
       RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG }}
+      THUMBNAIL_REFRESH_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.THUMBNAIL_REFRESH_IMAGE_TAG }}
     defaults:
       run:
         working-directory: ./terraform/test_cluster


### PR DESCRIPTION
One of the required image tag variables taken from the generate image tags job is missing on the staging deploy that precedes prod deploys. This commit adds it.