### PR TITLE
Make share links accessible via share token without JWTs

### DIFF
--- a/packages/api/src/share_link/queries/get_share_links.sql
+++ b/packages/api/src/share_link/queries/get_share_links.sql
@@ -35,4 +35,7 @@ WHERE
     shareby_url.shareby_urlid::text = any(:shareLinkIds)
     OR shareby_url.urltoken = any(:shareTokens)
   )
-  AND account.primaryemail = :email;
+  AND (
+    account.primaryemail = :email
+    OR :email IS NULL
+  );

--- a/packages/api/src/share_link/service.ts
+++ b/packages/api/src/share_link/service.ts
@@ -168,7 +168,7 @@ const updateShareLink = async (
 };
 
 const getShareLinks = async (
-	email: string,
+	email: string | undefined,
 	shareTokens: string[] | undefined,
 	shareLinkIds: string[] | undefined,
 ): Promise<ShareLink[]> => {


### PR DESCRIPTION
The UI needs to be able to determine the access restrictions of a share link without a logged in user. Thus this commit makes share links accessible without a JWT, provided they're accessed by share token and not by ID.