### PR TITLE
Update Github Action runners to Ubuntu 24.04

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
   build_api:
     needs:
       - generate_image_tags
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       API_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.API_IMAGE_TAG }}
     steps:
@@ -29,7 +29,7 @@ jobs:
   build_am_cleanup:
     needs:
       - generate_image_tags
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       AM_CLEANUP_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.AM_CLEANUP_IMAGE_TAG }}
     steps:
@@ -47,7 +47,7 @@ jobs:
   build_record_thumbnail_lambda:
     needs:
       - generate_image_tags
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG }}
     steps:
@@ -67,7 +67,7 @@ jobs:
   build_thumbnail_refresh:
     needs:
       - generate_image_tags
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       THUMBNAIL_REFRESH_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.THUMBNAIL_REFRESH_IMAGE_TAG }}
     steps:
@@ -87,7 +87,7 @@ jobs:
   build_access_copy_lambda:
     needs:
       - generate_image_tags
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       ACCESS_COPY_LAMBDA_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.ACCESS_COPY_LAMBDA_IMAGE_TAG }}
     steps:
@@ -107,7 +107,7 @@ jobs:
   build_account_space_updater:
     needs:
       - generate_image_tags
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       ACCOUNT_SPACE_UPDATER_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.ACCOUNT_SPACE_UPDATER_IMAGE_TAG }}
     steps:

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -22,7 +22,7 @@ jobs:
       - run_tests
       - build_images
       - generate_image_tags
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       API_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.API_IMAGE_TAG }}
       AM_CLEANUP_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.AM_CLEANUP_IMAGE_TAG }}

--- a/.github/workflows/dev_validate_terraform.yml
+++ b/.github/workflows/dev_validate_terraform.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   validate_terraform:
     name: "Validate Terraform"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: ./terraform/test_cluster

--- a/.github/workflows/full_test_deploy.yml
+++ b/.github/workflows/full_test_deploy.yml
@@ -19,7 +19,7 @@ jobs:
       - run_tests
       - build_images
       - generate_image_tags
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       API_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.API_IMAGE_TAG }}
       AM_CLEANUP_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.AM_CLEANUP_IMAGE_TAG }}

--- a/.github/workflows/generate_image_tags.yml
+++ b/.github/workflows/generate_image_tags.yml
@@ -16,7 +16,7 @@ on:
         value: ${{ jobs.generate_image_tags.outputs.ACCOUNT_SPACE_UPDATER_IMAGE_TAG }}
 jobs:
   generate_image_tags:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     outputs:
       API_IMAGE_TAG: ${{ steps.generate_api_image_tag.outputs.API_IMAGE_TAG }}
       AM_CLEANUP_IMAGE_TAG: ${{ steps.generate_am_cleanup_image_tag.outputs.AM_CLEANUP_IMAGE_TAG }}

--- a/.github/workflows/prod_deploy.yml
+++ b/.github/workflows/prod_deploy.yml
@@ -16,7 +16,7 @@ jobs:
     needs:
       - deploy_staging
       - generate_image_tags
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     environment: prod
     env:
       API_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.API_IMAGE_TAG }}

--- a/.github/workflows/prod_validate_terraform.yml
+++ b/.github/workflows/prod_validate_terraform.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   validate_terraform:
     name: "Validate Terraform"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     defaults:
       run:
         working-directory: ./terraform/prod_cluster

--- a/.github/workflows/staging_deploy.yml
+++ b/.github/workflows/staging_deploy.yml
@@ -20,7 +20,7 @@ jobs:
       - run_tests
       - build_images
       - generate_image_tags
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     env:
       API_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.API_IMAGE_TAG }}
       AM_CLEANUP_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.AM_CLEANUP_IMAGE_TAG }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ on:
   workflow_call:
 jobs:
   run_tests:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Because they're retiring the 20.04 runners that we're using now.