### PR TITLE
Correctly handle folder children that the caller can't see

### DIFF
--- a/packages/api/src/folder/controller/get_folder_children.test.ts
+++ b/packages/api/src/folder/controller/get_folder_children.test.ts
@@ -341,6 +341,25 @@ describe("GET /folder/{id}/children", () => {
     expect(children[1]?.displayName).toEqual("Private Folder");
   });
 
+  test("should return an empty list if the caller doesn't have access to the folder", async () => {
+    (extractUserEmailFromAuthToken as jest.Mock).mockImplementation(
+      async (
+        req: Request<unknown, unknown, { emailFromAuthToken?: string }>,
+        __,
+        next: NextFunction
+      ) => {
+        req.body.emailFromAuthToken = "test+5@permanent.org";
+        next();
+      }
+    );
+    const response = await agent
+      .get("/api/v2/folder/2/children?pageSize=100")
+      .expect(200);
+    const children = (response.body as { items: (ArchiveRecord | Folder)[] })
+      .items;
+    expect(children.length).toEqual(0);
+  });
+
   test("should return no more than pageSize items", async () => {
     const response = await agent
       .get("/api/v2/folder/10/children?pageSize=1")

--- a/packages/api/src/folder/fixtures/create_test_accounts.sql
+++ b/packages/api/src/folder/fixtures/create_test_accounts.sql
@@ -53,4 +53,13 @@ VALUES
   'type.account.standard',
   'Jenny Rando',
   null
+),
+(
+  7,
+  'test+5@permanent.org',
+  'status.auth.ok',
+  '{}',
+  'type.account.standard',
+  'Jorge Rando',
+  null
 );

--- a/packages/api/src/folder/queries/get_folder_children.sql
+++ b/packages/api/src/folder/queries/get_folder_children.sql
@@ -69,6 +69,8 @@ WITH all_children AS (
       ON folder_link.folderid = folder.folderid
     WHERE
       folder_link.parentfolderid = :parentFolderId
+      AND folder_link.status != 'status.generic.deleted'
+      AND folder.status != 'status.generic.deleted'
     UNION
     SELECT
       folder_link.recordid AS "id",
@@ -84,6 +86,8 @@ WITH all_children AS (
       ON folder_link.recordid = record.recordid
     WHERE
       folder_link.parentfolderid = :parentFolderId
+      AND folder_link.status != 'status.generic.deleted'
+      AND record.status != 'status.generic.deleted'
   ) AS "children"
 ),
 

--- a/packages/api/src/folder/service.ts
+++ b/packages/api/src/folder/service.ts
@@ -175,18 +175,19 @@ export const getFolderChildren = async (
     shareToken,
   });
 
-  const children: (ArchiveRecord | Folder)[] = result.rows.map((row) => {
-    const child =
-      row.item_type === "folder"
-        ? folders.find((folder) => folder.folderId === row.id)
-        : records.find((record) => record.recordId === row.id);
-    if (child === undefined) {
-      throw new createError.InternalServerError(
-        "Failed to retrieve folder children"
-      );
-    }
-    return child;
-  });
+  const children: (ArchiveRecord | Folder)[] = result.rows.reduce(
+    (accumulator: (ArchiveRecord | Folder)[], row) => {
+      const child =
+        row.item_type === "folder"
+          ? folders.find((folder) => folder.folderId === row.id)
+          : records.find((record) => record.recordId === row.id);
+      if (child !== undefined) {
+        accumulator.push(child);
+      }
+      return accumulator;
+    },
+    []
+  );
 
   const nextCursor = children[children.length - 1]?.folderLinkId;
   return {


### PR DESCRIPTION
Currently, /folder/{id}/children errors if the folder has children the caller can't access. This is a bug; it should instead simply omit those children from the response. This commit updates the endpoint to do that.