### PR TITLE
Join only on original file for account space updater

### DIFF
--- a/packages/account_space_updater/src/fixtures/create_test_files.sql
+++ b/packages/account_space_updater/src/fixtures/create_test_files.sql
@@ -4,6 +4,7 @@ file (
   archiveid,
   status,
   size,
+  format,
   createddt,
   updateddt
 )
@@ -13,6 +14,7 @@ VALUES
   1,
   'status.generic.ok',
   1024,
+  'file.format.original',
   CURRENT_TIMESTAMP,
   CURRENT_TIMESTAMP
 );

--- a/packages/account_space_updater/src/queries/update_account_space.sql
+++ b/packages/account_space_updater/src/queries/update_account_space.sql
@@ -10,7 +10,9 @@ WITH upload_data AS (
     ON record.recordid = record_file.recordid
   INNER JOIN
     file
-    ON record_file.fileid = file.fileid
+    ON
+      record_file.fileid = file.fileid
+      AND file.format = 'file.format.original'
   WHERE
     record.recordid = :recordId
 ),


### PR DESCRIPTION
The account space updater joins a record to a corresponding file to get the file size. This commit ensure it joins only to the original file and not an access copy.