### PR TITLE
Update tests to work with changes to devenvs docker compose

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,6 +32,7 @@ jobs:
             - run: (cd stela; npm install --production=false)
             - run : (cd stela; npm run build -ws)
             - run: touch stela/.env
+            - run: touch devenv/.env
             - run: (cd devenv; docker compose up database_setup -d; docker logs devenv-database_setup-1)
             - run: (cd stela/packages/api; npm run start-containers)
             - run: (cd stela/packages/api; docker compose run stela npm run test-ci)


### PR DESCRIPTION
When running in Github Actions, this repo's tests use the devenv repo's docker compose to set up the database. Recent changes to the development environment have caused that docker compose to expect the devenv direction to have a .env file, which is currently not present when this repo runs tests. This commit adds a step to the test action to create an empty .env file to prevent docker from erroring when it sets up the database.