### PR TITLE
Optimize get queries for folders and records

### DIFF
--- a/packages/api/src/folder/queries/get_folders.sql
+++ b/packages/api/src/folder/queries/get_folders.sql
@@ -90,6 +90,7 @@ aggregated_tags AS (
     tag_link.reftable = 'folder'
     AND tag.status != 'status.generic.deleted'
     AND tag_link.status != 'status.generic.deleted'
+    AND tag_link.refid = ANY(:folderIds)
   GROUP BY tag_link.refid
 ),
 

--- a/packages/api/src/record/queries/get_record_by_id.sql
+++ b/packages/api/src/record/queries/get_record_by_id.sql
@@ -26,6 +26,7 @@ WITH RECURSIVE aggregated_files AS (
     ON record_file.fileid = file.fileid
   WHERE
     file.status != 'status.generic.deleted'
+    AND record_file.recordid = any(:recordIds)
   GROUP BY record_file.recordid)
 ),
 
@@ -50,6 +51,7 @@ aggregated_tags AS (
   WHERE
     tag_link.reftable = 'record'
     AND tag_link.status = 'status.generic.ok'
+    AND tag_link.refid = any(:recordIds)
   GROUP BY tag_link.refid
 ),
 


### PR DESCRIPTION
Currently, the queries for getting folders and records generate some CTEs that are much larger than they need to be. This commit updates those CTEs to only collect data relevant to the records or folders the query is trying to retrieve.