### PR TITLE
Trigger terraform validation on PR

### DIFF
--- a/.github/workflows/dev_validate_terraform.yml
+++ b/.github/workflows/dev_validate_terraform.yml
@@ -2,7 +2,7 @@ name: Validate Terraform (test envs)
 on:
   push:
     paths:
-      - ./terraform/test_cluster/**
+      - terraform/test_cluster/**
 jobs:
   validate_terraform:
     name: "Validate Terraform"

--- a/.github/workflows/prod_validate_terraform.yml
+++ b/.github/workflows/prod_validate_terraform.yml
@@ -2,7 +2,7 @@ name: Validate Terraform (prod)
 on:
   push:
     paths:
-      - ./terraform/prod_cluster/**
+      - terraform/prod_cluster/**
 jobs:
   validate_terraform:
     name: "Validate Terraform"


### PR DESCRIPTION
Currently, terraform validation Github actions trigger only when changes to the terraform code are merge to main. We'd like to know about validation errors before this, so this commit updates the actions to also run when we create PRs changing the terraform code.