### PR TITLE
Add tests for the legacy client

### DIFF
--- a/packages/api/src/legacy_client.test.ts
+++ b/packages/api/src/legacy_client.test.ts
@@ -1,0 +1,58 @@
+import fetch from "node-fetch";
+import { legacyClient } from "./legacy_client";
+
+jest.mock("node-fetch");
+
+describe("transferArchiveOwnership", () => {
+  test("should submit the correct request", async () => {
+    const testEmail = "test@permanent.org";
+    const archiveSlug = "0001-0001";
+    const testMessage = "Please carry on the mission of this archive";
+
+    await legacyClient.transferArchiveOwnership(
+      testEmail,
+      archiveSlug,
+      testMessage,
+      true,
+      1024
+    );
+
+    expect(fetch).toHaveBeenCalledWith("/archive/transferOwnership", {
+      method: "POST",
+      headers: {
+        "Request-Version": "2",
+        "Content-Type": "application/json",
+        "X-Permanent-Stela-Shared-Secret": "",
+      },
+      body: JSON.stringify({
+        recipientEmail: testEmail,
+        archiveNbr: archiveSlug,
+        storageGiftInMB: 1024,
+        isLegacyAction: true,
+        message: testMessage,
+      }),
+    });
+  });
+  test("should use the correct defaults for optional arguments", async () => {
+    const testEmail = "test@permanent.org";
+    const archiveSlug = "0001-0001";
+
+    await legacyClient.transferArchiveOwnership(testEmail, archiveSlug);
+
+    expect(fetch).toHaveBeenCalledWith("/archive/transferOwnership", {
+      method: "POST",
+      headers: {
+        "Request-Version": "2",
+        "Content-Type": "application/json",
+        "X-Permanent-Stela-Shared-Secret": "",
+      },
+      body: JSON.stringify({
+        recipientEmail: testEmail,
+        archiveNbr: archiveSlug,
+        storageGiftInMB: 0,
+        isLegacyAction: false,
+        message: null,
+      }),
+    });
+  });
+});


### PR DESCRIPTION
Currently, the client we use to make calls to the legacy API is untested. This commit adds tests for it.