### PR TITLE
Update EKS clusters to Kubernetes 1.32

### DIFF
--- a/terraform/prod_cluster/eks-cluster.tf
+++ b/terraform/prod_cluster/eks-cluster.tf
@@ -3,7 +3,7 @@ module "eks" {
   version = "19.0.4"
 
   cluster_name    = local.cluster_name
-  cluster_version = "1.30"
+  cluster_version = "1.32"
 
   vpc_id                         = var.vpc_id
   subnet_ids                     = var.subnet_ids

--- a/terraform/test_cluster/eks-cluster.tf
+++ b/terraform/test_cluster/eks-cluster.tf
@@ -3,7 +3,7 @@ module "eks" {
   version = "19.0.4"
 
   cluster_name    = local.cluster_name
-  cluster_version = "1.30"
+  cluster_version = "1.32"
 
   vpc_id                         = var.vpc_id
   subnet_ids                     = var.subnet_ids


### PR DESCRIPTION
Kubernetes 1.30 will exit standard support on EKS in July (and thus become more expensive). To avoid cost increases, this commit updates our EKS clusters to the lastest Kubernetes version, 1.32.