### PR TITLE
Get folders without folder_size from GET /folder

### DIFF
--- a/packages/api/docs/future/models/folder.yaml
+++ b/packages/api/docs/future/models/folder.yaml
@@ -16,7 +16,6 @@ folder:
   type: object
   required:
     - id
-    - size
     - displayName
     - archive
     - status

--- a/packages/api/src/folder/controller.test.ts
+++ b/packages/api/src/folder/controller.test.ts
@@ -663,12 +663,13 @@ describe("GET /folder/{id}", () => {
     expect(folders.length).toEqual(0);
   });
 
-  test("should not retrieve a folder with a deleted folder_size", async () => {
+  test("should omit size from a folder with a deleted folder_size", async () => {
     const response = await agent
       .get("/api/v2/folder?folderIds[]=7")
       .expect(200);
     const folders = (response.body as { items: Folder[] }).items;
-    expect(folders.length).toEqual(0);
+    expect(folders.length).toEqual(1);
+    expect(folders[0]?.size).toBeNull();
   });
 
   test("should throw a 500 error if database call fails", async () => {

--- a/packages/api/src/folder/models.ts
+++ b/packages/api/src/folder/models.ts
@@ -3,7 +3,7 @@ import type { Tag } from "../tag/models";
 
 export interface FolderRow {
   folderId: string;
-  size: string;
+  size: string | null;
   location?: Location;
   parentFolder?: {
     id: string;
@@ -56,7 +56,7 @@ export interface Location {
 
 export interface Folder {
   folderId: string;
-  size: number;
+  size: number | null;
   location?: Location;
   parentFolder?: {
     id: string;

--- a/packages/api/src/folder/queries/get_folders.sql
+++ b/packages/api/src/folder/queries/get_folders.sql
@@ -253,7 +253,7 @@ INNER JOIN
   ON
     folder.folderid = folder_link.folderid
     AND folder_link.status != 'status.generic.deleted'
-INNER JOIN
+LEFT JOIN
   folder_size
   ON
     folder.folderid = folder_size.folderid

--- a/packages/api/src/folder/service.ts
+++ b/packages/api/src/folder/service.ts
@@ -116,7 +116,7 @@ export const getFolders = async (
   const folders = result.rows.map<Folder>(
     (row: FolderRow): Folder => ({
       ...row,
-      size: +row.size,
+      size: row.size !== null ? +row.size : null,
       imageRatio: +(row.imageRatio ?? 0),
       sort: prettifyFolderSortType(row.sort),
       type: prettifyFolderType(row.type),


### PR DESCRIPTION
Folder size is calculated asynchronously, which means there are times folders exist without a corresponding folder_size. This commit updates GET /folder to return such folders (with size set to null).