### PR TITLE
Add SITE_URL env var

### DIFF
--- a/terraform/prod_cluster/stela_prod_deployment.tf
+++ b/terraform/prod_cluster/stela_prod_deployment.tf
@@ -207,6 +207,11 @@ resource "kubernetes_deployment" "stela_prod" {
             value = var.new_relic_app_name
           }
 
+          env {
+            name  = "SITE_URL"
+            value = var.site_url
+          }
+
           port {
             container_port = 80
           }

--- a/terraform/prod_cluster/variables.tf
+++ b/terraform/prod_cluster/variables.tf
@@ -211,3 +211,9 @@ variable "backblaze_bucket" {
   description = "The name of the Backblaze bucket where files are stored"
   type        = string
 }
+
+variable "site_url" {
+  description = "The URL of the site"
+  type        = string
+  default     = "www.permanent.org"
+}

--- a/terraform/test_cluster/stela_dev_deployment.tf
+++ b/terraform/test_cluster/stela_dev_deployment.tf
@@ -207,6 +207,11 @@ resource "kubernetes_deployment" "stela_dev" {
             value = var.dev_new_relic_app_name
           }
 
+          env {
+            name  = "SITE_URL"
+            value = var.dev_site_url
+          }
+
           port {
             container_port = 80
           }

--- a/terraform/test_cluster/stela_staging_deployment.tf
+++ b/terraform/test_cluster/stela_staging_deployment.tf
@@ -207,6 +207,11 @@ resource "kubernetes_deployment" "stela_staging" {
             value = var.staging_new_relic_app_name
           }
 
+          env {
+            name  = "SITE_URL"
+            value = var.staging_site_url
+          }
+
           port {
             container_port = 80
           }

--- a/terraform/test_cluster/variables.tf
+++ b/terraform/test_cluster/variables.tf
@@ -359,3 +359,15 @@ variable "staging_backblaze_bucket" {
   description = "Name of the Backblaze bucket where files are stored in staging"
   type        = string
 }
+
+variable "dev_site_url" {
+  description = "URL of the dev site"
+  type        = string
+  default     = "dev.permanent.org"
+}
+
+variable "staging_site_url" {
+  description = "URL of the staging site"
+  type        = string
+  default     = "staging.permanent.org"
+}


### PR DESCRIPTION
The previous commit, which adds the POST /share-links endpoint, requires a SITE_URL env var in order to construct share links. This commit adds that env var to our terraform configuration.