### PR TITLE
Remove package node types dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20445,7 +20445,6 @@
 				"@stela/file-utils": "^1.0.0",
 				"@stela/logger": "^1.0.0",
 				"@stela/s3-utils": "^1.0.0",
-				"@types/node": "^12.20.55",
 				"ajv": "^8.17.1",
 				"aws-cloudfront-sign": "^3.0.2",
 				"dotenv": "^16.5.0",
@@ -20540,14 +20539,6 @@
 				"node": ">=18"
 			}
 		},
-		"packages/access_copy_attacher/node_modules/@types/node": {
-			"version": "22.9.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.9.0.tgz",
-			"integrity": "sha512-vuyHg81vvWA1Z1ELfvLko2c8f34gyA0zaic0+Rllc5lbCnbSyuvb2Oxpm6TAUAC/2xZN3QGqxBNggD1nNR2AfQ==",
-			"dependencies": {
-				"undici-types": "~6.19.8"
-			}
-		},
 		"packages/access_copy_attacher/node_modules/ajv": {
 			"version": "8.17.1",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-8.17.1.tgz",
@@ -20594,11 +20585,6 @@
 			"resolved": "https://registry.npmjs.org/require-env-variable/-/require-env-variable-4.0.2.tgz",
 			"integrity": "sha512-gdVmg7tVno0u5MokVSVeuRDSez1XyktsGaNCJfdEqrU40OUXw1oG7MWVPr8PLC7UJul6L98hjULh1e2pmGwdPg==",
 			"license": "MIT"
-		},
-		"packages/access_copy_attacher/node_modules/undici-types": {
-			"version": "6.19.8",
-			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
-			"integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw=="
 		},
 		"packages/account_space_updater": {
 			"name": "@stela/account_space_updater",

--- a/packages/access_copy_attacher/package.json
+++ b/packages/access_copy_attacher/package.json
@@ -38,7 +38,6 @@
 		"@stela/s3-utils": "^1.0.0",
 		"@stela/archivematica-utils": "^1.0.0",
 		"@stela/file-utils": "^1.0.0",
-		"@types/node": "^12.20.55",
 		"ajv": "^8.17.1",
 		"aws-cloudfront-sign": "^3.0.2",
 		"dotenv": "^16.5.0",


### PR DESCRIPTION
This PR removes a dependency for @types/node from one of our stela packages; we already have the types dependency at the root level so this was redundant.