### PR TITLE
Switch to EditorConfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,9 @@
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 2
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-  "editor.tabSize": 2
-}


### PR DESCRIPTION
This PR (1) sets up an editorconfig file in line with our other repositories and (2) removes developer-specific settings.

@liam-lloyd if you're up for it, you could add `.vs-code` to your global gitignore (`~/.gitignore`) which means it wouldn't be committed with a project unless you explicitly wanted to.  Generally I believe this is a best practice to separate individual dev env settings from the general code base.  I'm also happy to leave that part in if that's preferred!

Resolves #217