### PR TITLE
Add PATCH /share-links endpoint

### DIFF
--- a/packages/api/src/share_link/controller.test.ts
+++ b/packages/api/src/share_link/controller.test.ts
@@ -19,6 +19,7 @@ const loadFixtures = async (): Promise<void> => {
   await db.sql("share_link.fixtures.create_test_records");
   await db.sql("share_link.fixtures.create_test_folders");
   await db.sql("share_link.fixtures.create_test_folder_links");
+  await db.sql("share_link.fixtures.create_test_shareby_urls");
 };
 
 const clearDatabase = async (): Promise<void> => {
@@ -329,5 +330,239 @@ describe("POST /share-links", () => {
       .post("/api/v2/share-links")
       .send({ itemId: "4", itemType: "record" })
       .expect(403);
+  });
+});
+
+describe("PATCH /share-links/{id}", () => {
+  const agent = request(app);
+
+  beforeEach(async () => {
+    (verifyUserAuthentication as jest.Mock).mockImplementation(
+      (req: Request, _, next: NextFunction) => {
+        (
+          req.body as {
+            emailFromAuthToken: string;
+            userSubjectFromAuthToken: string;
+          }
+        ).emailFromAuthToken = "test@permanent.org";
+        (
+          req.body as {
+            emailFromAuthToken: string;
+            userSubjectFromAuthToken: string;
+          }
+        ).userSubjectFromAuthToken = "315aedc2-67d5-4144-9f0d-ee547d98af9c";
+        next();
+      }
+    );
+
+    await loadFixtures();
+  });
+
+  afterEach(async () => {
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+    await clearDatabase();
+  });
+
+  test("should return 200 for a valid request", async () => {
+    await agent
+      .patch("/api/v2/share-links/1000")
+      .send({ expirationTimestamp: "2032-10-10" })
+      .expect(200);
+  });
+
+  test("should return 401 if the caller is unauthenticated", async () => {
+    (verifyUserAuthentication as jest.Mock).mockImplementation(
+      (_: Request, __: Response, next: NextFunction) => {
+        next(new createError.Unauthorized("Invalid token"));
+      }
+    );
+    await agent.patch("/api/v2/share-links/1").send({}).expect(401);
+  });
+
+  test("should return 404 the caller is not the creator of the share link", async () => {
+    (verifyUserAuthentication as jest.Mock).mockImplementation(
+      (req: Request, _, next: NextFunction) => {
+        (
+          req.body as {
+            emailFromAuthToken: string;
+            userSubjectFromAuthToken: string;
+          }
+        ).emailFromAuthToken = "test+1@permanent.org";
+        (
+          req.body as {
+            emailFromAuthToken: string;
+            userSubjectFromAuthToken: string;
+          }
+        ).userSubjectFromAuthToken = "315aedc2-67d5-4144-9f0d-ee547d98af9c";
+        next();
+      }
+    );
+    await agent
+      .patch("/api/v2/share-links/1000")
+      .send({ permissionsLevel: "viewer" })
+      .expect(404);
+  });
+
+  test("should return 400 if the request is invalid", async () => {
+    await agent
+      .patch("/api/v2/share-links/1")
+      .send({ maxUses: -1 })
+      .expect(400);
+  });
+
+  test("should return 400 if the request attempts to set maxUses on an unlisted link", async () => {
+    await agent
+      .patch("/api/v2/share-links/1000")
+      .send({ maxUses: 100 })
+      .expect(400);
+  });
+
+  test("should return 400 if the request attempts to set permissionsLevel above 'viewer' on an unlisted link", async () => {
+    await agent
+      .patch("/api/v2/share-links/1000")
+      .send({ permissionsLevel: "owner" })
+      .expect(400);
+  });
+
+  test("should return 400 if the request attempts to set a link with maxUses set to be unlisted", async () => {
+    await agent
+      .patch("/api/v2/share-links/1001")
+      .send({ accessRestrictions: "none" })
+      .expect(400);
+  });
+
+  test("should return 400 if the request attempts to set a link where permissionsLevel != 'viewer to be unlisted", async () => {
+    await agent
+      .patch("/api/v2/share-links/1002")
+      .send({ accessRestrictions: "none" })
+      .expect(400);
+  });
+
+  test("should allow maxUses and permissionsLevel != 'viewer' if updating accessRestrictions to something other than 'none'", async () => {
+    await agent
+      .patch("/api/v2/share-links/1000")
+      .send({
+        permissionsLevel: "owner",
+        maxUses: 100,
+        accessRestrictions: "account",
+      })
+      .expect(200);
+  });
+
+  test("should update provided fields", async () => {
+    await agent
+      .patch("/api/v2/share-links/1000")
+      .send({
+        accessRestrictions: "account",
+        permissionsLevel: "editor",
+        maxUses: 500,
+        expirationTimestamp: "2052-01-01T00:00:00.000Z",
+      })
+      .expect(200);
+
+    const shareLink = await retrieveShareLink("5");
+    expect(shareLink?.maxuses).toEqual("500");
+    expect(shareLink?.unrestricted).toEqual(false);
+    expect(shareLink?.autoapprovetoggle).toEqual(1);
+    expect(shareLink?.defaultaccessrole).toEqual("access.role.editor");
+    expect(shareLink?.expiresdt).toEqual(new Date("2052-01-01T00:00:00.000Z"));
+  });
+
+  test("should update nullable fields to null if request sets them to explicit null", async () => {
+    await agent
+      .patch("/api/v2/share-links/1001")
+      .send({
+        maxUses: null,
+        expirationTimestamp: null,
+      })
+      .expect(200);
+
+    const shareLink = await retrieveShareLink("6");
+    expect(shareLink?.maxuses).toBeNull();
+    expect(shareLink?.expiresdt).toBeNull();
+  });
+
+  test("should not update fields if they aren't set in the request", async () => {
+    await agent
+      .patch("/api/v2/share-links/1001")
+      .send({
+        permissionsLevel: "editor",
+      })
+      .expect(200);
+
+    const shareLink = await retrieveShareLink("6");
+    expect(shareLink?.maxuses).not.toBeNull();
+    expect(shareLink?.expiresdt).not.toBeNull();
+    expect(shareLink?.defaultaccessrole).toEqual("access.role.editor");
+    expect(shareLink?.unrestricted).toEqual(false);
+    expect(shareLink?.autoapprovetoggle).toEqual(0);
+  });
+
+  test("should return 400 if the request is empty", async () => {
+    await agent.patch("/api/v2/share-links/1001").send().expect(400);
+  });
+
+  test("should return 400 is not parseable json", async () => {
+    await agent
+      .patch("/api/v2/share-links/1001")
+      .send("{'this_object': 'is_missing_a_closing_brace'")
+      .expect(400);
+  });
+
+  test("should return the updated share link", async () => {
+    const response = await agent
+      .patch("/api/v2/share-links/1000")
+      .send({
+        accessRestrictions: "account",
+        permissionsLevel: "editor",
+        maxUses: 500,
+        expirationTimestamp: "2052-01-01T00:00:00.000Z",
+      })
+      .expect(200);
+
+    const shareLink = (response.body as { data: ShareLink }).data;
+    expect(shareLink.accessRestrictions).toEqual("account");
+    expect(shareLink.permissionsLevel).toEqual("editor");
+    expect(shareLink.maxUses).toEqual(500);
+    expect(shareLink.expirationTimestamp).toEqual("2052-01-01T00:00:00.000Z");
+  });
+
+  test("should return 500 if the query to retrieve the share link fails", async () => {
+    jest.spyOn(db, "sql").mockRejectedValue(new Error("Test error"));
+    await agent
+      .patch("/api/v2/share-links/1000")
+      .send({
+        accessRestrictions: "account",
+        permissionsLevel: "editor",
+        maxUses: 500,
+        expirationTimestamp: "2052-01-01T00:00:00.000Z",
+      })
+      .expect(500);
+  });
+
+  test("should return 500 if the query to update the share link fails", async () => {
+    const dbSpy = jest.spyOn(db, "sql");
+    when(dbSpy)
+      .calledWith("share_link.queries.update_share_link", {
+        permissionsLevel: "access.role.editor",
+        unlisted: false,
+        noApproval: 1,
+        maxUses: 500,
+        setMaxUsesToNull: false,
+        expirationTimestamp: undefined,
+        setExpirationTimestampToNull: false,
+        shareLinkId: "1000",
+        email: "test@permanent.org",
+      })
+      .mockRejectedValue(new Error("Test error"));
+    await agent
+      .patch("/api/v2/share-links/1000")
+      .send({
+        accessRestrictions: "account",
+        permissionsLevel: "editor",
+        maxUses: 500,
+      })
+      .expect(500);
   });
 });

--- a/packages/api/src/share_link/controller.ts
+++ b/packages/api/src/share_link/controller.ts
@@ -1,7 +1,10 @@
 import { Router } from "express";
 import type { Request, Response, NextFunction } from "express";
 import { verifyUserAuthentication } from "../middleware";
-import { validateCreateShareLinkRequest } from "./validators";
+import {
+  validateCreateShareLinkRequest,
+  validateUpdateShareLinkRequest,
+} from "./validators";
 import { isValidationError } from "../validators/validator_util";
 import { shareLinkService } from "./service";
 
@@ -15,6 +18,27 @@ shareLinkController.post(
       validateCreateShareLinkRequest(req.body);
       const response = await shareLinkService.createShareLink(req.body);
       res.status(201).json({ data: response });
+    } catch (err) {
+      if (isValidationError(err)) {
+        res.status(400).json({ error: err });
+        return;
+      }
+      next(err);
+    }
+  }
+);
+
+shareLinkController.patch(
+  "/:shareLinkId",
+  verifyUserAuthentication,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      validateUpdateShareLinkRequest(req.body);
+      const updatedShareLink = await shareLinkService.updateShareLink(
+        req.params["shareLinkId"] ?? "",
+        req.body
+      );
+      res.status(200).json({ data: updatedShareLink });
     } catch (err) {
       if (isValidationError(err)) {
         res.status(400).json({ error: err });

--- a/packages/api/src/share_link/fixtures/create_test_folder_links.sql
+++ b/packages/api/src/share_link/fixtures/create_test_folder_links.sql
@@ -58,4 +58,40 @@ VALUES
   'access.role.owner',
   'status.generic.ok',
   'type.folder_link.public'
+),
+(
+  5,
+  6,
+  NULL,
+  5,
+  NULL,
+  1,
+  1,
+  'access.role.owner',
+  'status.generic.ok',
+  'type.folder_link.private'
+),
+(
+  6,
+  7,
+  NULL,
+  5,
+  NULL,
+  1,
+  1,
+  'access.role.owner',
+  'status.generic.ok',
+  'type.folder_link.private'
+),
+(
+  7,
+  8,
+  NULL,
+  5,
+  NULL,
+  1,
+  1,
+  'access.role.owner',
+  'status.generic.ok',
+  'type.folder_link.private'
 );

--- a/packages/api/src/share_link/fixtures/create_test_records.sql
+++ b/packages/api/src/share_link/fixtures/create_test_records.sql
@@ -59,4 +59,40 @@ VALUES
   'public.jpg',
   'status.generic.ok',
   'type.record.image'
+),
+(
+  6,
+  1,
+  NULL,
+  NULL,
+  'Private File',
+  2,
+  2,
+  'private_file.jpg',
+  'status.generic.ok',
+  'type.record.image'
+),
+(
+  7,
+  1,
+  NULL,
+  NULL,
+  'Private File',
+  2,
+  2,
+  'private_file.jpg',
+  'status.generic.ok',
+  'type.record.image'
+),
+(
+  8,
+  1,
+  NULL,
+  NULL,
+  'Private File',
+  2,
+  2,
+  'private_file.jpg',
+  'status.generic.ok',
+  'type.record.image'
 );

--- a/packages/api/src/share_link/fixtures/create_test_shareby_urls.sql
+++ b/packages/api/src/share_link/fixtures/create_test_shareby_urls.sql
@@ -1,0 +1,51 @@
+INSERT INTO shareby_url (
+  shareby_urlid,
+  folder_linkid,
+  urltoken,
+  shareurl,
+  byaccountid,
+  byarchiveid,
+  unrestricted,
+  maxuses,
+  expiresdt,
+  defaultaccessrole,
+  autoapprovetoggle
+) VALUES (
+  1000,
+  5,
+  'e969f9dc-42b5-45c0-a496-1dcff2ca11f5',
+  'https://local.permanent.org/share/e969f9dc-42b5-45c0-a496-1dcff2ca11f5',
+  2,
+  1,
+  true,
+  null,
+  null,
+  'access.role.viewer',
+  0
+),
+(
+  1001,
+  6,
+  '0fcb840f-d22c-4a51-a358-2a61677e8fb2',
+  'https://local.permanent.org/share/0fcb840f-d22c-4a51-a358-2a61677e8fb2',
+  2,
+  1,
+  false,
+  100,
+  CURRENT_TIMESTAMP + INTERVAL '1 day',
+  'access.role.viewer',
+  0
+),
+(
+  1002,
+  7,
+  'd188df4b-7839-4d08-882f-78dc8988d864',
+  'https://local.permanent.org/share/d188df4b-7839-4d08-882f-78dc8988d864',
+  2,
+  1,
+  false,
+  100,
+  CURRENT_TIMESTAMP + INTERVAL '1 day',
+  'access.role.editor',
+  0
+);

--- a/packages/api/src/share_link/models.ts
+++ b/packages/api/src/share_link/models.ts
@@ -8,6 +8,14 @@ export interface CreateShareLinkRequest {
   expirationTimestamp?: string;
 }
 
+export interface UpdateShareLinkRequest {
+  emailFromAuthToken: string;
+  permissionsLevel?: "contributor" | "editor" | "manager" | "owner" | "viewer";
+  accessRestrictions?: "account" | "approval" | "none";
+  maxUses?: number | null;
+  expirationTimestamp?: string | null;
+}
+
 export interface ShareLink {
   id: string;
   itemId: string;

--- a/packages/api/src/share_link/queries/get_share_link.sql
+++ b/packages/api/src/share_link/queries/get_share_link.sql
@@ -1,0 +1,35 @@
+SELECT
+  shareby_url.shareby_urlid AS "id",
+  shareby_url.urltoken AS "token",
+  shareby_url.uses AS "usesExpended",
+  shareby_url.expiresdt AS "expirationTimestamp",
+  shareby_url.createddt AS "createdAt",
+  shareby_url.updateddt AS "updatedAt",
+  substring(
+    shareby_url.defaultaccessrole FROM (length('access.role.') + 1)
+  ) AS "permissionsLevel",
+  CASE
+    WHEN shareby_url.maxuses = 0 THEN NULL
+    ELSE shareby_url.maxuses
+  END AS "maxUses",
+  coalesce(folder_link.recordid, folder_link.folderid) AS "itemId",
+  CASE
+    WHEN folder_link.recordid IS NOT NULL THEN 'record'
+    ELSE 'folder'
+  END AS "itemType",
+  CASE
+    WHEN shareby_url.unrestricted THEN 'none'
+    WHEN shareby_url.autoapprovetoggle = 1 THEN 'account'
+    ELSE 'approval'
+  END AS "accessRestrictions"
+FROM
+  shareby_url
+INNER JOIN
+  account
+  ON shareby_url.byaccountid = account.accountid
+INNER JOIN
+  folder_link
+  ON shareby_url.folder_linkid = folder_link.folder_linkid
+WHERE
+  shareby_url.shareby_urlid = :shareLinkId
+  AND account.primaryemail = :email;

--- a/packages/api/src/share_link/queries/update_share_link.sql
+++ b/packages/api/src/share_link/queries/update_share_link.sql
@@ -1,0 +1,45 @@
+UPDATE
+shareby_url
+SET
+  defaultaccessrole = COALESCE(:permissionsLevel, defaultaccessrole),
+  unrestricted = COALESCE(:unlisted, unrestricted),
+  autoapprovetoggle = COALESCE(:noApproval, autoapprovetoggle),
+  maxuses = CASE
+    WHEN :setMaxUsesToNull THEN NULL
+    ELSE COALESCE(:maxUses, maxuses)
+  END,
+  expiresdt = CASE
+    WHEN :setExpirationTimestampToNull THEN NULL
+    ELSE COALESCE(:expirationTimestamp, expiresdt)
+  END
+FROM
+  account, folder_link
+WHERE
+  shareby_urlid = :shareLinkId
+  AND account.accountid = shareby_url.byaccountid
+  AND account.primaryemail = :email
+  AND folder_link.folder_linkid = shareby_url.folder_linkid
+RETURNING
+shareby_url.shareby_urlid AS "id",
+COALESCE(folder_link.recordid, folder_link.folderid) AS "itemId",
+CASE
+  WHEN folder_link.recordid IS NOT NULL THEN 'record'
+  ELSE 'folder'
+END AS "itemType",
+shareby_url.urltoken AS "token",
+SUBSTRING(
+  shareby_url.defaultaccessrole FROM (LENGTH('access.role.') + 1)
+) AS "permissionsLevel",
+CASE
+  WHEN shareby_url.unrestricted THEN 'none'
+  WHEN shareby_url.autoapprovetoggle = 0 THEN 'approval'
+  ELSE 'account'
+END AS "accessRestrictions",
+CASE
+  WHEN shareby_url.maxuses = 0 THEN NULL
+  ELSE shareby_url.maxuses
+END AS "maxUses",
+shareby_url.uses AS "usesExpended",
+shareby_url.expiresdt AS "expirationTimestamp",
+shareby_url.createddt AS "createdAt",
+shareby_url.updateddt AS "updatedAt";

--- a/packages/api/src/share_link/validators.test.ts
+++ b/packages/api/src/share_link/validators.test.ts
@@ -1,4 +1,7 @@
-import { validateCreateShareLinkRequest } from "./validators";
+import {
+  validateCreateShareLinkRequest,
+  validateUpdateShareLinkRequest,
+} from "./validators";
 
 describe("validateCreateShareLinkRequest", () => {
   test("should find no errors in a valid request", () => {
@@ -511,6 +514,339 @@ describe("validateCreateShareLinkRequest", () => {
         userSubjectFromAuthToken: "1129f5a8-7b9c-4211-ae59-dd83faad2455",
         itemId: "315aedc2-67d5-4144-9f0d-ee547d98af9c",
         itemType: "record",
+        permissionsLevel: "owner",
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+});
+
+describe("validateUpdateShareLinkRequest", () => {
+  test("should find no errors in a valid request", () => {
+    let error = null;
+    try {
+      validateUpdateShareLinkRequest({
+        emailFromAuthToken: "test@permanent.org",
+        userSubjectFromAuthToken: "1129f5a8-7b9c-4211-ae59-dd83faad2455",
+        permissionsLevel: "viewer",
+        accessRestrictions: "account",
+        expirationTimestamp: "2030-12-31",
+        maxUses: 100,
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).toBeNull();
+    }
+  });
+  test("should error if emailFromAuthToken is missing", () => {
+    let error = null;
+    try {
+      validateUpdateShareLinkRequest({
+        userSubjectFromAuthToken: "1129f5a8-7b9c-4211-ae59-dd83faad2455",
+        permissionsLevel: "viewer",
+        accessRestrictions: "account",
+        expirationTimestamp: "2030-12-31",
+        maxUses: 100,
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+  test("should error if userSubjectFromAuthToken is missing", () => {
+    let error = null;
+    try {
+      validateUpdateShareLinkRequest({
+        emailFromAuthToken: "test@permanent.org",
+        permissionsLevel: "viewer",
+        accessRestrictions: "account",
+        expirationTimestamp: "2030-12-31",
+        maxUses: 100,
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+  test("should error if all fields are missing", () => {
+    let error = null;
+    try {
+      validateUpdateShareLinkRequest({
+        emailFromAuthToken: "test@permanent.org",
+        userSubjectFromAuthToken: "1129f5a8-7b9c-4211-ae59-dd83faad2455",
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+  test("should error if permissionsLevel is not a string", () => {
+    let error = null;
+    try {
+      validateUpdateShareLinkRequest({
+        emailFromAuthToken: "test@permanent.org",
+        userSubjectFromAuthToken: "1129f5a8-7b9c-4211-ae59-dd83faad2455",
+        permissionsLevel: 1,
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+  test("should error if permissionsLevel is an invalid value", () => {
+    let error = null;
+    try {
+      validateUpdateShareLinkRequest({
+        emailFromAuthToken: "test@permanent.org",
+        userSubjectFromAuthToken: "1129f5a8-7b9c-4211-ae59-dd83faad2455",
+        permissionsLevel: "admin",
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+  test("should error if permissionsLevel is null", () => {
+    let error = null;
+    try {
+      validateUpdateShareLinkRequest({
+        emailFromAuthToken: "test@permanent.org",
+        userSubjectFromAuthToken: "1129f5a8-7b9c-4211-ae59-dd83faad2455",
+        permissionsLevel: null,
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+  test("should not error if permissionsLevel is missing", () => {
+    let error = null;
+    try {
+      validateUpdateShareLinkRequest({
+        emailFromAuthToken: "test@permanent.org",
+        userSubjectFromAuthToken: "1129f5a8-7b9c-4211-ae59-dd83faad2455",
+        maxUses: null,
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).toBeNull();
+    }
+  });
+  test("should error if accessRestrictions is not a string", () => {
+    let error = null;
+    try {
+      validateUpdateShareLinkRequest({
+        emailFromAuthToken: "test@permanent.org",
+        userSubjectFromAuthToken: "1129f5a8-7b9c-4211-ae59-dd83faad2455",
+        accessRestrictions: 1,
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+  test("should error if accessRestrictions is an invalid value", () => {
+    let error = null;
+    try {
+      validateUpdateShareLinkRequest({
+        emailFromAuthToken: "test@permanent.org",
+        userSubjectFromAuthToken: "1129f5a8-7b9c-4211-ae59-dd83faad2455",
+        accessRestrictions: "all",
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+  test("should error if accessRestrictions is null", () => {
+    let error = null;
+    try {
+      validateUpdateShareLinkRequest({
+        emailFromAuthToken: "test@permanent.org",
+        userSubjectFromAuthToken: "1129f5a8-7b9c-4211-ae59-dd83faad2455",
+        accessRestrictions: null,
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+  test("should not error if accessRestrictions is missing", () => {
+    let error = null;
+    try {
+      validateUpdateShareLinkRequest({
+        emailFromAuthToken: "test@permanent.org",
+        userSubjectFromAuthToken: "1129f5a8-7b9c-4211-ae59-dd83faad2455",
+        maxUses: null,
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).toBeNull();
+    }
+  });
+  test("should error if expirationTimestamp is not a string", () => {
+    let error = null;
+    try {
+      validateUpdateShareLinkRequest({
+        emailFromAuthToken: "test@permanent.org",
+        userSubjectFromAuthToken: "1129f5a8-7b9c-4211-ae59-dd83faad2455",
+        expirationTimestamp: 1,
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+  test("should error if expirationTimestamp is the wrong format", () => {
+    let error = null;
+    try {
+      validateUpdateShareLinkRequest({
+        emailFromAuthToken: "test@permanent.org",
+        userSubjectFromAuthToken: "1129f5a8-7b9c-4211-ae59-dd83faad2455",
+        expirationTimestamp: "not_a_date",
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+  test("should accept expirationTimestamp = null", () => {
+    let error = null;
+    try {
+      validateUpdateShareLinkRequest({
+        emailFromAuthToken: "test@permanent.org",
+        userSubjectFromAuthToken: "1129f5a8-7b9c-4211-ae59-dd83faad2455",
+        expirationTimestamp: null,
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).toBeNull();
+    }
+  });
+  test("should not error if expirationTimestamp missing", () => {
+    let error = null;
+    try {
+      validateUpdateShareLinkRequest({
+        emailFromAuthToken: "test@permanent.org",
+        userSubjectFromAuthToken: "1129f5a8-7b9c-4211-ae59-dd83faad2455",
+        maxUses: null,
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).toBeNull();
+    }
+  });
+  test("should error if maxUses is not a number", () => {
+    let error = null;
+    try {
+      validateUpdateShareLinkRequest({
+        emailFromAuthToken: "test@permanent.org",
+        userSubjectFromAuthToken: "1129f5a8-7b9c-4211-ae59-dd83faad2455",
+        maxUses: "one",
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+  test("should error if maxUses is not an integer", () => {
+    let error = null;
+    try {
+      validateUpdateShareLinkRequest({
+        emailFromAuthToken: "test@permanent.org",
+        userSubjectFromAuthToken: "1129f5a8-7b9c-4211-ae59-dd83faad2455",
+        maxUses: 2.5,
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+  test("should error if maxUses is less than one", () => {
+    let error = null;
+    try {
+      validateUpdateShareLinkRequest({
+        emailFromAuthToken: "test@permanent.org",
+        userSubjectFromAuthToken: "1129f5a8-7b9c-4211-ae59-dd83faad2455",
+        maxUses: 0,
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+  test("should accept maxUses=null", () => {
+    let error = null;
+    try {
+      validateUpdateShareLinkRequest({
+        emailFromAuthToken: "test@permanent.org",
+        userSubjectFromAuthToken: "1129f5a8-7b9c-4211-ae59-dd83faad2455",
+        maxUses: null,
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).toBeNull();
+    }
+  });
+  test("should not error if maxUses is missing", () => {
+    let error = null;
+    try {
+      validateUpdateShareLinkRequest({
+        emailFromAuthToken: "test@permanent.org",
+        userSubjectFromAuthToken: "1129f5a8-7b9c-4211-ae59-dd83faad2455",
+        expirationTimestamp: null,
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).toBeNull();
+    }
+  });
+  test("should error if request tries to create an unrestricted link with limited uses", () => {
+    let error = null;
+    try {
+      validateUpdateShareLinkRequest({
+        emailFromAuthToken: "test@permanent.org",
+        userSubjectFromAuthToken: "1129f5a8-7b9c-4211-ae59-dd83faad2455",
+        accessRestrictions: "none",
+        maxUses: 100,
+      });
+    } catch (err) {
+      error = err;
+    } finally {
+      expect(error).not.toBeNull();
+    }
+  });
+  test("should error if request tries to create an unrestricted link with permissions higher than 'viewer'", () => {
+    let error = null;
+    try {
+      validateUpdateShareLinkRequest({
+        emailFromAuthToken: "test@permanent.org",
+        userSubjectFromAuthToken: "1129f5a8-7b9c-4211-ae59-dd83faad2455",
+        accessRestrictions: "none",
         permissionsLevel: "owner",
       });
     } catch (err) {


### PR DESCRIPTION
We need to update our share link endpoints to support unlisted links, and this is a good opportunity to migrate these endpoints to stela. To that end, this commit adds a PATCH endpoint for share links which supports unlisted links.