### PR TITLE
Add API designs for notification endpoints

### DIFF
--- a/packages/api/docs/future/api.yaml
+++ b/packages/api/docs/future/api.yaml
@@ -57,3 +57,5 @@ paths:
     $ref: "./paths/application.yaml#/applications-with-id"
   /developer-accounts:
     $ref: "./paths/developer_account.yaml#/developer-accounts"
+  /notifications:
+    $ref: "./paths/notification.yaml#/notifications"

--- a/packages/api/docs/future/models/notification.yaml
+++ b/packages/api/docs/future/models/notification.yaml
@@ -1,0 +1,31 @@
+notification:
+  description: A notification for display in a Permanent client
+  type: object
+  required:
+    - id
+    - recipientAccountId
+    - status
+    - data
+    - createdAt
+    - updatedAt
+  properties:
+    id:
+      type: string
+    recipientAccountId:
+      type: string
+    status:
+      type: string
+      enum:
+        - new
+        - seen
+        - read
+    data:
+      description: >
+        Any data required by clients to display the notification, and to implement its calls to action
+      type: object
+    createdAt:
+      type: string
+      format: date-time
+    updatedAt:
+      type: string
+      format: date-time

--- a/packages/api/docs/future/models/pagination_metadata.yaml
+++ b/packages/api/docs/future/models/pagination_metadata.yaml
@@ -1,0 +1,7 @@
+pagination:
+  type: object
+  properties:
+    nextCursor:
+      type: string
+    totalPages:
+      type: integer

--- a/packages/api/docs/future/paths/folder.yaml
+++ b/packages/api/docs/future/paths/folder.yaml
@@ -80,14 +80,7 @@ folders-id-children:
                       - $ref: "../models/folder.yaml#/folder"
                       - $ref: "../models/record.yaml#/record"
                 pagination:
-                  type: object
-                  properties:
-                    nextCursor:
-                      type: string
-                    nextPage:
-                      type: string
-                    totalPages:
-                      type: integer
+                  $ref: "../models/pagination_metadata.yaml#/pagination"
       "400":
         $ref: "../../shared/errors.yaml#/400"
       "401":

--- a/packages/api/docs/future/paths/notification.yaml
+++ b/packages/api/docs/future/paths/notification.yaml
@@ -1,0 +1,80 @@
+notifications:
+  get:
+    summary: Get an account's notification's. Notifications will be sorted in reverse chronological order
+    parameters:
+      - name: cursor
+        description: |
+          The id of the notification right before the first notification you want returned.
+          In most cases, this will be that of the last item on the previous page.
+        in: query
+        required: false
+        schema:
+          type: string
+      - name: pageSize
+        in: query
+        required: true
+        schema:
+          type: integer
+    security:
+      - bearerHttpAuthentication: []
+    tags:
+      - notifications
+    operationId: getNotifications
+    responses:
+      "200":
+        description: A page of the account's notifications
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                items:
+                  type: array
+                  items:
+                    $ref: "../models/notification.yaml#/notification"
+                pagination:
+                  $ref: "../models/pagination_metadata.yaml#/pagination"
+      "400":
+        $ref: "../../shared/errors.yaml#/400"
+      "401":
+        $ref: "../../shared/errors.yaml#/401"
+      "404":
+        $ref: "../../shared/errors.yaml#/404"
+      "500":
+        $ref: "../../shared/errors.yaml#/500"
+  patch:
+    summary: Update a notification's status. Legal updates are new->seen, new->read, and seen->read
+    security:
+      - bearerHttpAuthentication: []
+    operationId: updateNotification
+    tags:
+      - notifications
+    requestBody:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              status:
+                type: string
+                enum:
+                  - seen
+                  - read
+    responses:
+      "200":
+        description: The updated notification
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                data:
+                  $ref: "../models/notification.yaml#/notification"
+      "400":
+        $ref: "../../shared/errors.yaml#/400"
+      "401":
+        $ref: "../../shared/errors.yaml#/401"
+      "404":
+        $ref: "../../shared/errors.yaml#/404"
+      "500":
+        $ref: "../../shared/errors.yaml#/500"


### PR DESCRIPTION
We are planning to rework our notifications system. As part of that, endpoints for accessing and updating in-app notifications should be moved to stela. This commit adds designs for the required GET and PATCH endpoints.