### PR TITLE
Support authentication via SFTP token for GET /folder endpoints

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -8,6 +8,7 @@ FUSIONAUTH_API_KEY=<API key here>
 FUSIONAUTH_TENANT=<Tenant ID here>
 FUSIONAUTH_BACKEND_APPLICATION_ID=<backend application ID here>
 FUSIONAUTH_ADMIN_APPLICATION_ID=<admin application ID here>
+FUSIONAUTH_SFTP_APPLICATION_ID=<sftp application ID here>
 
 LEGACY_BACKEND_HOST_URL='http://load_balancer:80/api'
 LEGACY_BACKEND_SHARED_SECRET=<shared secret here>

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ For these, simply fill in any fake value to prevent `require-env-variable` from 
 | FUSIONAUTH_TENANT                 | <none. needs to be set>                               | Find it in Fusionauth admin panel -> Tenants -> the one called "Local"                                                      |
 | FUSIONAUTH_BACKEND_APPLICATION_ID | <none. needs to be set>                               | Find it in Fusionauth admin panel -> Applications -> the one called "back-end (local)"                                      |
 | FUSIONAUTH_ADMIN_APPLICATION_ID   | <none. needs to be set>                               | Find it in Fusionauth admin panel -> Applications -> the one called "admin-local"                                           |
+| FUSIONAUTH_SFTP_APPLICATION_ID    | <none. needs to be set>                               | Find it in Fusionauth admin panel -> Applications -> the one called "sftp (local)"                                          |
 | LEGACY_BACKEND_HOST_URL           | http://load_balancer:80/api                           |
 | LEGACY_BACKEND_SHARED_SECRET      | none                                                  | Can be found in `back-end`'s library/base/constants/base.constants.php                                                      |
 | MAILCHIMP_API_KEY                 | none                                                  | Can be found in `back-end`'s library/base/constants/base.constants.php                                                      |

--- a/packages/api/src/env.ts
+++ b/packages/api/src/env.ts
@@ -5,9 +5,11 @@ config({ path: "../../.env" });
 
 requireEnv("ENV");
 requireEnv("DATABASE_URL");
-requireEnv("FUSIONAUTH_API_KEY");
 requireEnv("FUSIONAUTH_HOST");
 requireEnv("FUSIONAUTH_TENANT");
+requireEnv("FUSIONAUTH_BACKEND_APPLICATION_ID");
+requireEnv("FUSIONAUTH_ADMIN_APPLICATION_ID");
+requireEnv("FUSIONAUTH_SFTP_APPLICATION_ID");
 requireEnv("LEGACY_BACKEND_HOST_URL");
 requireEnv("LEGACY_BACKEND_SHARED_SECRET");
 requireEnv("MAILCHIMP_API_KEY");

--- a/terraform/prod_cluster/stela_prod_deployment.tf
+++ b/terraform/prod_cluster/stela_prod_deployment.tf
@@ -84,6 +84,11 @@ resource "kubernetes_deployment" "stela_prod" {
           }
 
           env {
+            name  = "FUSIONAUTH_SFTP_APPLICATION_ID"
+            value = var.prod_fusionauth_sftp_application_id
+          }
+
+          env {
             name  = "LEGACY_BACKEND_HOST_URL"
             value = var.legacy_backend_prod_host_url
           }

--- a/terraform/prod_cluster/variables.tf
+++ b/terraform/prod_cluster/variables.tf
@@ -92,6 +92,12 @@ variable "prod_fusionauth_admin_application_id" {
   default     = "28003417-1976-447c-bcbe-c5c1f575b596"
 }
 
+variable "prod_fusionauth_sftp_application_id" {
+  description = "ID of the FusionAuth application that manages authentication to the sftp service in the prod environment"
+  type        = string
+  default     = "5879a6f3-6b68-476c-a590-914905b6f6d3"
+}
+
 variable "legacy_backend_prod_host_url" {
   description = "Host URL of the legacy PHP backend"
   type        = string

--- a/terraform/test_cluster/stela_dev_deployment.tf
+++ b/terraform/test_cluster/stela_dev_deployment.tf
@@ -84,6 +84,11 @@ resource "kubernetes_deployment" "stela_dev" {
           }
 
           env {
+            name  = "FUSIONAUTH_SFTP_APPLICATION_ID"
+            value = var.dev_fusionauth_sftp_application_id
+          }
+
+          env {
             name  = "LEGACY_BACKEND_HOST_URL"
             value = var.legacy_backend_dev_host_url
           }

--- a/terraform/test_cluster/stela_staging_deployment.tf
+++ b/terraform/test_cluster/stela_staging_deployment.tf
@@ -84,6 +84,11 @@ resource "kubernetes_deployment" "stela_staging" {
           }
 
           env {
+            name  = "FUSIONAUTH_SFTP_APPLICATION_ID"
+            value = var.staging_fusionauth_sftp_application_id
+          }
+
+          env {
             name  = "LEGACY_BACKEND_HOST_URL"
             value = var.legacy_backend_dev_host_url
           }

--- a/terraform/test_cluster/variables.tf
+++ b/terraform/test_cluster/variables.tf
@@ -162,6 +162,18 @@ variable "staging_fusionauth_admin_application_id" {
   default     = "5df9c061-0988-4f8d-b05a-0a338d5c44b6"
 }
 
+variable "dev_fusionauth_sftp_application_id" {
+  description = "ID of the FusionAuth application that manages authentication to the sftp service in the dev environment"
+  type        = string
+  default     = "00eecfff-180f-4db5-9a34-10498c971830"
+}
+
+variable "staging_fusionauth_sftp_application_id" {
+  description = "ID of the FusionAuth application that manages authentication to the sftp service in the staging environment"
+  type        = string
+  default     = "ed2d6e4d-fca3-4929-bba6-2df1c2fcb921"
+}
+
 variable "legacy_backend_dev_host_url" {
   description = "Host URL of the legacy PHP backend"
   type        = string


### PR DESCRIPTION
The SFTP service is it's own application in Fusionauth, and SFTP users should be able to access the GET /folder endpoints offered by this API. To enable this, this commit updates the auth middleware used by those endpoints to check tokens against both the backend and sftp applications, and succeed if the token comes from either.

Note that this is not a good or scalable way to do this. In the short term, we should rewrite this to validate JWTs on our own without making calls to FusionAuth, and then check the aud field of the JWTs against an internal list of application IDs to see what kind of access the caller should have. In the longer term, this check should be based on claims assigned to applications, rather than on applications directly.