### PR TITLE
Add endpoints for third party developers to future API design

### DIFF
--- a/packages/api/docs/future/api.yaml
+++ b/packages/api/docs/future/api.yaml
@@ -21,6 +21,8 @@ components:
 paths:
   /login:
     $ref: "./paths/authentication.yaml#/login"
+  /token:
+    $ref: "./paths/authentication.yaml#/token"
   /start-mfa:
     $ref: "./paths/authentication.yaml#/start-mfa"
   /complete-mfa:
@@ -47,3 +49,9 @@ paths:
     $ref: "./paths/folder.yaml#/folders-id-share-links"
   /archive/{id}/folders/shared:
     $ref: "./paths/archive.yaml#/archive-id-folders-shared"
+  /applications:
+    $ref: "./paths/application.yaml#/applications"
+  /applications/{id}:
+    $ref: "./paths/application.yaml#/applications-with-id"
+  /developer-accounts:
+    $ref: "./paths/developer_account.yaml#/developer-accounts"

--- a/packages/api/docs/future/models/application.yaml
+++ b/packages/api/docs/future/models/application.yaml
@@ -1,0 +1,27 @@
+applicationScope:
+  type: string
+  enum:
+    - record.create
+    - folder.view
+    - folder.create
+    - archive.view
+    - archive.create
+    - storage.view
+
+application:
+  type: object
+  required: [id, secret, scopes, redirectUris]
+  properties:
+    id:
+      type: string
+    secret:
+      type: string
+    scopes:
+      type: array
+      items:
+        type: string
+    redirectUris:
+      type: array
+      items:
+        type: string
+        format: uri

--- a/packages/api/docs/future/paths/application.yaml
+++ b/packages/api/docs/future/paths/application.yaml
@@ -1,0 +1,152 @@
+applications:
+  post:
+    summary: >
+      Register a new application to use the Permanent API.
+      Authorization token must belong to a registered developer account.
+    operationId: createApplication
+    security:
+      - bearerHttpAuthentication: []
+    tags:
+      - application
+    requestBody:
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [scopes]
+            properties:
+              redirectUris:
+                type: array
+                items:
+                  type: string
+                  format: uri
+              scopes:
+                type: array
+                items:
+                  $ref: "../models/application.yaml#/applicationScope"
+    responses:
+      "201":
+        description: The application created
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                data:
+                  $ref: "../models/application.yaml#/application"
+      "400":
+        $ref: "../../shared/errors.yaml#/400"
+      "401":
+        $ref: "../../shared/errors.yaml#/401"
+      "403":
+        $ref: "../../shared/errors.yaml#/403"
+      "500":
+        $ref: "../../shared/errors.yaml#/500"
+
+applications-with-id:
+  parameters:
+    - name: id
+      in: path
+      required: true
+      description: An application ID
+      schema:
+        type: string
+  get:
+    summary: >
+      Get application data by ID.
+      Authorization token must belong to a registered developer account.
+    operationId: getApplication
+    security:
+      - bearerHttpAuthentication: []
+    tags:
+      - application
+    responses:
+      "200":
+        description: The application requested
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                data:
+                  $ref: "../models/application.yaml#/application"
+      "400":
+        $ref: "../../shared/errors.yaml#/400"
+      "401":
+        $ref: "../../shared/errors.yaml#/401"
+      "403":
+        $ref: "../../shared/errors.yaml#/403"
+      "404":
+        $ref: "../../shared/errors.yaml#/404"
+      "500":
+        $ref: "../../shared/errors.yaml#/500"
+  patch:
+    summary: >
+      Update an application.
+      Authorization token must belong to a registered developer account.
+    operationId: updateApplication
+    security:
+      - bearerHttpAuthentication: []
+    tags:
+      - application
+    requestBody:
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [scopes]
+            properties:
+              scopes:
+                type: array
+                items:
+                  $ref: "../models/application.yaml#/applicationScope"
+              redirectUris:
+                type: array
+                items:
+                  type: string
+                  format: uri
+    responses:
+      "200":
+        description: The updated application
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                data:
+                  $ref: "../models/application.yaml#/application"
+      "400":
+        $ref: "../../shared/errors.yaml#/400"
+      "401":
+        $ref: "../../shared/errors.yaml#/401"
+      "403":
+        $ref: "../../shared/errors.yaml#/403"
+      "404":
+        $ref: "../../shared/errors.yaml#/404"
+      "500":
+        $ref: "../../shared/errors.yaml#/500"
+  delete:
+    summary: >
+      Delete an application.
+      Authorization token must belong to a registered developer account.
+    operationId: deleteApplication
+    security:
+      - bearerHttpAuthentication: []
+    tags:
+      - application
+    responses:
+      "204":
+        description: An empty response, indicating a successful deletion
+      "400":
+        $ref: "../../shared/errors.yaml#/400"
+      "401":
+        $ref: "../../shared/errors.yaml#/401"
+      "403":
+        $ref: "../../shared/errors.yaml#/403"
+      "404":
+        $ref: "../../shared/errors.yaml#/404"
+      "500":
+        $ref: "../../shared/errors.yaml#/500"
+applications-id-register-user:
+  post:
+    summary: Register a user to an application

--- a/packages/api/docs/future/paths/authentication.yaml
+++ b/packages/api/docs/future/paths/authentication.yaml
@@ -168,3 +168,48 @@ logout:
         $ref: "../../shared/errors.yaml#/400"
       "500":
         $ref: "../../shared/errors.yaml#/500"
+token:
+  post:
+    summary: >
+      Exchange a code for an authentication JWT at the conclusion of the OAuth process
+    operationId: getAuthToken
+    security: []
+    tags:
+      - authentication
+    requestBody:
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [applicationId, applicationSecret, code, redirectUri]
+            properties:
+              applicationId:
+                type: string
+              applicationSecret:
+                type: string
+              code:
+                description: The code received from the OAuth login page
+                type: string
+              redirectUri:
+                description: The same redirect URI passed to the OAuth login page
+                type: string
+                format: uri
+    responses:
+      "200":
+        description: The token exchange was successful, the response contains the authentication JWT
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                data:
+                  type: object
+                  properties:
+                    accessToken:
+                      type: string
+                    refreshToken:
+                      type: string
+      "400":
+        $ref: "../../shared/errors.yaml#/400"
+      "500":
+        $ref: "../../shared/errors.yaml#/500"

--- a/packages/api/docs/future/paths/developer_account.yaml
+++ b/packages/api/docs/future/paths/developer_account.yaml
@@ -1,0 +1,38 @@
+developer-accounts:
+  post:
+    summary: Create a new developer account
+    operationId: createDeveloperAccount
+    security: []
+    tags:
+      - application
+    requestBody:
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [email, password]
+            properties:
+              email:
+                type: string
+              password:
+                type: string
+    responses:
+      "201":
+        description: >
+          Authentication tokens for the new developer account
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                data:
+                  type: object
+                  properties:
+                    authenticationToken:
+                      type: string
+                    refreshToken:
+                      type: string
+      "400":
+        $ref: "../../shared/errors.yaml#/400"
+      "500":
+        $ref: "../../shared/errors.yaml#/500"


### PR DESCRIPTION
We want to create a smooth process for third-party developers to integrate their apps with Permanent, or build their entire apps on top of Permanent. In pursuit of this, this commit adds several endpoints to our future API design, covering the creation of third-party developer accounts, the creation and management of third party applications in FusionAuth, and login via OAuth.