### PR TITLE
Add createdAt and updatedAt fields to file objects

### DIFF
--- a/packages/api/docs/shared/models/archive_file.yaml
+++ b/packages/api/docs/shared/models/archive_file.yaml
@@ -15,3 +15,9 @@ archiveFile:
       type: string
     downloadUrl:
       type: string
+    createdAt:
+      type: string
+      format: date-time
+    updatedAt:
+      type: string
+      format: date-time

--- a/packages/api/src/record/controller.test.ts
+++ b/packages/api/src/record/controller.test.ts
@@ -399,6 +399,10 @@ describe("GET /record", () => {
     expect(originalFile?.downloadUrl).toEqual(
       "https://localcdn.permanent.org/_Dev/8?t=1732914102&response-content-disposition=attachment%3B+filename%3D%22Robert+birthday+%281%29.jpg%22&Expires=1732914102&Signature=R25~ODA0uZ77J2rjQ__&Key-Pair-Id=APKA"
     );
+    expect(originalFile?.createdAt).toEqual("2023-06-21T00:00:00+00:00");
+    expect(convertedFile?.createdAt).toEqual("2023-06-21T00:00:00+00:00");
+    expect(originalFile?.updatedAt).toEqual("2023-06-21T00:00:00+00:00");
+    expect(convertedFile?.updatedAt).toEqual("2023-06-21T00:00:00+00:00");
 
     expect(record?.folderLinkId).toEqual("8");
     expect(record?.folderLinkType).toEqual("type.folder_link.public");

--- a/packages/api/src/record/models.ts
+++ b/packages/api/src/record/models.ts
@@ -78,6 +78,8 @@ export interface ArchiveFile {
   type: FileType;
   fileUrl: string;
   downloadUrl: string;
+  createdAt: Date;
+  updatedAt: Date;
 }
 
 export interface RecordColumnsForUpdate {

--- a/packages/api/src/record/queries/get_record_by_id.sql
+++ b/packages/api/src/record/queries/get_record_by_id.sql
@@ -13,7 +13,11 @@ WITH RECURSIVE aggregated_files AS (
       'fileUrl',
       file.fileurl,
       'downloadUrl',
-      file.downloadurl
+      file.downloadurl,
+      'createdAt',
+      file.createddt,
+      'updatedAt',
+      file.updateddt
     )) AS files
   FROM
     record_file


### PR DESCRIPTION
The SFTP service used the createdAt and updatedAt fields of file objects; thus they should be included in file objects returned by this API.