### PR TITLE
Remove unnecessary body-parser dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -100,8 +100,7 @@
 		},
 		"node_modules/@aws-crypto/crc32c": {
 			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
-			"integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/util": "^5.2.0",
 				"@aws-sdk/types": "^3.222.0",
@@ -259,8 +258,7 @@
 		},
 		"node_modules/@aws-sdk/client-s3": {
 			"version": "3.879.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.879.0.tgz",
-			"integrity": "sha512-1bD2Do/OdCIzl72ncHKYamDhPijUErLYpuLvciyYD4Ywt4cVLHjWtVIqb22XOOHYYHE3NqHMd4uRhvXMlsBRoQ==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha1-browser": "5.2.0",
 				"@aws-crypto/sha256-browser": "5.2.0",
@@ -331,8 +329,7 @@
 		},
 		"node_modules/@aws-sdk/client-sns": {
 			"version": "3.879.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.879.0.tgz",
-			"integrity": "sha512-nIsDf0FjE/A1HGTBggz9Cwr1CWch9UcRZH+9XqFbtCpiWiVe7guOcviY2mML5z9B6njXh/4K8+Fq608KtlRV0Q==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
@@ -380,8 +377,7 @@
 		},
 		"node_modules/@aws-sdk/client-sso": {
 			"version": "3.879.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.879.0.tgz",
-			"integrity": "sha512-+Pc3OYFpRYpKLKRreovPM63FPPud1/SF9vemwIJfz6KwsBCJdvg7vYD1xLSIp5DVZLeetgf4reCyAA5ImBfZuw==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
@@ -428,8 +424,7 @@
 		},
 		"node_modules/@aws-sdk/core": {
 			"version": "3.879.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.879.0.tgz",
-			"integrity": "sha512-AhNmLCrx980LsK+SfPXGh7YqTyZxsK0Qmy18mWmkfY0TSq7WLaSDB5zdQbgbnQCACCHy8DUYXbi4KsjlIhv3PA==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "3.862.0",
 				"@aws-sdk/xml-builder": "3.873.0",
@@ -453,14 +448,13 @@
 		},
 		"node_modules/@aws-sdk/core/node_modules/fast-xml-parser": {
 			"version": "5.2.5",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.2.5.tgz",
-			"integrity": "sha512-pfX9uG9Ki0yekDHx2SiuRIyFdyAr1kMIMitPvb0YBo8SUfKvia7w7FIyd/l6av85pFYRhZscS75MwMnbvY+hcQ==",
 			"funding": [
 				{
 					"type": "github",
 					"url": "https://github.com/sponsors/NaturalIntelligence"
 				}
 			],
+			"license": "MIT",
 			"dependencies": {
 				"strnum": "^2.1.0"
 			},
@@ -470,19 +464,17 @@
 		},
 		"node_modules/@aws-sdk/core/node_modules/strnum": {
 			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/strnum/-/strnum-2.1.1.tgz",
-			"integrity": "sha512-7ZvoFTiCnGxBtDqJ//Cu6fWtZtc7Y3x+QOirG15wztbdngGSkht27o2pyGWrVy0b4WAy3jbKmnoK6g5VlVNUUw==",
 			"funding": [
 				{
 					"type": "github",
 					"url": "https://github.com/sponsors/NaturalIntelligence"
 				}
-			]
+			],
+			"license": "MIT"
 		},
 		"node_modules/@aws-sdk/credential-provider-env": {
 			"version": "3.879.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.879.0.tgz",
-			"integrity": "sha512-JgG7A8SSbr5IiCYL8kk39Y9chdSB5GPwBorDW8V8mr19G9L+qd6ohED4fAocoNFaDnYJ5wGAHhCfSJjzcsPBVQ==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "3.879.0",
 				"@aws-sdk/types": "3.862.0",
@@ -496,8 +488,7 @@
 		},
 		"node_modules/@aws-sdk/credential-provider-http": {
 			"version": "3.879.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.879.0.tgz",
-			"integrity": "sha512-2hM5ByLpyK+qORUexjtYyDZsgxVCCUiJQZRMGkNXFEGz6zTpbjfTIWoh3zRgWHEBiqyPIyfEy50eIF69WshcuA==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "3.879.0",
 				"@aws-sdk/types": "3.862.0",
@@ -516,8 +507,7 @@
 		},
 		"node_modules/@aws-sdk/credential-provider-ini": {
 			"version": "3.879.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.879.0.tgz",
-			"integrity": "sha512-07M8zfb73KmMBqVO5/V3Ea9kqDspMX0fO0kaI1bsjWI6ngnMye8jCE0/sIhmkVAI0aU709VA0g+Bzlopnw9EoQ==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "3.879.0",
 				"@aws-sdk/credential-provider-env": "3.879.0",
@@ -539,8 +529,7 @@
 		},
 		"node_modules/@aws-sdk/credential-provider-node": {
 			"version": "3.879.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.879.0.tgz",
-			"integrity": "sha512-FYaAqJbnSTrVL2iZkNDj2hj5087yMv2RN2GA8DJhe7iOJjzhzRojrtlfpWeJg6IhK0sBKDH+YXbdeexCzUJvtA==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/credential-provider-env": "3.879.0",
 				"@aws-sdk/credential-provider-http": "3.879.0",
@@ -561,8 +550,7 @@
 		},
 		"node_modules/@aws-sdk/credential-provider-process": {
 			"version": "3.879.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.879.0.tgz",
-			"integrity": "sha512-7r360x1VyEt35Sm1JFOzww2WpnfJNBbvvnzoyLt7WRfK0S/AfsuWhu5ltJ80QvJ0R3AiSNbG+q/btG2IHhDYPQ==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "3.879.0",
 				"@aws-sdk/types": "3.862.0",
@@ -577,8 +565,7 @@
 		},
 		"node_modules/@aws-sdk/credential-provider-sso": {
 			"version": "3.879.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.879.0.tgz",
-			"integrity": "sha512-gd27B0NsgtKlaPNARj4IX7F7US5NuU691rGm0EUSkDsM7TctvJULighKoHzPxDQlrDbVI11PW4WtKS/Zg5zPlQ==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/client-sso": "3.879.0",
 				"@aws-sdk/core": "3.879.0",
@@ -595,8 +582,7 @@
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity": {
 			"version": "3.879.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.879.0.tgz",
-			"integrity": "sha512-Jy4uPFfGzHk1Mxy+/Wr43vuw9yXsE2yiF4e4598vc3aJfO0YtA2nSfbKD3PNKRORwXbeKqWPfph9SCKQpWoxEg==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "3.879.0",
 				"@aws-sdk/nested-clients": "3.879.0",
@@ -611,8 +597,7 @@
 		},
 		"node_modules/@aws-sdk/middleware-bucket-endpoint": {
 			"version": "3.873.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.873.0.tgz",
-			"integrity": "sha512-b4bvr0QdADeTUs+lPc9Z48kXzbKHXQKgTvxx/jXDgSW9tv4KmYPO1gIj6Z9dcrBkRWQuUtSW3Tu2S5n6pe+zeg==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "3.862.0",
 				"@aws-sdk/util-arn-parser": "3.873.0",
@@ -628,8 +613,7 @@
 		},
 		"node_modules/@aws-sdk/middleware-expect-continue": {
 			"version": "3.873.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.873.0.tgz",
-			"integrity": "sha512-GIqoc8WgRcf/opBOZXFLmplJQKwOMjiOMmDz9gQkaJ8FiVJoAp8EGVmK2TOWZMQUYsavvHYsHaor5R2xwPoGVg==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "3.862.0",
 				"@smithy/protocol-http": "^5.1.3",
@@ -642,8 +626,7 @@
 		},
 		"node_modules/@aws-sdk/middleware-flexible-checksums": {
 			"version": "3.879.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.879.0.tgz",
-			"integrity": "sha512-U1rcWToy2rlQPQLsx5h73uTC1XYo/JpnlJGCc3Iw7b1qrK8Mke4+rgMPKCfnXELD5TTazGrbT03frxH4Y1Ycvw==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/crc32": "5.2.0",
 				"@aws-crypto/crc32c": "5.2.0",
@@ -665,8 +648,7 @@
 		},
 		"node_modules/@aws-sdk/middleware-host-header": {
 			"version": "3.873.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.873.0.tgz",
-			"integrity": "sha512-KZ/W1uruWtMOs7D5j3KquOxzCnV79KQW9MjJFZM/M0l6KI8J6V3718MXxFHsTjUE4fpdV6SeCNLV1lwGygsjJA==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "3.862.0",
 				"@smithy/protocol-http": "^5.1.3",
@@ -679,8 +661,7 @@
 		},
 		"node_modules/@aws-sdk/middleware-location-constraint": {
 			"version": "3.873.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.873.0.tgz",
-			"integrity": "sha512-r+hIaORsW/8rq6wieDordXnA/eAu7xAPLue2InhoEX6ML7irP52BgiibHLpt9R0psiCzIHhju8qqKa4pJOrmiw==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "3.862.0",
 				"@smithy/types": "^4.3.2",
@@ -692,8 +673,7 @@
 		},
 		"node_modules/@aws-sdk/middleware-logger": {
 			"version": "3.876.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.876.0.tgz",
-			"integrity": "sha512-cpWJhOuMSyz9oV25Z/CMHCBTgafDCbv7fHR80nlRrPdPZ8ETNsahwRgltXP1QJJ8r3X/c1kwpOR7tc+RabVzNA==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "3.862.0",
 				"@smithy/types": "^4.3.2",
@@ -705,8 +685,7 @@
 		},
 		"node_modules/@aws-sdk/middleware-recursion-detection": {
 			"version": "3.873.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.873.0.tgz",
-			"integrity": "sha512-OtgY8EXOzRdEWR//WfPkA/fXl0+WwE8hq0y9iw2caNyKPtca85dzrrZWnPqyBK/cpImosrpR1iKMYr41XshsCg==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "3.862.0",
 				"@smithy/protocol-http": "^5.1.3",
@@ -719,8 +698,7 @@
 		},
 		"node_modules/@aws-sdk/middleware-sdk-s3": {
 			"version": "3.879.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.879.0.tgz",
-			"integrity": "sha512-ZTpLr2AbZcCsEzu18YCtB8Tp8tjAWHT0ccfwy3HiL6g9ncuSMW+7BVi1hDYmBidFwpPbnnIMtM0db3pDMR6/WA==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "3.879.0",
 				"@aws-sdk/types": "3.862.0",
@@ -743,8 +721,7 @@
 		},
 		"node_modules/@aws-sdk/middleware-ssec": {
 			"version": "3.873.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.873.0.tgz",
-			"integrity": "sha512-AF55J94BoiuzN7g3hahy0dXTVZahVi8XxRBLgzNp6yQf0KTng+hb/V9UQZVYY1GZaDczvvvnqC54RGe9OZZ9zQ==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "3.862.0",
 				"@smithy/types": "^4.3.2",
@@ -756,8 +733,7 @@
 		},
 		"node_modules/@aws-sdk/middleware-user-agent": {
 			"version": "3.879.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.879.0.tgz",
-			"integrity": "sha512-DDSV8228lQxeMAFKnigkd0fHzzn5aauZMYC3CSj6e5/qE7+9OwpkUcjHfb7HZ9KWG6L2/70aKZXHqiJ4xKhOZw==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "3.879.0",
 				"@aws-sdk/types": "3.862.0",
@@ -773,8 +749,7 @@
 		},
 		"node_modules/@aws-sdk/nested-clients": {
 			"version": "3.879.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.879.0.tgz",
-			"integrity": "sha512-7+n9NpIz9QtKYnxmw1fHi9C8o0GrX8LbBR4D50c7bH6Iq5+XdSuL5AFOWWQ5cMD0JhqYYJhK/fJsVau3nUtC4g==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
@@ -821,8 +796,7 @@
 		},
 		"node_modules/@aws-sdk/region-config-resolver": {
 			"version": "3.873.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/region-config-resolver/-/region-config-resolver-3.873.0.tgz",
-			"integrity": "sha512-q9sPoef+BBG6PJnc4x60vK/bfVwvRWsPgcoQyIra057S/QGjq5VkjvNk6H8xedf6vnKlXNBwq9BaANBXnldUJg==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "3.862.0",
 				"@smithy/node-config-provider": "^4.1.4",
@@ -837,8 +811,7 @@
 		},
 		"node_modules/@aws-sdk/signature-v4-multi-region": {
 			"version": "3.879.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.879.0.tgz",
-			"integrity": "sha512-MDsw0EWOHyKac75X3gD8tLWtmPuRliS/s4IhWRhsdDCU13wewHIs5IlA5B65kT6ISf49yEIalEH3FHUSVqdmIQ==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/middleware-sdk-s3": "3.879.0",
 				"@aws-sdk/types": "3.862.0",
@@ -853,8 +826,7 @@
 		},
 		"node_modules/@aws-sdk/token-providers": {
 			"version": "3.879.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.879.0.tgz",
-			"integrity": "sha512-47J7sCwXdnw9plRZNAGVkNEOlSiLb/kR2slnDIHRK9NB/ECKsoqgz5OZQJ9E2f0yqOs8zSNJjn3T01KxpgW8Qw==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "3.879.0",
 				"@aws-sdk/nested-clients": "3.879.0",
@@ -881,8 +853,7 @@
 		},
 		"node_modules/@aws-sdk/util-arn-parser": {
 			"version": "3.873.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-arn-parser/-/util-arn-parser-3.873.0.tgz",
-			"integrity": "sha512-qag+VTqnJWDn8zTAXX4wiVioa0hZDQMtbZcGRERVnLar4/3/VIKBhxX2XibNQXFu1ufgcRn4YntT/XEPecFWcg==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
 			},
@@ -892,8 +863,7 @@
 		},
 		"node_modules/@aws-sdk/util-endpoints": {
 			"version": "3.879.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.879.0.tgz",
-			"integrity": "sha512-aVAJwGecYoEmbEFju3127TyJDF9qJsKDUUTRMDuS8tGn+QiWQFnfInmbt+el9GU1gEJupNTXV+E3e74y51fb7A==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "3.862.0",
 				"@smithy/types": "^4.3.2",
@@ -917,8 +887,7 @@
 		},
 		"node_modules/@aws-sdk/util-user-agent-browser": {
 			"version": "3.873.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.873.0.tgz",
-			"integrity": "sha512-AcRdbK6o19yehEcywI43blIBhOCSo6UgyWcuOJX5CFF8k39xm1ILCjQlRRjchLAxWrm0lU0Q7XV90RiMMFMZtA==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "3.862.0",
 				"@smithy/types": "^4.3.2",
@@ -928,8 +897,7 @@
 		},
 		"node_modules/@aws-sdk/util-user-agent-node": {
 			"version": "3.879.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.879.0.tgz",
-			"integrity": "sha512-A5KGc1S+CJRzYnuxJQQmH1BtGsz46AgyHkqReKfGiNQA8ET/9y9LQ5t2ABqnSBHHIh3+MiCcQSkUZ0S3rTodrQ==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/middleware-user-agent": "3.879.0",
 				"@aws-sdk/types": "3.862.0",
@@ -951,8 +919,7 @@
 		},
 		"node_modules/@aws-sdk/xml-builder": {
 			"version": "3.873.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.873.0.tgz",
-			"integrity": "sha512-kLO7k7cGJ6KaHiExSJWojZurF7SnGMDHXRuQunFnEoD0n1yB6Lqy/S/zHiQ7oJnBhPr9q0TW9qFkrsZb1Uc54w==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.3.2",
 				"tslib": "^2.6.2"
@@ -1597,9 +1564,8 @@
 		},
 		"node_modules/@eslint/js": {
 			"version": "9.34.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.34.0.tgz",
-			"integrity": "sha512-EoyvqQnBNsV1CWaEJ559rxXL4c8V92gxirbawSmVUOWXlsRxxQXl6LmCpdUblgxgSkDIqKnhzba2SjRTI/A5Rw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
@@ -2903,8 +2869,7 @@
 		},
 		"node_modules/@opentelemetry/instrumentation-aws-sdk": {
 			"version": "0.57.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-aws-sdk/-/instrumentation-aws-sdk-0.57.0.tgz",
-			"integrity": "sha512-RfbyjaeZzX3mPhuaRHlSAQyfX3skfeWOl30jrqSXtE9k0DPdnIqpHhdYS0C/DEDuZbwTmruVJ4cUwMBw5Z6FAg==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/core": "^2.0.0",
 				"@opentelemetry/instrumentation": "^0.203.0",
@@ -2943,8 +2908,7 @@
 		},
 		"node_modules/@opentelemetry/instrumentation-dataloader": {
 			"version": "0.21.1",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-dataloader/-/instrumentation-dataloader-0.21.1.tgz",
-			"integrity": "sha512-hNAm/bwGawLM8VDjKR0ZUDJ/D/qKR3s6lA5NV+btNaPVm2acqhPcT47l2uCVi+70lng2mywfQncor9v8/ykuyw==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/instrumentation": "^0.203.0"
 			},
@@ -3079,8 +3043,7 @@
 		},
 		"node_modules/@opentelemetry/instrumentation-kafkajs": {
 			"version": "0.13.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-kafkajs/-/instrumentation-kafkajs-0.13.0.tgz",
-			"integrity": "sha512-FPQyJsREOaGH64hcxlzTsIEQC4DYANgTwHjiB7z9lldmvua1LRMVn3/FfBlzXoqF179B0VGYviz6rn75E9wsDw==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/instrumentation": "^0.203.0",
 				"@opentelemetry/semantic-conventions": "^1.30.0"
@@ -3201,8 +3164,7 @@
 		},
 		"node_modules/@opentelemetry/instrumentation-mysql2": {
 			"version": "0.50.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation-mysql2/-/instrumentation-mysql2-0.50.0.tgz",
-			"integrity": "sha512-PoOMpmq73rOIE3nlTNLf3B1SyNYGsp7QXHYKmeTZZnJ2Ou7/fdURuOhWOI0e6QZ5gSem18IR1sJi6GOULBQJ9g==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/instrumentation": "^0.203.0",
 				"@opentelemetry/semantic-conventions": "^1.27.0",
@@ -3340,8 +3302,7 @@
 		},
 		"node_modules/@opentelemetry/propagation-utils": {
 			"version": "0.31.3",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/propagation-utils/-/propagation-utils-0.31.3.tgz",
-			"integrity": "sha512-ZI6LKjyo+QYYZY5SO8vfoCQ9A69r1/g+pyjvtu5RSK38npINN1evEmwqbqhbg2CdcIK3a4PN6pDAJz/yC5/gAA==",
+			"license": "Apache-2.0",
 			"engines": {
 				"node": "^18.19.0 || >=20.6.0"
 			},
@@ -3488,8 +3449,7 @@
 		},
 		"node_modules/@prisma/instrumentation": {
 			"version": "6.14.0",
-			"resolved": "https://registry.npmjs.org/@prisma/instrumentation/-/instrumentation-6.14.0.tgz",
-			"integrity": "sha512-Po/Hry5bAeunRDq0yAQueKookW3glpP+qjjvvyOfm6dI2KG5/Y6Bgg3ahyWd7B0u2E+Wf9xRk2rtdda7ySgK1A==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/instrumentation": "^0.52.0 || ^0.53.0 || ^0.54.0 || ^0.55.0 || ^0.56.0 || ^0.57.0"
 			},
@@ -3499,8 +3459,7 @@
 		},
 		"node_modules/@prisma/instrumentation/node_modules/@opentelemetry/api-logs": {
 			"version": "0.57.2",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.57.2.tgz",
-			"integrity": "sha512-uIX52NnTM0iBh84MShlpouI7UKqkZ7MrUszTmaypHBu4r7NofznSnQRfJ+uUeDtQDj6w8eFGg5KBLDAwAPz1+A==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/api": "^1.3.0"
 			},
@@ -3510,8 +3469,7 @@
 		},
 		"node_modules/@prisma/instrumentation/node_modules/@opentelemetry/instrumentation": {
 			"version": "0.57.2",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/instrumentation/-/instrumentation-0.57.2.tgz",
-			"integrity": "sha512-BdBGhQBh8IjZ2oIIX6F2/Q3LKm/FDDKi6ccYKcBTeilh6SNdNKveDOLk73BkSJjQLJk6qe4Yh+hHw1UPhCDdrg==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/api-logs": "0.57.2",
 				"@types/shimmer": "^1.2.0",
@@ -3879,8 +3837,7 @@
 		},
 		"node_modules/@sentry/aws-serverless": {
 			"version": "10.8.0",
-			"resolved": "https://registry.npmjs.org/@sentry/aws-serverless/-/aws-serverless-10.8.0.tgz",
-			"integrity": "sha512-W+xlx+xwPAM52tlajQDz/fv0ltVuo5yenFNlwIqI8Eav0gvkUI/MsHKQ3bdcpI6HL+c26PpkkjdtavZTaMohFw==",
+			"license": "MIT",
 			"dependencies": {
 				"@opentelemetry/api": "^1.9.0",
 				"@opentelemetry/instrumentation": "^0.203.0",
@@ -3896,24 +3853,21 @@
 		},
 		"node_modules/@sentry/aws-serverless/node_modules/@opentelemetry/semantic-conventions": {
 			"version": "1.36.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/semantic-conventions/-/semantic-conventions-1.36.0.tgz",
-			"integrity": "sha512-TtxJSRD8Ohxp6bKkhrm27JRHAxPczQA7idtcTOMYI+wQRRrfgqxHv1cFbCApcSnNjtXkmzFozn6jQtFrOmbjPQ==",
+			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=14"
 			}
 		},
 		"node_modules/@sentry/core": {
 			"version": "10.8.0",
-			"resolved": "https://registry.npmjs.org/@sentry/core/-/core-10.8.0.tgz",
-			"integrity": "sha512-scYzM/UOItu4PjEq6CpHLdArpXjIS0laHYxE4YjkIbYIH6VMcXGQbD/FSBClsnCr1wXRnlXfXBzj0hrQAFyw+Q==",
+			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			}
 		},
 		"node_modules/@sentry/node": {
 			"version": "10.8.0",
-			"resolved": "https://registry.npmjs.org/@sentry/node/-/node-10.8.0.tgz",
-			"integrity": "sha512-1TtCjxzn4SxoGw+ulLK+jF/v9NaZfP0yCclQIqfvWNDjMf2F+SbZL1UnXx4L184FGlNpRQnJBDrBe88gxnMX0A==",
+			"license": "MIT",
 			"dependencies": {
 				"@opentelemetry/api": "^1.9.0",
 				"@opentelemetry/context-async-hooks": "^2.0.0",
@@ -3957,8 +3911,7 @@
 		},
 		"node_modules/@sentry/node-core": {
 			"version": "10.8.0",
-			"resolved": "https://registry.npmjs.org/@sentry/node-core/-/node-core-10.8.0.tgz",
-			"integrity": "sha512-KCFy5Otq6KTXge8hBKMgU13EDRFkO4gNwSyZGXub8a7KHYFtoUgpRkborR59SWxeJmC6aEYTyh0PyOoWZJbHUQ==",
+			"license": "MIT",
 			"dependencies": {
 				"@sentry/core": "10.8.0",
 				"@sentry/opentelemetry": "10.8.0",
@@ -3979,8 +3932,7 @@
 		},
 		"node_modules/@sentry/node/node_modules/minimatch": {
 			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
+			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^2.0.1"
 			},
@@ -3993,8 +3945,7 @@
 		},
 		"node_modules/@sentry/opentelemetry": {
 			"version": "10.8.0",
-			"resolved": "https://registry.npmjs.org/@sentry/opentelemetry/-/opentelemetry-10.8.0.tgz",
-			"integrity": "sha512-62R/RPwTYVaiZ5lVcxcjHCAGwgCyfn8Q3kaQld8/LPm8FRizZeUJmmtrI80KaYCvPJhSB/Pvfma4X3w+aN5Q3A==",
+			"license": "MIT",
 			"dependencies": {
 				"@sentry/core": "10.8.0"
 			},
@@ -4011,8 +3962,7 @@
 		},
 		"node_modules/@sentry/profiling-node": {
 			"version": "10.8.0",
-			"resolved": "https://registry.npmjs.org/@sentry/profiling-node/-/profiling-node-10.8.0.tgz",
-			"integrity": "sha512-3x8VRhEjJGQzICb6exM7sHA+Gi9EVeBszo0IPtAZAQLI7nuSb0q3PbV1gRIF09t1qRkRcj/VnpM4mc9Kk8G54Q==",
+			"license": "MIT",
 			"dependencies": {
 				"@sentry-internal/node-cpu-profiler": "^2.2.0",
 				"@sentry/core": "10.8.0",
@@ -4094,8 +4044,7 @@
 		},
 		"node_modules/@smithy/core": {
 			"version": "3.9.1",
-			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.9.1.tgz",
-			"integrity": "sha512-E3erEn1SjPq8P9w2fPlp1+slaq6FlrRKlsaLCo0aPMY2j94lwZlwz1yqY4yDeX3+ViG+sOEPPRBZGfdciMtABA==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/middleware-serde": "^4.0.9",
 				"@smithy/protocol-http": "^5.1.3",
@@ -4115,13 +4064,11 @@
 		},
 		"node_modules/@smithy/core/node_modules/@types/uuid": {
 			"version": "9.0.8",
-			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
-			"integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA=="
+			"license": "MIT"
 		},
 		"node_modules/@smithy/credential-provider-imds": {
 			"version": "4.0.7",
-			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.0.7.tgz",
-			"integrity": "sha512-dDzrMXA8d8riFNiPvytxn0mNwR4B3h8lgrQ5UjAGu6T9z/kRg/Xncf4tEQHE/+t25sY8IH3CowcmWi+1U5B1Gw==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/node-config-provider": "^4.1.4",
 				"@smithy/property-provider": "^4.0.5",
@@ -4292,8 +4239,7 @@
 		},
 		"node_modules/@smithy/middleware-endpoint": {
 			"version": "4.1.20",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-endpoint/-/middleware-endpoint-4.1.20.tgz",
-			"integrity": "sha512-6jwjI4l9LkpEN/77ylyWsA6o81nKSIj8itRjtPpVqYSf+q8b12uda0Upls5CMSDXoL/jY2gPsNj+/Tg3gbYYew==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/core": "^3.9.1",
 				"@smithy/middleware-serde": "^4.0.9",
@@ -4310,8 +4256,7 @@
 		},
 		"node_modules/@smithy/middleware-retry": {
 			"version": "4.1.21",
-			"resolved": "https://registry.npmjs.org/@smithy/middleware-retry/-/middleware-retry-4.1.21.tgz",
-			"integrity": "sha512-oFpp+4JfNef0Mp2Jw8wIl1jVxjhUU3jFZkk3UTqBtU5Xp6/ahTu6yo1EadWNPAnCjKTo8QB6Q+SObX97xfMUtA==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/node-config-provider": "^4.1.4",
 				"@smithy/protocol-http": "^5.1.3",
@@ -4330,8 +4275,7 @@
 		},
 		"node_modules/@smithy/middleware-retry/node_modules/@types/uuid": {
 			"version": "9.0.8",
-			"resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
-			"integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA=="
+			"license": "MIT"
 		},
 		"node_modules/@smithy/middleware-serde": {
 			"version": "4.0.9",
@@ -4451,8 +4395,7 @@
 		},
 		"node_modules/@smithy/signature-v4": {
 			"version": "5.1.3",
-			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.1.3.tgz",
-			"integrity": "sha512-mARDSXSEgllNzMw6N+mC+r1AQlEBO3meEAkR/UlfAgnMzJUB3goRBWgip1EAMG99wh36MDqzo86SfIX5Y+VEaw==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/is-array-buffer": "^4.0.0",
 				"@smithy/protocol-http": "^5.1.3",
@@ -4469,8 +4412,7 @@
 		},
 		"node_modules/@smithy/smithy-client": {
 			"version": "4.5.1",
-			"resolved": "https://registry.npmjs.org/@smithy/smithy-client/-/smithy-client-4.5.1.tgz",
-			"integrity": "sha512-PuvtnQgwpy3bb56YvHAP7eRwp862yJxtQno40UX9kTjjkgTlo//ov+e1IVCFTiELcAOiqF2++Y0e7eH/Zgv5Vw==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/core": "^3.9.1",
 				"@smithy/middleware-endpoint": "^4.1.20",
@@ -4561,8 +4503,7 @@
 		},
 		"node_modules/@smithy/util-defaults-mode-browser": {
 			"version": "4.0.28",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-browser/-/util-defaults-mode-browser-4.0.28.tgz",
-			"integrity": "sha512-83Iqb9c443d8S/9PD6Bb770Q3ZvCenfgJDoR98iveI+zKpu6d4mOVS2RKBU9Z4VQPbRcrRj71SY0kZePGh+wZg==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/property-provider": "^4.0.5",
 				"@smithy/smithy-client": "^4.5.1",
@@ -4576,8 +4517,7 @@
 		},
 		"node_modules/@smithy/util-defaults-mode-node": {
 			"version": "4.0.28",
-			"resolved": "https://registry.npmjs.org/@smithy/util-defaults-mode-node/-/util-defaults-mode-node-4.0.28.tgz",
-			"integrity": "sha512-LzklW4HepBM198vH0C3v+WSkMHOkxu7axCEqGoKdICz3RHLq+mDs2AkDDXVtB61+SHWoiEsc6HOObzVQbNLO0Q==",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/config-resolver": "^4.1.5",
 				"@smithy/credential-provider-imds": "^4.0.7",
@@ -4989,8 +4929,7 @@
 		},
 		"node_modules/@types/node": {
 			"version": "22.18.0",
-			"resolved": "https://registry.npmjs.org/@types/node/-/node-22.18.0.tgz",
-			"integrity": "sha512-m5ObIqwsUp6BZzyiy4RdZpzWGub9bqLJMvZDD0QMXhxjqMHMENlj+SqF5QxoUwaQNFe+8kz8XM8ZQhqkQPTgMQ==",
+			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~6.21.0"
 			}
@@ -5050,8 +4989,7 @@
 		},
 		"node_modules/@types/shimmer": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/@types/shimmer/-/shimmer-1.2.0.tgz",
-			"integrity": "sha512-UE7oxhQLLd9gub6JKIAhDq06T0F6FnztwMNRvYgjeQSBeMc1ZG/tA47EwfduvkuQS8apbkM/lpLpWsaCeYsXVg=="
+			"license": "MIT"
 		},
 		"node_modules/@types/stack-utils": {
 			"version": "2.0.3",
@@ -5125,9 +5063,8 @@
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "8.42.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.42.0.tgz",
-			"integrity": "sha512-Aq2dPqsQkxHOLfb2OPv43RnIvfj05nw8v/6n3B2NABIPpHnjQnaLo9QGMTvml+tv4korl/Cjfrb/BYhoL8UUTQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.10.0",
 				"@typescript-eslint/scope-manager": "8.42.0",
@@ -5162,9 +5099,8 @@
 		},
 		"node_modules/@typescript-eslint/parser": {
 			"version": "8.42.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.42.0.tgz",
-			"integrity": "sha512-r1XG74QgShUgXph1BYseJ+KZd17bKQib/yF3SR+demvytiRXrwd12Blnz5eYGm8tXaeRdd4x88MlfwldHoudGg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@typescript-eslint/scope-manager": "8.42.0",
 				"@typescript-eslint/types": "8.42.0",
@@ -5186,9 +5122,8 @@
 		},
 		"node_modules/@typescript-eslint/project-service": {
 			"version": "8.42.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.42.0.tgz",
-			"integrity": "sha512-vfVpLHAhbPjilrabtOSNcUDmBboQNrJUiNAGoImkZKnMjs2TIcWG33s4Ds0wY3/50aZmTMqJa6PiwkwezaAklg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@typescript-eslint/tsconfig-utils": "^8.42.0",
 				"@typescript-eslint/types": "^8.42.0",
@@ -5207,9 +5142,8 @@
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
 			"version": "8.42.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.42.0.tgz",
-			"integrity": "sha512-51+x9o78NBAVgQzOPd17DkNTnIzJ8T/O2dmMBLoK9qbY0Gm52XJcdJcCl18ExBMiHo6jPMErUQWUv5RLE51zJw==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@typescript-eslint/types": "8.42.0",
 				"@typescript-eslint/visitor-keys": "8.42.0"
@@ -5224,9 +5158,8 @@
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
 			"version": "8.42.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.42.0.tgz",
-			"integrity": "sha512-kHeFUOdwAJfUmYKjR3CLgZSglGHjbNTi1H8sTYRYV2xX6eNz4RyJ2LIgsDLKf8Yi0/GL1WZAC/DgZBeBft8QAQ==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
@@ -5240,9 +5173,8 @@
 		},
 		"node_modules/@typescript-eslint/type-utils": {
 			"version": "8.42.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.42.0.tgz",
-			"integrity": "sha512-9KChw92sbPTYVFw3JLRH1ockhyR3zqqn9lQXol3/YbI6jVxzWoGcT3AsAW0mu1MY0gYtsXnUGV/AKpkAj5tVlQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@typescript-eslint/types": "8.42.0",
 				"@typescript-eslint/typescript-estree": "8.42.0",
@@ -5264,9 +5196,8 @@
 		},
 		"node_modules/@typescript-eslint/types": {
 			"version": "8.42.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.42.0.tgz",
-			"integrity": "sha512-LdtAWMiFmbRLNP7JNeY0SqEtJvGMYSzfiWBSmx+VSZ1CH+1zyl8Mmw1TT39OrtsRvIYShjJWzTDMPWZJCpwBlw==",
 			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
@@ -5277,9 +5208,8 @@
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
 			"version": "8.42.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.42.0.tgz",
-			"integrity": "sha512-ku/uYtT4QXY8sl9EDJETD27o3Ewdi72hcXg1ah/kkUgBvAYHLwj2ofswFFNXS+FL5G+AGkxBtvGt8pFBHKlHsQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@typescript-eslint/project-service": "8.42.0",
 				"@typescript-eslint/tsconfig-utils": "8.42.0",
@@ -5305,9 +5235,8 @@
 		},
 		"node_modules/@typescript-eslint/typescript-estree/node_modules/minimatch": {
 			"version": "9.0.5",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.5.tgz",
-			"integrity": "sha512-G6T0ZX48xgozx7587koeX9Ys2NYy6Gmv//P89sEte9V9whIapMNF4idKxnW2QtCcLiTWlb/wfCabAtAFWhhBow==",
 			"dev": true,
+			"license": "ISC",
 			"dependencies": {
 				"brace-expansion": "^2.0.1"
 			},
@@ -5320,9 +5249,8 @@
 		},
 		"node_modules/@typescript-eslint/utils": {
 			"version": "8.42.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.42.0.tgz",
-			"integrity": "sha512-JnIzu7H3RH5BrKC4NoZqRfmjqCIS1u3hGZltDYJgkVdqAezl4L9d1ZLw+36huCujtSBSAirGINF/S4UxOcR+/g==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.7.0",
 				"@typescript-eslint/scope-manager": "8.42.0",
@@ -5343,9 +5271,8 @@
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
 			"version": "8.42.0",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.42.0.tgz",
-			"integrity": "sha512-3WbiuzoEowaEn8RSnhJBrxSwX8ULYE9CXaPepS2C2W3NSA5NNIvBaslpBSBElPq0UGr0xVJlXFWOAKIkyylydQ==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@typescript-eslint/types": "8.42.0",
 				"eslint-visitor-keys": "^4.2.1"
@@ -5989,8 +5916,7 @@
 		},
 		"node_modules/bowser": {
 			"version": "2.12.1",
-			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.12.1.tgz",
-			"integrity": "sha512-z4rE2Gxh7tvshQ4hluIT7XcFrgLIQaw9X3A+kTTRdovCz5PMukm/0QC/BKSYPj3omF5Qfypn9O/c5kgpmvYUCw=="
+			"license": "MIT"
 		},
 		"node_modules/brace-expansion": {
 			"version": "2.0.2",
@@ -7160,9 +7086,8 @@
 		},
 		"node_modules/eslint": {
 			"version": "9.34.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.34.0.tgz",
-			"integrity": "sha512-RNCHRX5EwdrESy3Jc9o8ie8Bog+PeYvvSR8sDGoZxNFTvZ4dlxUB3WzQ3bQMztFrSRODGrLLj8g6OFuGY/aiQg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.12.1",
@@ -11159,6 +11084,7 @@
 		},
 		"node_modules/media-typer": {
 			"version": "0.3.0",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
@@ -13419,8 +13345,7 @@
 		},
 		"node_modules/shimmer": {
 			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/shimmer/-/shimmer-1.2.1.tgz",
-			"integrity": "sha512-sQTKC1Re/rM6XyFM6fIAGHRPVGvyXfgzIDvzoq608vM+jeyVD0Tu1E6Np0Kc2zAIFWIj963V2800iF/9LPieQw=="
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/should": {
 			"version": "13.2.3",
@@ -14768,6 +14693,7 @@
 		},
 		"node_modules/type-is": {
 			"version": "1.6.18",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"media-typer": "0.3.0",
@@ -14932,9 +14858,8 @@
 		},
 		"node_modules/typescript-eslint": {
 			"version": "8.42.0",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.42.0.tgz",
-			"integrity": "sha512-ozR/rQn+aQXQxh1YgbCzQWDFrsi9mcg+1PM3l/z5o1+20P7suOIaNg515bpr/OYt6FObz/NHcBstydDLHWeEKg==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"@typescript-eslint/eslint-plugin": "8.42.0",
 				"@typescript-eslint/parser": "8.42.0",
@@ -15712,7 +15637,6 @@
 				"@sentry/node": "^10.6.0",
 				"@stela/logger": "^1.0.0",
 				"@stela/permanent_models": "^1.0.0",
-				"body-parser": "^1.20.3",
 				"cors": "^2.8.5",
 				"dotenv": "^17.2.1",
 				"express": "^5.1.0",
@@ -15743,42 +15667,6 @@
 				"node": ">=22.0"
 			}
 		},
-		"packages/api/node_modules/body-parser": {
-			"version": "1.20.3",
-			"license": "MIT",
-			"dependencies": {
-				"bytes": "3.1.2",
-				"content-type": "~1.0.5",
-				"debug": "2.6.9",
-				"depd": "2.0.0",
-				"destroy": "1.2.0",
-				"http-errors": "2.0.0",
-				"iconv-lite": "0.4.24",
-				"on-finished": "2.4.1",
-				"qs": "6.13.0",
-				"raw-body": "2.5.2",
-				"type-is": "~1.6.18",
-				"unpipe": "1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8",
-				"npm": "1.2.8000 || >= 1.4.16"
-			}
-		},
-		"packages/api/node_modules/debug": {
-			"version": "2.6.9",
-			"license": "MIT",
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"packages/api/node_modules/depd": {
-			"version": "2.0.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"packages/api/node_modules/dotenv": {
 			"version": "17.2.1",
 			"license": "BSD-2-Clause",
@@ -15787,46 +15675,6 @@
 			},
 			"funding": {
 				"url": "https://dotenvx.com"
-			}
-		},
-		"packages/api/node_modules/iconv-lite": {
-			"version": "0.4.24",
-			"license": "MIT",
-			"dependencies": {
-				"safer-buffer": ">= 2.1.2 < 3"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"packages/api/node_modules/ms": {
-			"version": "2.0.0",
-			"license": "MIT"
-		},
-		"packages/api/node_modules/qs": {
-			"version": "6.13.0",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"side-channel": "^1.0.6"
-			},
-			"engines": {
-				"node": ">=0.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"packages/api/node_modules/raw-body": {
-			"version": "2.5.2",
-			"license": "MIT",
-			"dependencies": {
-				"bytes": "3.1.2",
-				"http-errors": "2.0.0",
-				"iconv-lite": "0.4.24",
-				"unpipe": "1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8"
 			}
 		},
 		"packages/api/node_modules/uuid": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -45,7 +45,6 @@
 		"@stela/logger": "^1.0.0",
 		"@stela/permanent_models": "^1.0.0",
 		"@pdc/http-status-codes": "^1.0.1",
-		"body-parser": "^1.20.3",
 		"cors": "^2.8.5",
 		"dotenv": "^17.2.1",
 		"express": "^5.1.0",

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -19,6 +19,16 @@ app.use(
 );
 app.use(expressWinston.logger({ level: "http", winstonInstance: logger }));
 app.use(express.json());
+
+// This is a temporary measure; it should be removed when the rest of
+// our middleware is updated not to add request metadata to the request body
+app.use((req, _res, next) => {
+	if (req.body === undefined) {
+		req.body = {};
+	}
+	next();
+});
+
 app.use("/api/v2", apiRoutes);
 Sentry.setupExpressErrorHandler(app);
 app.use(handleError);

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -3,7 +3,6 @@ import * as Sentry from "@sentry/node";
 import express from "express";
 import cors from "cors";
 import expressWinston from "express-winston";
-import bodyParser from "body-parser";
 import { logger } from "@stela/logger";
 import { apiRoutes } from "./routes";
 import { handleError } from "./middleware/handleError";
@@ -19,7 +18,7 @@ app.use(
 	}),
 );
 app.use(expressWinston.logger({ level: "http", winstonInstance: logger }));
-app.use(bodyParser.json());
+app.use(express.json());
 app.use("/api/v2", apiRoutes);
 Sentry.setupExpressErrorHandler(app);
 app.use(handleError);


### PR DESCRIPTION
This PR removes an unnecessary dependency (Express provides a native version of `.json()` middleware now)

Resolves #284 