### PR TITLE
Add /archive/:archiveId/backfill-ledger admin endpoint

### DIFF
--- a/packages/api/src/archive/controller/backfill_ledger.test.ts
+++ b/packages/api/src/archive/controller/backfill_ledger.test.ts
@@ -1,0 +1,116 @@
+import request from "supertest";
+import type { Request, NextFunction } from "express";
+import createError from "http-errors";
+import { logger } from "@stela/logger";
+import { app } from "../../app";
+import { verifyAdminAuthentication } from "../../middleware";
+import { db } from "../../database";
+import { publisherClient } from "../../publisher_client";
+
+jest.mock("../../database");
+jest.mock("../../middleware");
+jest.mock("../../publisher_client");
+jest.mock("@stela/logger");
+
+const loadFixtures = async (): Promise<void> => {
+  await db.sql("archive.fixtures.create_test_accounts");
+  await db.sql("archive.fixtures.create_test_archives");
+  await db.sql("archive.fixtures.create_test_records");
+};
+
+const clearDatabase = async (): Promise<void> => {
+  await db.query("TRUNCATE account, archive, record CASCADE");
+};
+
+describe("POST /:archiveId/backfill-ledger", () => {
+  const agent = request(app);
+  beforeEach(async () => {
+    (verifyAdminAuthentication as jest.Mock).mockImplementation(
+      (req: Request, _: Response, next: NextFunction) => {
+        (req.body as { emailFromAuthToken: string }).emailFromAuthToken =
+          "test+1@permanent.org";
+        (
+          req.body as { adminSubjectFromAuthToken: string }
+        ).adminSubjectFromAuthToken = "82bd483e-914b-4bfe-abf9-92ffe86d7803";
+        next();
+      }
+    );
+    await loadFixtures();
+    jest.spyOn(publisherClient, "publishMessage").mockResolvedValue();
+  });
+
+  afterEach(async () => {
+    await clearDatabase();
+    jest.clearAllMocks();
+  });
+
+  test("should backfill ledger records successfully", async () => {
+    await agent.post("/api/v2/archive/2/backfill-ledger").expect(200);
+
+    const result = await db.query<{
+      recordId: string;
+      uploadPayerAccountId: string;
+    }>(
+      'SELECT recordid "recordId", uploadpayeraccountid "uploadPayerAccountId" FROM record WHERE archiveId = 2'
+    );
+    expect(result.rows.length).toBe(4);
+
+    expect(publisherClient.publishMessage).toHaveBeenCalledTimes(
+      result.rows.length
+    );
+    result.rows.forEach((row) => {
+      expect(row.uploadPayerAccountId).toBe("3");
+      expect(publisherClient.publishMessage).toHaveBeenCalledWith(
+        expect.any(String),
+        {
+          id: row.recordId,
+          body: JSON.stringify({
+            entity: "record",
+            action: "create",
+            body: {
+              record: {
+                recordId: row.recordId,
+              },
+            },
+          }),
+          attributes: { Entity: "record", Action: "create" },
+        }
+      );
+    });
+  });
+
+  test("should require admin authentication", async () => {
+    (verifyAdminAuthentication as jest.Mock).mockImplementation(
+      (_: Request, __: Response, next: NextFunction) => {
+        next(createError.Unauthorized("Invalid token"));
+      }
+    );
+
+    await agent.post("/api/v2/archive/1/backfill-ledger").expect(401);
+    expect(publisherClient.publishMessage).not.toHaveBeenCalled();
+  });
+
+  test("should handle a nonexistent archive ID", async () => {
+    await agent.post("/api/v2/archive/1000/backfill-ledger").expect(200);
+    expect(publisherClient.publishMessage).not.toHaveBeenCalled();
+  });
+
+  test("should handle database query errors", async () => {
+    const testError = new Error("Database error");
+    jest.spyOn(db, "sql").mockRejectedValueOnce(testError);
+
+    await agent.post("/api/v2/archive/1/backfill-ledger").expect(500);
+    expect(logger.error).toHaveBeenCalledWith(testError);
+    expect(publisherClient.publishMessage).not.toHaveBeenCalled();
+  });
+
+  test("should handle publisher client errors", async () => {
+    const testError = new Error("Publisher error");
+    (publisherClient.publishMessage as jest.Mock).mockRejectedValueOnce(
+      testError
+    );
+
+    await agent.post("/api/v2/archive/1/backfill-ledger").expect(500);
+    expect(logger.error).toHaveBeenCalledWith(testError);
+  });
+});

--- a/packages/api/src/archive/controller/controller.ts
+++ b/packages/api/src/archive/controller/controller.ts
@@ -87,6 +87,20 @@ archiveController.get(
   }
 );
 
+archiveController.post(
+  "/:archiveId/backfill-ledger",
+  verifyAdminAuthentication,
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      validateArchiveIdFromParams(req.params);
+      await archiveService.backfillLedger(req.params.archiveId);
+      res.sendStatus(200);
+    } catch (err) {
+      next(err);
+    }
+  }
+);
+
 archiveController.get(
   "/:archiveId/folders/shared",
   verifyUserAuthentication,

--- a/packages/api/src/archive/controller/get_payer_account_storage.test.ts
+++ b/packages/api/src/archive/controller/get_payer_account_storage.test.ts
@@ -69,7 +69,7 @@ describe("getPayerAccountStorage", () => {
   });
 
   test("should throw a not found error if archive has no payer account", async () => {
-    await agent.get("/api/v2/archive/2/payer-account-storage").expect(404);
+    await agent.get("/api/v2/archive/3/payer-account-storage").expect(404);
   });
 
   test("should throw a bad request error if the request is invalid", async () => {

--- a/packages/api/src/archive/fixtures/create_test_archives.sql
+++ b/packages/api/src/archive/fixtures/create_test_archives.sql
@@ -4,7 +4,7 @@ archive (
 )
 VALUES
 (1, '0001-0001', 2, false, 'type.archive.person', null, 'status.generic.ok'),
-(2, '0001-0002', null, false, 'type.archive.person', null, 'status.generic.ok'),
+(2, '0001-0002', 3, false, 'type.archive.person', null, 'status.generic.ok'),
 (
   3,
   '0001-0003',

--- a/packages/api/src/archive/queries/update_payer_accounts_for_ledger_backfill.sql
+++ b/packages/api/src/archive/queries/update_payer_accounts_for_ledger_backfill.sql
@@ -1,0 +1,26 @@
+WITH missing_ledger_records AS (
+  SELECT
+    record.recordid,
+    record.archiveid
+  FROM
+    record
+  LEFT JOIN
+    ledger_nonfinancial ON record.recordid = ledger_nonfinancial.recordid
+  WHERE
+    record.archiveid = :archiveId
+    AND record.status != 'status.generic.deleted'
+    AND ledger_nonfinancial.recordid IS NULL
+)
+
+UPDATE record
+SET
+  uploadpayeraccountid = archive.payeraccountid,
+  updateddt = CURRENT_TIMESTAMP
+FROM
+  missing_ledger_records
+INNER JOIN
+  archive ON missing_ledger_records.archiveid = archive.archiveid
+WHERE
+  record.recordid = missing_ledger_records.recordid
+RETURNING
+record.recordid AS "recordId";

--- a/packages/api/src/archive/service/backfill_ledger.ts
+++ b/packages/api/src/archive/service/backfill_ledger.ts
@@ -1,0 +1,47 @@
+import createError from "http-errors";
+import { logger } from "@stela/logger";
+import { db } from "../../database";
+import { publisherClient } from "../../publisher_client";
+
+export const backfillLedger = async (archiveId: string): Promise<void> => {
+  const backfillRecords = await db
+    .sql<{ recordId: string }>(
+      "archive.queries.update_payer_accounts_for_ledger_backfill",
+      {
+        archiveId,
+      }
+    )
+    .catch((err) => {
+      logger.error(err);
+      throw new createError.InternalServerError(
+        "failed to update payer accounts"
+      );
+    });
+
+  await Promise.all(
+    backfillRecords.rows.map(async (record) => {
+      const message = {
+        entity: "record",
+        action: "create",
+        body: {
+          record: {
+            recordId: record.recordId,
+          },
+        },
+      };
+
+      await publisherClient
+        .publishMessage(process.env["EVENT_TOPIC_ARN"] ?? "", {
+          id: record.recordId,
+          body: JSON.stringify(message),
+          attributes: { Entity: "record", Action: "create" },
+        })
+        .catch((err: unknown) => {
+          logger.error(err);
+          throw new createError.InternalServerError(
+            "failed to send account space update message"
+          );
+        });
+    })
+  );
+};

--- a/packages/api/src/archive/service/index.ts
+++ b/packages/api/src/archive/service/index.ts
@@ -4,6 +4,7 @@ import { makeFeatured } from "./make_featured";
 import { unfeature } from "./unfeature";
 import { getFeatured } from "./get_featured";
 import { getSharedFolders } from "./get_shared_folders";
+import { backfillLedger } from "./backfill_ledger";
 
 export const archiveService = {
   getPublicTags,
@@ -12,4 +13,5 @@ export const archiveService = {
   unfeature,
   getFeatured,
   getSharedFolders,
+  backfillLedger,
 };


### PR DESCRIPTION
We have some archives in the system where storage wasn't historically tracked via the application, but rather by hand, in order to facilitate free storage for nonprofit partners. We can now achieve this while still tracking storage in the application, and this in fact preferable for partners because it allows them to track their storage balances more easily. This commit adds an admin tool that can help migrate archives from the old accounting system to the new one by backfilling the storage ledger for all items in the archive that weren't originally included therein.