### PR TITLE
Use established access role enums for share links at the database level

### DIFF
--- a/packages/api/src/share_link/controller.test.ts
+++ b/packages/api/src/share_link/controller.test.ts
@@ -164,7 +164,7 @@ describe("POST /share-links", () => {
     expect(shareLink?.uses).toBeNull();
     expect(shareLink?.unrestricted).toEqual(true);
     expect(shareLink?.autoapprovetoggle).toEqual(1);
-    expect(shareLink?.defaultaccessrole).toEqual("viewer");
+    expect(shareLink?.defaultaccessrole).toEqual("access.role.viewer");
     expect(shareLink?.expiresdt).toBeNull();
     expect(shareLink?.byaccountid).toEqual("2");
     expect(shareLink?.byarchiveid).toEqual("1");
@@ -187,7 +187,7 @@ describe("POST /share-links", () => {
     expect(shareLink?.maxuses).toEqual("5");
     expect(shareLink?.unrestricted).toEqual(false);
     expect(shareLink?.autoapprovetoggle).toEqual(0);
-    expect(shareLink?.defaultaccessrole).toEqual("editor");
+    expect(shareLink?.defaultaccessrole).toEqual("access.role.editor");
     expect(shareLink?.expiresdt).toEqual(new Date("2022-01-01T00:00:00.000Z"));
   });
 
@@ -264,7 +264,7 @@ describe("POST /share-links", () => {
       .calledWith("share_link.queries.create_share_link", {
         itemId: "2",
         itemType: "record",
-        permissionsLevel: "viewer",
+        permissionsLevel: "access.role.viewer",
         unlisted: true,
         noApproval: 1,
         maxUses: 0,
@@ -289,7 +289,7 @@ describe("POST /share-links", () => {
       .calledWith("share_link.queries.create_share_link", {
         itemId: "2",
         itemType: "record",
-        permissionsLevel: "viewer",
+        permissionsLevel: "access.role.viewer",
         unlisted: true,
         noApproval: 1,
         maxUses: 0,

--- a/packages/api/src/share_link/queries/create_share_link.sql
+++ b/packages/api/src/share_link/queries/create_share_link.sql
@@ -36,7 +36,9 @@ shareby_urlid AS "id",
 :itemId AS "itemId",
 :itemType AS "itemType",
 urltoken AS "token",
-defaultaccessrole AS "permissionsLevel",
+SUBSTRING(
+  defaultaccessrole FROM (LENGTH('access.role.') + 1)
+) AS "permissionsLevel",
 CASE
   WHEN unrestricted THEN 'none'
   WHEN autoapprovetoggle = 1 THEN 'account'

--- a/packages/api/src/share_link/service.ts
+++ b/packages/api/src/share_link/service.ts
@@ -36,7 +36,7 @@ const createShareLink = async (
     .sql<ShareLink>("share_link.queries.create_share_link", {
       itemId: data.itemId,
       itemType: data.itemType,
-      permissionsLevel: data.permissionsLevel ?? "viewer",
+      permissionsLevel: `access.role.${data.permissionsLevel ?? "viewer"}`,
       unlisted:
         (data.accessRestrictions === "none" ||
           data.accessRestrictions === undefined) &&


### PR DESCRIPTION
The initial implementation of POST /share-links used a different format for defaultAccessRole than is currently used in the database; this commit updates it to remain consistent with the database, while still offering a friendlier expression of that enum to end users.