### PR TITLE
Add GET /archive/{archiveId}/folders/shared endpoint

### DIFF
--- a/packages/api/src/archive/controller/controller.ts
+++ b/packages/api/src/archive/controller/controller.ts
@@ -86,3 +86,25 @@ archiveController.get(
     }
   }
 );
+
+archiveController.get(
+  "/:archiveId/folders/shared",
+  verifyUserAuthentication,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      validateArchiveIdFromParams(req.params);
+      validateBodyFromAuthentication(req.body);
+      const folders = await archiveService.getSharedFolders(
+        req.params.archiveId,
+        req.body.emailFromAuthToken
+      );
+      res.json({ items: folders });
+    } catch (err) {
+      if (isValidationError(err)) {
+        res.status(400).json({ error: err });
+        return;
+      }
+      next(err);
+    }
+  }
+);

--- a/packages/api/src/archive/controller/get_shared_folders.test.ts
+++ b/packages/api/src/archive/controller/get_shared_folders.test.ts
@@ -1,0 +1,135 @@
+import request from "supertest";
+import type { Request, NextFunction } from "express";
+import createError from "http-errors";
+import { logger } from "@stela/logger";
+import { app } from "../../app";
+import { verifyUserAuthentication } from "../../middleware";
+import { db } from "../../database";
+import type { Folder } from "../../folder/models";
+
+jest.mock("../../database");
+jest.mock("../../middleware");
+jest.mock("@stela/logger");
+
+const loadFixtures = async (): Promise<void> => {
+  await db.sql("archive.fixtures.create_test_accounts");
+  await db.sql("archive.fixtures.create_test_archives");
+  await db.sql("archive.fixtures.create_test_account_archives");
+  await db.sql("archive.fixtures.create_test_folders");
+  await db.sql("archive.fixtures.create_test_folder_links");
+  await db.sql("archive.fixtures.create_test_shares");
+};
+
+const clearDatabase = async (): Promise<void> => {
+  await db.query(
+    "TRUNCATE account, archive, account_archive, folder, folder_link, share CASCADE"
+  );
+};
+
+describe("getSharedFolders", () => {
+  const agent = request(app);
+  beforeEach(async () => {
+    (verifyUserAuthentication as jest.Mock).mockImplementation(
+      async (
+        req: Request<
+          unknown,
+          unknown,
+          { userSubjectFromAuthToken?: string; emailFromAuthToken?: string }
+        >,
+        __,
+        next: NextFunction
+      ) => {
+        req.body.emailFromAuthToken = "test+1@permanent.org";
+        req.body.userSubjectFromAuthToken =
+          "553f3cb8-b753-43ce-83af-4443a404741b";
+        next();
+      }
+    );
+    await loadFixtures();
+  });
+
+  afterEach(async () => {
+    await clearDatabase();
+    jest.restoreAllMocks();
+    jest.clearAllMocks();
+  });
+
+  test("should return shared folders for an archive", async () => {
+    const response = await agent
+      .get(`/api/v2/archive/2/folders/shared`)
+      .expect(200);
+
+    const folders = (response.body as { items: Folder[] }).items;
+    expect(folders.length).toBe(1);
+    expect(folders[0]?.folderId).toBe("3");
+  });
+
+  test("should return 401 when not authenticated", async () => {
+    (verifyUserAuthentication as jest.Mock).mockImplementation(
+      (_: Request, __: Response, next: NextFunction) => {
+        next(new createError.Unauthorized("Invalid token"));
+      }
+    );
+
+    await agent.get(`/api/v2/archive/2/folders/shared`).expect(401);
+  });
+
+  test("should return 400 if the header data is missing", async () => {
+    (verifyUserAuthentication as jest.Mock).mockImplementation(
+      (_: Request, __: Response, next: NextFunction) => {
+        next();
+      }
+    );
+    await agent.get(`/api/v2/archive/2/folders/shared`).expect(400);
+  });
+
+  test("should return 500 if database query fails", async () => {
+    const testError = new Error("error: database connection lost");
+    jest.spyOn(db, "sql").mockRejectedValueOnce(testError);
+    await agent.get(`/api/v2/archive/2/folders/shared`).expect(500);
+    expect(logger.error).toHaveBeenCalledWith(testError);
+  });
+
+  test("should not return shared folders for an archive if the user is not a member", async () => {
+    (verifyUserAuthentication as jest.Mock).mockImplementation(
+      async (
+        req: Request<
+          unknown,
+          unknown,
+          { userSubjectFromAuthToken?: string; emailFromAuthToken?: string }
+        >,
+        __,
+        next: NextFunction
+      ) => {
+        req.body.emailFromAuthToken = "test@permanent.org";
+        req.body.userSubjectFromAuthToken =
+          "553f3cb8-b753-43ce-83af-4443a404741b";
+        next();
+      }
+    );
+    const response = await agent
+      .get(`/api/v2/archive/2/folders/shared`)
+      .expect(200);
+
+    const folders = (response.body as { items: Folder[] }).items;
+    expect(folders.length).toBe(0);
+  });
+
+  test("should not return folders where the share has been deleted", async () => {
+    const response = await agent
+      .get(`/api/v2/archive/1/folders/shared`)
+      .expect(200);
+
+    const folders = (response.body as { items: Folder[] }).items;
+    expect(folders.length).toBe(0);
+  });
+
+  test("should not return folders where archive membership has been deleted", async () => {
+    const response = await agent
+      .get(`/api/v2/archive/3/folders/shared`)
+      .expect(200);
+
+    const folders = (response.body as { items: Folder[] }).items;
+    expect(folders.length).toBe(0);
+  });
+});

--- a/packages/api/src/archive/fixtures/create_test_account_archives.sql
+++ b/packages/api/src/archive/fixtures/create_test_account_archives.sql
@@ -62,4 +62,13 @@ VALUES
   0,
   'type.account.standard',
   'status.generic.deleted'
+),
+(
+  35,
+  3,
+  3,
+  'access.role.curator',
+  0,
+  'type.account.standard',
+  'status.generic.deleted'
 );

--- a/packages/api/src/archive/fixtures/create_test_folder_links.sql
+++ b/packages/api/src/archive/fixtures/create_test_folder_links.sql
@@ -1,0 +1,50 @@
+INSERT INTO
+folder_link (
+  folder_linkid,
+  folderid,
+  archiveid,
+  parentfolderid,
+  position,
+  status,
+  type,
+  createddt,
+  updateddt,
+  accessrole
+)
+VALUES
+(
+  1,
+  1,
+  3,
+  7,
+  0,
+  'status.generic.ok',
+  'type.folder_link.folder',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP,
+  'access.role.owner'
+),
+(
+  2,
+  2,
+  1,
+  10,
+  1,
+  'status.generic.ok',
+  'type.folder_link.folder',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP,
+  'access.role.owner'
+),
+(
+  3,
+  3,
+  2,
+  10,
+  2,
+  'status.generic.ok',
+  'type.folder_link.folder',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP,
+  'access.role.owner'
+);

--- a/packages/api/src/archive/fixtures/create_test_shares.sql
+++ b/packages/api/src/archive/fixtures/create_test_shares.sql
@@ -1,0 +1,50 @@
+INSERT INTO
+share (
+  shareid,
+  folder_linkid,
+  archiveid,
+  accessrole,
+  status,
+  type,
+  requesttoken,
+  previewtoggle,
+  createddt,
+  updateddt
+)
+VALUES
+(
+  1,
+  1,
+  3,
+  'access.role.viewer',
+  'status.generic.ok',
+  'type.share.folder',
+  NULL,
+  0,
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
+),
+(
+  2,
+  2,
+  1,
+  'access.role.viewer',
+  'status.generic.deleted',
+  'type.share.folder',
+  NULL,
+  0,
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
+),
+(
+  3,
+  3,
+  1,
+  'access.role.viewer',
+  'status.generic.ok',
+  'type.share.folder',
+  NULL,
+  0,
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
+);

--- a/packages/api/src/archive/queries/get_shared_folders.sql
+++ b/packages/api/src/archive/queries/get_shared_folders.sql
@@ -1,0 +1,15 @@
+WITH archive_access AS (
+  SELECT account_archive.archiveid
+  FROM account_archive
+  INNER JOIN account ON account_archive.accountid = account.accountid
+  WHERE
+    account.primaryemail = :email
+    AND account_archive.archiveid = :archiveId
+    AND account_archive.status = 'status.generic.ok'
+)
+
+SELECT folder_link.folderid AS "folderId"
+FROM folder_link
+INNER JOIN share ON folder_link.folder_linkid = share.folder_linkid
+INNER JOIN archive_access ON folder_link.archiveid = archive_access.archiveid
+WHERE share.status = 'status.generic.ok';

--- a/packages/api/src/archive/service/get_shared_folders.ts
+++ b/packages/api/src/archive/service/get_shared_folders.ts
@@ -1,0 +1,26 @@
+import { logger } from "@stela/logger";
+import createError from "http-errors";
+import { db } from "../../database";
+import { getFolders } from "../../folder/service";
+import type { Folder } from "../../folder/models";
+
+export const getSharedFolders = async (
+  archiveId: string,
+  email: string
+): Promise<Folder[]> => {
+  const result = await db
+    .sql<{ folderId: string }>("archive.queries.get_shared_folders", {
+      archiveId,
+      email,
+    })
+    .catch((err) => {
+      logger.error(err);
+      throw new createError.InternalServerError(
+        "Failed to retrieve shared folder IDs"
+      );
+    });
+
+  const folderIds = result.rows.map((row) => row.folderId);
+
+  return getFolders(folderIds, email);
+};

--- a/packages/api/src/archive/service/index.ts
+++ b/packages/api/src/archive/service/index.ts
@@ -3,6 +3,7 @@ import { getPayerAccountStorage } from "./get_payer_account_storage";
 import { makeFeatured } from "./make_featured";
 import { unfeature } from "./unfeature";
 import { getFeatured } from "./get_featured";
+import { getSharedFolders } from "./get_shared_folders";
 
 export const archiveService = {
   getPublicTags,
@@ -10,4 +11,5 @@ export const archiveService = {
   makeFeatured,
   unfeature,
   getFeatured,
+  getSharedFolders,
 };


### PR DESCRIPTION
The new sharing menu wants to offer users the opportunity to move the item they're sharing into an existing shared folder. This commit adds a new endpoint that will retrieve all an archive's shared folders to suppor this use case. Note that it retrieves only top-level shared folders, the idea being the the user would navigate into their children if they wanted to move the item to a descendent folder.