### PR TITLE
Updates the account space lambda to use file.size over record.size

### DIFF
--- a/packages/account_space_updater/src/fixtures/create_test_files.sql
+++ b/packages/account_space_updater/src/fixtures/create_test_files.sql
@@ -3,6 +3,7 @@ file (
   fileid,
   archiveid,
   status,
+  size,
   createddt,
   updateddt
 )
@@ -11,6 +12,7 @@ VALUES
   1,
   1,
   'status.generic.ok',
+  1024,
   CURRENT_TIMESTAMP,
   CURRENT_TIMESTAMP
 );

--- a/packages/account_space_updater/src/queries/update_account_space.sql
+++ b/packages/account_space_updater/src/queries/update_account_space.sql
@@ -1,13 +1,16 @@
 WITH upload_data AS (
   SELECT
     record.uploadpayeraccountid,
-    record.size,
-    record_file.fileid
+    file.size,
+    file.fileid
   FROM
     record
   INNER JOIN
     record_file
     ON record.recordid = record_file.recordid
+  INNER JOIN
+    file
+    ON record_file.fileid = file.fileid
   WHERE
     record.recordid = :recordId
 ),


### PR DESCRIPTION
Currently, the account space update lambda uses record.size to determine the size of the record. However, at the point that the lambda runs, that value is set based on a parameter provided by the user, while file.size is set based on the actual file size as reported by S3. Thus, we should use file.size instead.