### PR TITLE
Expose 429 errors during optional token processing

### DIFF
--- a/packages/api/src/middleware/authentication.ts
+++ b/packages/api/src/middleware/authentication.ts
@@ -1,6 +1,7 @@
 import type { Request, Response, NextFunction } from "express";
 import createError from "http-errors";
 import { fusionAuthClient } from "../fusionauth";
+import { isErrorWithStatusCode } from "./handleError";
 
 const emailKey = "email";
 const subjectKey = "sub";
@@ -46,6 +47,13 @@ const getOptionalValueFromAuthToken = async (
 				);
 				return response;
 			} catch (err) {
+				if (
+					err instanceof Error &&
+					isErrorWithStatusCode(err) &&
+					err.statusCode === 429
+				) {
+					throw err;
+				}
 				return null;
 			}
 		}),

--- a/packages/api/src/middleware/handleError.ts
+++ b/packages/api/src/middleware/handleError.ts
@@ -12,7 +12,9 @@ interface ErrorWithStatusCode {
 const isErrorWithStatus = (err: unknown): err is ErrorWithStatus =>
 	typeof (err as ErrorWithStatus).status === "number";
 
-const isErrorWithStatusCode = (err: unknown): err is ErrorWithStatusCode =>
+export const isErrorWithStatusCode = (
+	err: unknown,
+): err is ErrorWithStatusCode =>
 	typeof (err as ErrorWithStatusCode).statusCode === "number";
 
 export const handleError = async (


### PR DESCRIPTION
When processing tokens for optionally authenticated endpoints, errors are ignored, because authentication isn't necessary. However, 429 errors indicate that the client should back off on calls to this API regardless of whether the requested resource required authentication, so they should be propagated to the caller. This commit updates the authentication middleware to do that.