### PR TITLE
Add creator account to share link object

### DIFF
--- a/packages/api/docs/src/models/share_link.yaml
+++ b/packages/api/docs/src/models/share_link.yaml
@@ -56,3 +56,15 @@ shareLink:
     updatedAt:
       type: string
       format: date-time
+    creatorAccount:
+      type: object
+      required:
+        [
+          id,
+          name,
+        ]
+      properties:
+        id:
+          type: string
+        name:
+          type: string

--- a/packages/api/src/share_link/fixtures/create_test_shareby_urls.sql
+++ b/packages/api/src/share_link/fixtures/create_test_shareby_urls.sql
@@ -9,7 +9,9 @@ INSERT INTO shareby_url (
   maxuses,
   expiresdt,
   defaultaccessrole,
-  autoapprovetoggle
+  autoapprovetoggle,
+  createddt,
+  updateddt
 ) VALUES (
   1000,
   5,
@@ -21,7 +23,9 @@ INSERT INTO shareby_url (
   null,
   null,
   'access.role.viewer',
-  0
+  0,
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   1001,
@@ -34,7 +38,9 @@ INSERT INTO shareby_url (
   100,
   CURRENT_TIMESTAMP + INTERVAL '1 day',
   'access.role.viewer',
-  0
+  0,
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   1002,
@@ -47,5 +53,7 @@ INSERT INTO shareby_url (
   100,
   CURRENT_TIMESTAMP + INTERVAL '1 day',
   'access.role.editor',
-  0
+  0,
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 );

--- a/packages/api/src/share_link/models.ts
+++ b/packages/api/src/share_link/models.ts
@@ -26,6 +26,10 @@ export interface ShareLink {
 	maxUses: number | null;
 	usesExpended: number | null;
 	expirationTimestamp?: Date;
+	creatorAccount: {
+		id: string;
+		name: string;
+	};
 	createdAt: Date;
 	updatedAt: Date;
 }

--- a/packages/api/src/share_link/queries/create_share_link.sql
+++ b/packages/api/src/share_link/queries/create_share_link.sql
@@ -50,5 +50,11 @@ CASE
 END AS "maxUses",
 uses AS "usesExpended",
 expiresdt AS "expirationTimestamp",
+JSON_BUILD_OBJECT(
+  'id',
+  byaccountid::text,
+  'name',
+  (SELECT fullname FROM account WHERE accountid = byaccountid)
+) AS "creatorAccount",
 createddt AS "createdAt",
 updateddt AS "updatedAt";

--- a/packages/api/src/share_link/queries/get_share_links.sql
+++ b/packages/api/src/share_link/queries/get_share_links.sql
@@ -21,7 +21,13 @@ SELECT
     WHEN shareby_url.unrestricted THEN 'none'
     WHEN shareby_url.autoapprovetoggle = 1 THEN 'account'
     ELSE 'approval'
-  END AS "accessRestrictions"
+  END AS "accessRestrictions",
+  json_build_object(
+    'id',
+    shareby_url.byaccountid::text,
+    'name',
+    account.fullname
+  ) AS "creatorAccount"
 FROM
   shareby_url
 INNER JOIN

--- a/packages/api/src/share_link/queries/update_share_link.sql
+++ b/packages/api/src/share_link/queries/update_share_link.sql
@@ -41,5 +41,11 @@ CASE
 END AS "maxUses",
 shareby_url.uses AS "usesExpended",
 shareby_url.expiresdt AS "expirationTimestamp",
+JSON_BUILD_OBJECT(
+  'id',
+  byaccountid::text,
+  'name',
+  (SELECT fullname FROM account WHERE accountid = byaccountid)
+) AS "creatorAccount",
 shareby_url.createddt AS "createdAt",
 shareby_url.updateddt AS "updatedAt";


### PR DESCRIPTION
There are cases where the UI wants to display the creator of a share link, so this commit adds a creatorAccount field to share links returned by the API.