### PR TITLE
Fix misleading Date types

### DIFF
--- a/packages/api/src/archive/models.ts
+++ b/packages/api/src/archive/models.ts
@@ -4,8 +4,8 @@ export interface Tag {
   archiveId: string;
   status: string;
   type: string;
-  createdDt: Date;
-  updatedDt: Date;
+  createdDt: string;
+  updatedDt: string;
 }
 
 export interface AccountStorage {
@@ -17,8 +17,8 @@ export interface AccountStorage {
   filesTotal: string;
   status: string;
   type: string;
-  createdDt: Date;
-  updatedDt: Date;
+  createdDt: string;
+  updatedDt: string;
 }
 
 export interface FeaturedArchive {

--- a/packages/api/src/directive/model.ts
+++ b/packages/api/src/directive/model.ts
@@ -23,20 +23,20 @@ export interface DirectiveTrigger {
   directiveTriggerId: string;
   directiveId: string;
   type: string;
-  createdDt: Date;
-  updatedDt: Date;
+  createdDt: string;
+  updatedDt: string;
 }
 
 export interface Directive {
   directiveId: string;
   archiveId: string;
   type: string;
-  createdDt: Date;
-  updatedDt: Date;
+  createdDt: string;
+  updatedDt: string;
   trigger: DirectiveTrigger;
   steward?: DirectiveSteward;
   note?: string;
-  executionDt?: Date;
+  executionDt?: string;
 }
 
 export interface DirectiveExecutionResult {

--- a/packages/api/src/legacy_contact/model.ts
+++ b/packages/api/src/legacy_contact/model.ts
@@ -15,6 +15,6 @@ export interface LegacyContact {
   accountId: string;
   name: string;
   email: string;
-  createdDt: Date;
-  updatedDt: Date;
+  createdDt: string;
+  updatedDt: string;
 }

--- a/packages/api/src/promo/models.ts
+++ b/packages/api/src/promo/models.ts
@@ -4,7 +4,7 @@ export interface CreatePromoRequest {
   code: string;
   storageInMB: number;
   expirationTimestamp: string;
-  totalUses: Date;
+  totalUses: number;
 }
 
 export interface Promo {
@@ -15,8 +15,8 @@ export interface Promo {
   remainingUses: number;
   status: string;
   type: string;
-  createdAt: Date;
-  updatedAt: Date;
+  createdAt: string;
+  updatedAt: string;
 }
 
 export interface PromoRow {
@@ -27,6 +27,6 @@ export interface PromoRow {
   remainingUses: string;
   status: string;
   type: string;
-  createdAt: Date;
-  updatedAt: Date;
+  createdAt: string;
+  updatedAt: string;
 }


### PR DESCRIPTION
There are a handful of interfaces in this repo that claim some of their fields are Dates, when in fact they are strings. Because the code never actually expects them to be dates, this doesn't cause errors, but it is confusing. This commit updates the types of such fields to string.