### PR TITLE
Optimize get folder and record queries

### DIFF
--- a/packages/api/src/folder/queries/get_folders.sql
+++ b/packages/api/src/folder/queries/get_folders.sql
@@ -64,8 +64,11 @@ aggregated_shares AS (
       archive.archiveid = profile_item.archiveid
       AND profile_item.fieldnameui = 'profile.basic'
       AND profile_item.string1 IS NOT NULL
+  INNER JOIN folder_link
+    ON share.folder_linkid = folder_link.folder_linkid
   WHERE
     share.status = 'status.generic.ok'
+    AND folder_link.folderid = ANY(:folderIds)
   GROUP BY share.folder_linkid
 ),
 

--- a/packages/api/src/record/queries/get_record_by_id.sql
+++ b/packages/api/src/record/queries/get_record_by_id.sql
@@ -80,11 +80,14 @@ aggregated_shares AS (
     ON share.archiveid = archive.archiveid
   INNER JOIN profile_item
     ON archive.archiveid = profile_item.archiveid
+  INNER JOIN folder_link
+    ON share.folder_linkid = folder_link.folder_linkid
   WHERE
     profile_item.fieldnameui = 'profile.basic'
     AND profile_item.status = 'status.generic.ok'
     AND profile_item.string1 IS NOT NULL
     AND share.status != 'status.generic.deleted'
+    AND folder_link.recordid = any(:recordIds)
   GROUP BY share.folder_linkid
 ),
 


### PR DESCRIPTION
Currently, the queries for getting folders and records assemble the lists of shares for all folders and records before joining the relevant ones to the folders and records in question. This commit optimizes the queries to only get the shares for the relevant folders and records in the first place.