### PR TITLE
Improve test coverage of accounts API

### DIFF
--- a/packages/api/src/account/controller/controller.ts
+++ b/packages/api/src/account/controller/controller.ts
@@ -1,17 +1,17 @@
 import { Router } from "express";
 import type { Request, Response, NextFunction } from "express";
 
-import { extractIp, verifyUserAuthentication } from "../middleware";
-import { isValidationError } from "../validators/validator_util";
+import { extractIp, verifyUserAuthentication } from "../../middleware";
+import { isValidationError } from "../../validators/validator_util";
 
 import {
   validateUpdateTagsRequest,
   validateBodyFromAuthentication,
   validateLeaveArchiveParams,
   validateLeaveArchiveRequest,
-} from "./validators";
-import { accountService } from "./service";
-import type { LeaveArchiveRequest } from "./models";
+} from "../validators";
+import { accountService } from "../service";
+import type { LeaveArchiveRequest } from "../models";
 
 export const accountController = Router();
 accountController.put(

--- a/packages/api/src/account/controller/get_signup_details.test.ts
+++ b/packages/api/src/account/controller/get_signup_details.test.ts
@@ -1,0 +1,123 @@
+import request from "supertest";
+import type { Request, NextFunction } from "express";
+import { logger } from "@stela/logger";
+import { app } from "../../app";
+import { db } from "../../database";
+import { verifyUserAuthentication } from "../../middleware";
+import type { SignupDetails } from "../models";
+
+jest.mock("../../database");
+jest.mock("../../middleware");
+jest.mock("@stela/logger");
+
+const loadFixtures = async (): Promise<void> => {
+  await db.sql("account.fixtures.create_test_accounts");
+  await db.sql("account.fixtures.create_test_invites");
+};
+
+const clearDatabase = async (): Promise<void> => {
+  await db.query("TRUNCATE account, invite CASCADE");
+};
+describe("getSignupDetails", () => {
+  const agent = request(app);
+  beforeEach(async () => {
+    (verifyUserAuthentication as jest.Mock).mockImplementation(
+      async (
+        req: Request<
+          unknown,
+          unknown,
+          { userSubjectFromAuthToken?: string; emailFromAuthToken?: string }
+        >,
+        __,
+        next: NextFunction
+      ) => {
+        req.body.emailFromAuthToken = "test@permanent.org";
+        req.body.userSubjectFromAuthToken =
+          "b5461dc2-1eb0-450e-b710-fef7b2cafe1e";
+
+        next();
+      }
+    );
+    await clearDatabase();
+    await loadFixtures();
+  });
+  afterEach(async () => {
+    jest.clearAllMocks();
+    await clearDatabase();
+  });
+
+  test("should return an account's signup details", async () => {
+    const response = await agent.get("/api/v2/account/signup").expect(200);
+    const signupDetails = response.body as SignupDetails;
+    expect(signupDetails.token).toEqual("earlyb1rd");
+  });
+
+  test("should throw an error if the account does not exist", async () => {
+    (verifyUserAuthentication as jest.Mock).mockImplementation(
+      async (
+        req: Request<
+          unknown,
+          unknown,
+          { userSubjectFromAuthToken?: string; emailFromAuthToken?: string }
+        >,
+        __,
+        next: NextFunction
+      ) => {
+        req.body.emailFromAuthToken = "not_an_account@permanent.org";
+        req.body.userSubjectFromAuthToken =
+          "b5461dc2-1eb0-450e-b710-fef7b2cafe1e";
+
+        next();
+      }
+    );
+    await agent.get("/api/v2/account/signup").expect(404);
+  });
+
+  test("should throw an error if the account has no signup details", async () => {
+    (verifyUserAuthentication as jest.Mock).mockImplementation(
+      async (
+        req: Request<
+          unknown,
+          unknown,
+          { userSubjectFromAuthToken?: string; emailFromAuthToken?: string }
+        >,
+        __,
+        next: NextFunction
+      ) => {
+        req.body.emailFromAuthToken = "test+1@permanent.org";
+        req.body.userSubjectFromAuthToken =
+          "b5461dc2-1eb0-450e-b710-fef7b2cafe1e";
+
+        next();
+      }
+    );
+    await agent.get("/api/v2/account/signup").expect(404);
+  });
+
+  test("should throw an error if database call fails unexpectedly", async () => {
+    jest.spyOn(db, "sql").mockImplementationOnce((async () => {
+      throw new Error("out of cheese - redo from start");
+    }) as unknown as typeof db.sql);
+    await agent.get("/api/v2/account/signup").expect(500);
+    expect(logger.error).toHaveBeenCalled();
+  });
+
+  test("should return a bad request error if the request is invalid", async () => {
+    (verifyUserAuthentication as jest.Mock).mockImplementation(
+      async (
+        req: Request<
+          unknown,
+          unknown,
+          { userSubjectFromAuthToken?: string; emailFromAuthToken?: string }
+        >,
+        __,
+        next: NextFunction
+      ) => {
+        req.body.emailFromAuthToken = "test+1@permanent.org";
+
+        next();
+      }
+    );
+    await agent.get("/api/v2/account/signup").expect(400);
+  });
+});

--- a/packages/api/src/account/controller/leave_archive.test.ts
+++ b/packages/api/src/account/controller/leave_archive.test.ts
@@ -1,16 +1,16 @@
 import request from "supertest";
 import type { Request, NextFunction } from "express";
+import { when } from "jest-when";
 
-import { db } from "../database";
-import { EVENT_ACTION, EVENT_ACTOR, EVENT_ENTITY } from "../constants";
-import { verifyUserAuthentication, extractIp } from "../middleware";
-import { app } from "../app";
-import { createEvent } from "../event/service";
+import { db } from "../../database";
+import { EVENT_ACTION, EVENT_ACTOR, EVENT_ENTITY } from "../../constants";
+import { verifyUserAuthentication, extractIp } from "../../middleware";
+import { app } from "../../app";
+import { createEvent } from "../../event/service";
 
-jest.mock("../database");
-jest.mock("@stela/logger");
-jest.mock("../middleware");
-jest.mock("../event/service");
+jest.mock("../../database");
+jest.mock("../../middleware");
+jest.mock("../../event/service");
 
 const loadFixtures = async (): Promise<void> => {
   await db.sql("account.fixtures.create_test_accounts");
@@ -109,5 +109,38 @@ describe("leaveArchive", () => {
     await agent.delete("/api/v2/account/archive/1").expect(204);
 
     expect(createEvent).toHaveBeenCalled();
+  });
+
+  test("should return a bad request error if the request is invalid", async () => {
+    (verifyUserAuthentication as jest.Mock).mockImplementation(
+      async (
+        req: Request<
+          unknown,
+          unknown,
+          { userSubjectFromAuthToken?: string; emailFromAuthToken?: string }
+        >,
+        __,
+        next: NextFunction
+      ) => {
+        req.body.emailFromAuthToken = "test+1@permanent.org";
+
+        next();
+      }
+    );
+
+    await agent.delete("/api/v2/account/archive/1").expect(400);
+  });
+
+  test("should return a 500 error if the deletion database call fails", async () => {
+    const spy = jest.spyOn(db, "sql");
+    when(spy)
+      .calledWith("account.queries.delete_account_archive", {
+        archiveId: "1",
+        email: "test+1@permanent.org",
+      })
+      .mockImplementation((async () => ({
+        rows: [],
+      })) as unknown as typeof db.sql);
+    await agent.delete("/api/v2/account/archive/1").expect(500);
   });
 });

--- a/packages/api/src/account/controller/update_tags.test.ts
+++ b/packages/api/src/account/controller/update_tags.test.ts
@@ -1,0 +1,106 @@
+import request from "supertest";
+import type { Request, NextFunction } from "express";
+import { Md5 } from "ts-md5";
+import { app } from "../../app";
+import { verifyUserAuthentication } from "../../middleware";
+import { MailchimpMarketing } from "../../mailchimp";
+import type { UpdateTagsRequest } from "../models";
+
+jest.mock("../../mailchimp", () => ({
+  MailchimpMarketing: {
+    lists: {
+      updateListMemberTags: jest.fn(),
+    },
+  },
+}));
+jest.mock("../../middleware");
+
+describe("updateTags", () => {
+  const agent = request.agent(app);
+
+  beforeEach(() => {
+    (verifyUserAuthentication as jest.Mock).mockImplementation(
+      async (
+        req: Request<
+          unknown,
+          unknown,
+          { userSubjectFromAuthToken?: string; emailFromAuthToken?: string }
+        >,
+        __,
+        next: NextFunction
+      ) => {
+        req.body.emailFromAuthToken = "test@permanent.org";
+        req.body.userSubjectFromAuthToken =
+          "b5461dc2-1eb0-450e-b710-fef7b2cafe1e";
+
+        next();
+      }
+    );
+    jest.clearAllMocks();
+  });
+
+  test("should call updateListMemberTags with the correct arguments", async () => {
+    const requestBody: UpdateTagsRequest = {
+      emailFromAuthToken: "test@permanent.org",
+      addTags: ["tag1", "tag2"],
+      removeTags: ["tag3", "tag4"],
+    };
+
+    const expectedTags = [
+      { name: "tag1", status: "active" },
+      { name: "tag2", status: "active" },
+      { name: "tag3", status: "inactive" },
+      { name: "tag4", status: "inactive" },
+    ];
+
+    const expectedListId = process.env["MAILCHIMP_COMMUNITY_LIST_ID"] ?? "";
+    const expectedSubscriberHash = Md5.hashStr(requestBody.emailFromAuthToken);
+
+    (
+      MailchimpMarketing.lists.updateListMemberTags as jest.MockedFunction<
+        typeof MailchimpMarketing.lists.updateListMemberTags
+      >
+    ).mockResolvedValue(null);
+
+    await agent.put("/api/v2/account/tags").send(requestBody).expect(200);
+
+    expect(MailchimpMarketing.lists.updateListMemberTags).toHaveBeenCalledWith(
+      expectedListId,
+      expectedSubscriberHash,
+      { tags: expectedTags }
+    );
+  });
+
+  test("should throw an error if MailChimp call fails", async () => {
+    (
+      MailchimpMarketing.lists.updateListMemberTags as jest.MockedFunction<
+        typeof MailchimpMarketing.lists.updateListMemberTags
+      >
+    ).mockResolvedValue({
+      detail: "Out of Cheese - Redo from Start",
+      status: 500,
+      type: "",
+      title: "",
+      instance: "",
+    });
+    await agent
+      .put("/api/v2/account/tags")
+      .send({
+        emailFromAuthToken: "test@permanent.org",
+        addTags: ["tag1", "tag2"],
+        removeTags: ["tag3", "tag4"],
+      })
+      .expect(500);
+  });
+
+  test("should throw a bad request error if the request body is invalid", async () => {
+    await agent
+      .put("/api/v2/account/tags")
+      .send({
+        emailFromAuthToken: "test@permanent.org",
+        addTags: [1, 2, 4],
+        removeTags: ["tag3", "tag4"],
+      })
+      .expect(400);
+  });
+});

--- a/packages/api/src/account/index.ts
+++ b/packages/api/src/account/index.ts
@@ -1,1 +1,1 @@
-export { accountController } from "./controller";
+export { accountController } from "./controller/controller";

--- a/packages/api/src/account/service.test.ts
+++ b/packages/api/src/account/service.test.ts
@@ -1,149 +1,55 @@
-import { NotFound, InternalServerError } from "http-errors";
-import { Md5 } from "ts-md5";
-import { logger } from "@stela/logger";
-import { MailchimpMarketing } from "../mailchimp";
+import { InternalServerError } from "http-errors";
 import { db } from "../database";
 import { accountService } from "./service";
-import type { UpdateTagsRequest } from "./models";
 
 jest.mock("../database");
-jest.mock("../mailchimp", () => ({
-  MailchimpMarketing: {
-    lists: {
-      updateListMemberTags: jest.fn(),
-    },
-  },
-}));
-jest.mock("@stela/logger", () => ({
-  logger: {
-    error: jest.fn(),
-  },
-}));
 
 const loadFixtures = async (): Promise<void> => {
   await db.sql("account.fixtures.create_test_accounts");
   await db.sql("account.fixtures.create_test_invites");
+  await db.sql("account.fixtures.create_test_archives");
+  await db.sql("account.fixtures.create_test_account_archives");
 };
 
 const clearDatabase = async (): Promise<void> => {
-  await db.query("TRUNCATE account, invite CASCADE");
+  await db.query("TRUNCATE event, account_archive, account, archive CASCADE");
 };
 
-describe("updateTags", () => {
-  beforeEach(() => {
-    jest.clearAllMocks();
-  });
-
-  test("should call updateListMemberTags with the correct arguments", async () => {
-    const requestBody: UpdateTagsRequest = {
-      emailFromAuthToken: "test@permanent.org",
-      addTags: ["tag1", "tag2"],
-      removeTags: ["tag3", "tag4"],
-    };
-
-    const expectedTags = [
-      { name: "tag1", status: "active" },
-      { name: "tag2", status: "active" },
-      { name: "tag3", status: "inactive" },
-      { name: "tag4", status: "inactive" },
-    ];
-
-    const expectedListId = process.env["MAILCHIMP_COMMUNITY_LIST_ID"] ?? "";
-    const expectedSubscriberHash = Md5.hashStr(requestBody.emailFromAuthToken);
-
-    (
-      MailchimpMarketing.lists.updateListMemberTags as jest.MockedFunction<
-        typeof MailchimpMarketing.lists.updateListMemberTags
-      >
-    ).mockResolvedValue(null);
-
-    await accountService.updateTags(requestBody);
-
-    expect(MailchimpMarketing.lists.updateListMemberTags).toHaveBeenCalledWith(
-      expectedListId,
-      expectedSubscriberHash,
-      { tags: expectedTags }
-    );
-  });
-
-  test("should throw an error if MailChimp call fails", async () => {
-    (
-      MailchimpMarketing.lists.updateListMemberTags as jest.MockedFunction<
-        typeof MailchimpMarketing.lists.updateListMemberTags
-      >
-    ).mockResolvedValue({
-      detail: "Out of Cheese - Redo from Start",
-      status: 500,
-      type: "",
-      title: "",
-      instance: "",
-    });
-    let error = null;
-    try {
-      await accountService.updateTags({
-        emailFromAuthToken: "test@permanent.org",
-        addTags: ["tag1", "tag2"],
-        removeTags: ["tag3", "tag4"],
-      });
-    } catch (err) {
-      error = err;
-    } finally {
-      expect(error).not.toBeNull();
-    }
-  });
-});
-
-describe("getSignupDetails", () => {
+describe("getAccountArchive", () => {
   beforeEach(async () => {
     await clearDatabase();
     await loadFixtures();
   });
+
   afterEach(async () => {
-    jest.clearAllMocks();
     await clearDatabase();
   });
 
-  test("should return an account's signup details", async () => {
-    const signupDetails = await accountService.getSignupDetails(
+  test("should retrieve an account_archive record if it exists", async () => {
+    const accountArchive = await accountService.getAccountArchive(
+      "1",
       "test@permanent.org"
     );
-    expect(signupDetails.token).toEqual("earlyb1rd");
+    expect(accountArchive).toEqual({
+      accountArchiveId: "3",
+      accountId: "2",
+      accessRole: "access.role.owner",
+      type: "type.account.standard",
+      status: "status.generic.ok",
+    });
   });
 
-  test("should throw an error if the account does not exist", async () => {
+  test("should throw an internal server error if the database call fails", async () => {
+    jest
+      .spyOn(db, "sql")
+      .mockRejectedValue(new Error("Out of Cheese - Redo from Start"));
     let error = null;
     try {
-      await accountService.getSignupDetails("not_an_account@permanent.org");
+      await accountService.getAccountArchive("1", "test@permanent.org");
     } catch (err) {
       error = err;
     } finally {
-      expect(error instanceof NotFound).toBe(true);
-    }
-  });
-
-  test("should throw an error if the account has no signup details", async () => {
-    let error = null;
-    try {
-      await accountService.getSignupDetails("test+1@permanent.org");
-    } catch (err) {
-      error = err;
-    } finally {
-      expect(error instanceof NotFound).toBe(true);
-    }
-  });
-
-  test("should throw an error if database call fails unexpectedly", async () => {
-    let error = null;
-    try {
-      jest.spyOn(db, "sql").mockImplementationOnce((async () => {
-        throw new Error("out of cheese - redo from start");
-      }) as unknown as typeof db.sql);
-      await accountService.getSignupDetails("test@permanent.org");
-    } catch (err) {
-      error = err;
-    } finally {
-      expect(error instanceof InternalServerError).toBe(true);
-      expect(logger.error).toHaveBeenCalled();
+      expect(error).toBeInstanceOf(InternalServerError);
     }
   });
 });


### PR DESCRIPTION
Currently the tests for account related endpoints don't cover the controller. This commit updates them so they do, and also adds a few tests to cover previously untested paths.