### PR TITLE
Memoize `introspectAccessToken`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
 				"./packages/account_space_updater",
 				"./packages/record_thumbnail_attacher",
 				"./packages/thumbnail_refresh",
+				"./packages/file_url_refresh",
 				"./packages/access_copy_attacher"
 			],
 			"devDependencies": {
@@ -5186,6 +5187,24 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/@mswjs/interceptors": {
+			"version": "0.38.7",
+			"resolved": "https://registry.npmjs.org/@mswjs/interceptors/-/interceptors-0.38.7.tgz",
+			"integrity": "sha512-Jkb27iSn7JPdkqlTqKfhncFfnEZsIJVYxsFbUSWEkxdIPdsyngrhoDBk0/BGD2FQcRH99vlRrkHpNTyKqI+0/w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@open-draft/deferred-promise": "^2.2.0",
+				"@open-draft/logger": "^0.3.0",
+				"@open-draft/until": "^2.0.0",
+				"is-node-process": "^1.2.0",
+				"outvariant": "^1.4.3",
+				"strict-event-emitter": "^0.5.1"
+			},
+			"engines": {
+				"node": ">=18"
+			}
+		},
 		"node_modules/@newrelic/native-metrics": {
 			"version": "10.2.0",
 			"hasInstallScript": true,
@@ -5393,6 +5412,31 @@
 			"engines": {
 				"node": "^14.17.0 || ^16.13.0 || >=18.0.0"
 			}
+		},
+		"node_modules/@open-draft/deferred-promise": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/@open-draft/deferred-promise/-/deferred-promise-2.2.0.tgz",
+			"integrity": "sha512-CecwLWx3rhxVQF6V4bAgPS5t+So2sTbPgAzafKkVizyi7tlwpcFpdFqq+wqF2OwNBmqFuu6tOyouTuxgpMfzmA==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/@open-draft/logger": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/@open-draft/logger/-/logger-0.3.0.tgz",
+			"integrity": "sha512-X2g45fzhxH238HKO4xbSr7+wBS8Fvw6ixhTDuvLd5mqh6bJJCFAPwU9mPDxbcrRtfxv4u5IHCEH77BmxvXmmxQ==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-node-process": "^1.2.0",
+				"outvariant": "^1.4.0"
+			}
+		},
+		"node_modules/@open-draft/until": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/@open-draft/until/-/until-2.1.0.tgz",
+			"integrity": "sha512-U69T3ItWHvLwGg5eJ0n3I62nWuE6ilHlmz7zM0npLBRvPRd7e6NYmg54vvRtP5mZG7kZqZCFVdsTWo7BPtBujg==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@opentelemetry/api": {
 			"version": "1.9.0",
@@ -8585,6 +8629,10 @@
 			"resolved": "packages/archivematica-utils",
 			"link": true
 		},
+		"node_modules/@stela/file_url_refresh": {
+			"resolved": "packages/file_url_refresh",
+			"link": true
+		},
 		"node_modules/@stela/file-utils": {
 			"resolved": "packages/file-utils",
 			"link": true
@@ -8823,6 +8871,13 @@
 			"dependencies": {
 				"axios": "^1.8.2"
 			}
+		},
+		"node_modules/@types/memoizee": {
+			"version": "0.4.12",
+			"resolved": "https://registry.npmjs.org/@types/memoizee/-/memoizee-0.4.12.tgz",
+			"integrity": "sha512-EdtpwNYNhe3kZ+4TlXj/++pvBoU0KdrAICMzgI7vjWgu9sIvvUhu9XR8Ks4L6Wh3sxpZ22wkZR7yCLAqUjnZuQ==",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@types/methods": {
 			"version": "1.1.4",
@@ -10895,6 +10950,19 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/d": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
+			"integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
+			"license": "ISC",
+			"dependencies": {
+				"es5-ext": "^0.10.64",
+				"type": "^2.7.2"
+			},
+			"engines": {
+				"node": ">=0.12"
+			}
+		},
 		"node_modules/data-view-buffer": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/data-view-buffer/-/data-view-buffer-1.0.2.tgz",
@@ -11519,12 +11587,64 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/es5-ext": {
+			"version": "0.10.64",
+			"resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.64.tgz",
+			"integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
+			"hasInstallScript": true,
+			"license": "ISC",
+			"dependencies": {
+				"es6-iterator": "^2.0.3",
+				"es6-symbol": "^3.1.3",
+				"esniff": "^2.0.1",
+				"next-tick": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
+		"node_modules/es6-iterator": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
+			"integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
+			"license": "MIT",
+			"dependencies": {
+				"d": "1",
+				"es5-ext": "^0.10.35",
+				"es6-symbol": "^3.1.1"
+			}
+		},
 		"node_modules/es6-promise": {
 			"version": "3.3.1",
 			"resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-3.3.1.tgz",
 			"integrity": "sha512-SOp9Phqvqn7jtEUxPWdWfWoLmyt2VaJ6MpvP9Comy1MceMXqE6bxvaTu4iaxpYYPzhny28Lc+M87/c2cPK6lDg==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/es6-symbol": {
+			"version": "3.1.4",
+			"resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
+			"integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
+			"license": "ISC",
+			"dependencies": {
+				"d": "^1.0.2",
+				"ext": "^1.7.0"
+			},
+			"engines": {
+				"node": ">=0.12"
+			}
+		},
+		"node_modules/es6-weak-map": {
+			"version": "2.0.3",
+			"resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
+			"integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
+			"license": "ISC",
+			"dependencies": {
+				"d": "1",
+				"es5-ext": "^0.10.46",
+				"es6-iterator": "^2.0.3",
+				"es6-symbol": "^3.1.1"
+			}
 		},
 		"node_modules/escalade": {
 			"version": "3.2.0",
@@ -12017,6 +12137,21 @@
 				"js-yaml": "bin/js-yaml.js"
 			}
 		},
+		"node_modules/esniff": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
+			"integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
+			"license": "ISC",
+			"dependencies": {
+				"d": "^1.0.1",
+				"es5-ext": "^0.10.62",
+				"event-emitter": "^0.3.5",
+				"type": "^2.7.2"
+			},
+			"engines": {
+				"node": ">=0.10"
+			}
+		},
 		"node_modules/espree": {
 			"version": "9.6.1",
 			"resolved": "https://registry.npmjs.org/espree/-/espree-9.6.1.tgz",
@@ -12105,6 +12240,16 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/event-emitter": {
+			"version": "0.3.5",
+			"resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
+			"integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
+			"license": "MIT",
+			"dependencies": {
+				"d": "1",
+				"es5-ext": "~0.10.14"
 			}
 		},
 		"node_modules/event-stream": {
@@ -12408,6 +12553,15 @@
 			},
 			"engines": {
 				"node": ">= 0.6"
+			}
+		},
+		"node_modules/ext": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
+			"integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
+			"license": "ISC",
+			"dependencies": {
+				"type": "^2.7.2"
 			}
 		},
 		"node_modules/extend": {
@@ -13973,6 +14127,13 @@
 				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
+		"node_modules/is-node-process": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/is-node-process/-/is-node-process-1.2.0.tgz",
+			"integrity": "sha512-Vg4o6/fqPxIjtxgUH5QLJhwZ7gW5diGCVlXpuUfELC62CuxM1iHcRe51f2W1FDy04Ai4KJkagKjx3XaqyfRKXw==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
 			"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
@@ -15290,6 +15451,15 @@
 				"node": ">=18"
 			}
 		},
+		"node_modules/lru-queue": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/lru-queue/-/lru-queue-0.1.0.tgz",
+			"integrity": "sha512-BpdYkt9EvGl8OfWHDQPISVpcl5xZthb+XPsbELj5AQXxIC8IriDZIQYjBJPEm5rS420sjZ0TLEzRcq5KdBhYrQ==",
+			"license": "MIT",
+			"dependencies": {
+				"es5-ext": "~0.10.2"
+			}
+		},
 		"node_modules/lunr": {
 			"version": "2.3.9",
 			"resolved": "https://registry.npmjs.org/lunr/-/lunr-2.3.9.tgz",
@@ -15422,6 +15592,31 @@
 			"engines": {
 				"node": ">= 0.6"
 			}
+		},
+		"node_modules/memoizee": {
+			"version": "0.4.17",
+			"resolved": "https://registry.npmjs.org/memoizee/-/memoizee-0.4.17.tgz",
+			"integrity": "sha512-DGqD7Hjpi/1or4F/aYAspXKNm5Yili0QDAFAY4QYvpqpgiY6+1jOfqpmByzjxbWd/T9mChbCArXAbDAsTm5oXA==",
+			"license": "ISC",
+			"dependencies": {
+				"d": "^1.0.2",
+				"es5-ext": "^0.10.64",
+				"es6-weak-map": "^2.0.3",
+				"event-emitter": "^0.3.5",
+				"is-promise": "^2.2.2",
+				"lru-queue": "^0.1.0",
+				"next-tick": "^1.1.0",
+				"timers-ext": "^0.1.7"
+			},
+			"engines": {
+				"node": ">=0.12"
+			}
+		},
+		"node_modules/memoizee/node_modules/is-promise": {
+			"version": "2.2.2",
+			"resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.2.2.tgz",
+			"integrity": "sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==",
+			"license": "MIT"
 		},
 		"node_modules/merge-descriptors": {
 			"version": "2.0.0",
@@ -15914,6 +16109,27 @@
 			},
 			"engines": {
 				"node": ">= 6"
+			}
+		},
+		"node_modules/next-tick": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
+			"integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
+			"license": "ISC"
+		},
+		"node_modules/nock": {
+			"version": "14.0.5",
+			"resolved": "https://registry.npmjs.org/nock/-/nock-14.0.5.tgz",
+			"integrity": "sha512-R49fALR9caB6vxuSWUIaK2eBYeTloZQUFBZ4rHO+TbhMGQHtwnhdqKLYki+o+8qMgLvoBYWrp/2KzGPhxL4S6w==",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@mswjs/interceptors": "^0.38.7",
+				"json-stringify-safe": "^5.0.1",
+				"propagate": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=18.20.0 <20 || >=20.12.1"
 			}
 		},
 		"node_modules/node-abi": {
@@ -16517,6 +16733,13 @@
 			"version": "0.8.0",
 			"resolved": "https://registry.npmjs.org/outdent/-/outdent-0.8.0.tgz",
 			"integrity": "sha512-KiOAIsdpUTcAXuykya5fnVVT+/5uS0Q1mrkRHcF89tpieSmY33O/tmc54CqwA+bfhbtEfZUNLHaPUiB9X3jt1A==",
+			"dev": true,
+			"license": "MIT"
+		},
+		"node_modules/outvariant": {
+			"version": "1.4.3",
+			"resolved": "https://registry.npmjs.org/outvariant/-/outvariant-1.4.3.tgz",
+			"integrity": "sha512-+Sl2UErvtsoajRDKCE5/dBz4DIvHXQQnAxtQTF04OJxY0+DyZXSo5P5Bb7XYWOh81syohlYL24hbDwxedPUJCA==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -17181,6 +17404,16 @@
 			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
 			"dev": true,
 			"license": "MIT"
+		},
+		"node_modules/propagate": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/propagate/-/propagate-2.0.1.tgz",
+			"integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 8"
+			}
 		},
 		"node_modules/protobufjs": {
 			"version": "7.3.2",
@@ -18641,6 +18874,13 @@
 				"node": ">= 4.0.0"
 			}
 		},
+		"node_modules/strict-event-emitter": {
+			"version": "0.5.1",
+			"resolved": "https://registry.npmjs.org/strict-event-emitter/-/strict-event-emitter-0.5.1.tgz",
+			"integrity": "sha512-vMgjE/GGEPEFnhFub6pa4FmJBRBVOLpIII2hvCZ8Kzb7K0hlHo7mQv6xYrBvCL2LtAIBwFUK8wvuJgTVSQ5MFQ==",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/string_decoder": {
 			"version": "1.1.1",
 			"license": "MIT",
@@ -19146,6 +19386,19 @@
 			"dev": true,
 			"license": "MIT"
 		},
+		"node_modules/timers-ext": {
+			"version": "0.1.8",
+			"resolved": "https://registry.npmjs.org/timers-ext/-/timers-ext-0.1.8.tgz",
+			"integrity": "sha512-wFH7+SEAcKfJpfLPkrgMPvvwnEtj8W4IurvEyrKsDleXnKLCDw71w8jltvfLa8Rm4qQxxT4jmDBYbJG/z7qoww==",
+			"license": "ISC",
+			"dependencies": {
+				"es5-ext": "^0.10.64",
+				"next-tick": "^1.1.0"
+			},
+			"engines": {
+				"node": ">=0.12"
+			}
+		},
 		"node_modules/tinypg": {
 			"version": "7.0.1",
 			"resolved": "https://registry.npmjs.org/tinypg/-/tinypg-7.0.1.tgz",
@@ -19618,6 +19871,12 @@
 			"engines": {
 				"node": ">=0.10.0"
 			}
+		},
+		"node_modules/type": {
+			"version": "2.7.3",
+			"resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
+			"integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
+			"license": "ISC"
 		},
 		"node_modules/type-check": {
 			"version": "0.4.0",
@@ -20892,6 +21151,7 @@
 				"express-winston": "^4.1.0",
 				"http-errors": "^2.0.0",
 				"joi": "^17.13.3",
+				"memoizee": "^0.4.17",
 				"mixpanel": "^0.18.0",
 				"newrelic": "^11.22.0",
 				"node-fetch": "^2.6.9",
@@ -20904,9 +21164,11 @@
 			},
 			"devDependencies": {
 				"@types/jest-when": "^3.5.5",
+				"@types/memoizee": "^0.4.12",
 				"@types/newrelic": "^9.14.4",
 				"@types/ua-parser-js": "^0.7.39",
 				"jest-when": "^3.7.0",
+				"nock": "^14.0.5",
 				"supertest": "^7.1.0"
 			},
 			"engines": {
@@ -20959,6 +21221,42 @@
 			},
 			"engines": {
 				"node": ">=18.0"
+			}
+		},
+		"packages/file_url_refresh": {
+			"name": "@stela/file_url_refresh",
+			"version": "1.0.0",
+			"license": "AGPL-3.0",
+			"dependencies": {
+				"@sentry/node": "^7.57.0",
+				"@sentry/profiling-node": "^7.57.0",
+				"@stela/logger": "^1.0.0",
+				"@stela/permanent_models": "^1.0.0",
+				"@stela/s3-utils": "^1.0.0",
+				"aws-cloudfront-sign": "^3.0.2",
+				"dotenv": "^16.5.0",
+				"require-env-variable": "^3.1.2",
+				"tinypg": "^7.0.1"
+			},
+			"engines": {
+				"node": ">=18.0"
+			}
+		},
+		"packages/file_url_refresh/node_modules/@sentry/profiling-node": {
+			"version": "7.120.3",
+			"resolved": "https://registry.npmjs.org/@sentry/profiling-node/-/profiling-node-7.120.3.tgz",
+			"integrity": "sha512-UXt/QROtBEAfcTXdtHMXZiDrc2jkW4O78Q/9HZkkXf5a+lZGbWOX326G2AaxXTcDlKRSH8nhHcssG5SLI4P+gw==",
+			"hasInstallScript": true,
+			"license": "MIT",
+			"dependencies": {
+				"detect-libc": "^2.0.2",
+				"node-abi": "^3.61.0"
+			},
+			"bin": {
+				"sentry-prune-profiler-binaries": "scripts/prune-profiler-binaries.js"
+			},
+			"engines": {
+				"node": ">=8.0.0"
 			}
 		},
 		"packages/file-utils": {

--- a/packages/api/jest.config.js
+++ b/packages/api/jest.config.js
@@ -4,4 +4,5 @@ module.exports = {
 	moduleNameMapper: {
 		"^@stela/(.*)$": "<rootDir>/../$1/src",
 	},
+	setupFiles: ["<rootDir>/jest.env.setup.js"],
 };

--- a/packages/api/jest.env.setup.js
+++ b/packages/api/jest.env.setup.js
@@ -1,0 +1,1 @@
+process.env.FUSIONAUTH_HOST = "https://example.com";

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -52,6 +52,7 @@
 		"express-winston": "^4.1.0",
 		"http-errors": "^2.0.0",
 		"joi": "^17.13.3",
+		"memoizee": "^0.4.17",
 		"mixpanel": "^0.18.0",
 		"newrelic": "^11.22.0",
 		"node-fetch": "^2.6.9",
@@ -64,8 +65,10 @@
 	},
 	"devDependencies": {
 		"@types/jest-when": "^3.5.5",
+		"@types/memoizee": "^0.4.12",
 		"@types/newrelic": "^9.14.4",
 		"@types/ua-parser-js": "^0.7.39",
+		"nock": "^14.0.5",
 		"jest-when": "^3.7.0",
 		"supertest": "^7.1.0"
 	}

--- a/packages/api/src/fusionauth.test.ts
+++ b/packages/api/src/fusionauth.test.ts
@@ -1,0 +1,54 @@
+import nock from "nock";
+import { fusionAuthClient } from "./fusionauth";
+
+const mockFusionAuthHost = process.env["FUSIONAUTH_HOST"] || "";
+
+describe("fusionAuthClient", () => {
+	describe("introspectAccessToken", () => {
+		afterEach(() => {
+			fusionAuthClient.introspectAccessToken.clear();
+			nock.cleanAll();
+		});
+		test("should correctly make a network call the first time a unique set of parameters are passed", async () => {
+			const mockFusionAuthService = nock(mockFusionAuthHost)
+				.post(/.*/)
+				.times(1)
+				.reply(200);
+			await fusionAuthClient.introspectAccessToken(
+				"appId",
+				"ThisIsTotallyAToken",
+			);
+			expect(mockFusionAuthService.isDone()).toBe(true);
+		});
+		test("should correctly make additional network calls when distinct parameters are passed", async () => {
+			const mockFusionAuthService = nock(mockFusionAuthHost)
+				.post(/.*/)
+				.times(2)
+				.reply(200);
+			await fusionAuthClient.introspectAccessToken(
+				"appIdFoo",
+				"ThisIsTotallyAToken",
+			);
+			await fusionAuthClient.introspectAccessToken(
+				"appIdBar",
+				"ThisIsTotallyAToken",
+			);
+			expect(mockFusionAuthService.isDone()).toBe(true);
+		});
+		test("should NOT make a network call, and should use the cached result, when identical parameters are passed", async () => {
+			const mockFusionAuthService = nock(mockFusionAuthHost)
+				.post(/.*/)
+				.times(1)
+				.reply(200);
+			await fusionAuthClient.introspectAccessToken(
+				"appIdFoo",
+				"ThisIsTotallyAToken",
+			);
+			await fusionAuthClient.introspectAccessToken(
+				"appIdFoo",
+				"ThisIsTotallyAToken",
+			);
+			expect(mockFusionAuthService.isDone()).toBe(true);
+		});
+	});
+});

--- a/packages/api/src/fusionauth.ts
+++ b/packages/api/src/fusionauth.ts
@@ -1,9 +1,25 @@
 import { FusionAuthClient } from "@fusionauth/typescript-client";
+import memoize from "memoizee";
 
-const fusionAuthClient = new FusionAuthClient(
+const baseFusionAuthClient = new FusionAuthClient(
 	process.env["FUSIONAUTH_API_KEY"] ?? "",
 	process.env["FUSIONAUTH_HOST"] ?? "",
 	process.env["FUSIONAUTH_TENANT"] ?? "",
 );
+
+const memoizedIntrospectAccessToken = memoize(
+	baseFusionAuthClient.introspectAccessToken.bind(baseFusionAuthClient),
+	{ maxAge: 10000 },
+);
+
+baseFusionAuthClient.introspectAccessToken = memoizedIntrospectAccessToken;
+
+// Simply replacing `introspectAccessToken` does not update the type of `baseFusionAuthClient`
+// And so we need to do this type cast so that `introspectAccessToken`'s type signature reflects
+// the additional `memoize` methods such as `.clear()`
+const fusionAuthClient = baseFusionAuthClient as Omit<
+	FusionAuthClient,
+	"introspectAccesstoken"
+> & { introspectAccessToken: typeof memoizedIntrospectAccessToken };
 
 export { fusionAuthClient };


### PR DESCRIPTION
This PR adds a memoization wrapper around the FusionAuth client's `introspectAccessToken` 

This means that successive calls to `introspectAccessToken` with identical parameters within a 10 second window will return the cached promise / introspection outcome instead of triggering additional network calls to FusionAuth.

I think this hits a good balance between triggering FusionAuth's rate limits and still maintaining the security of `introspect`.

Resolves #314