### PR TITLE
Unpin NPM in build containers

### DIFF
--- a/Dockerfile.access_copy_attacher
+++ b/Dockerfile.access_copy_attacher
@@ -7,7 +7,6 @@ COPY tsconfig.json ./
 COPY jest.config.js ./
 COPY packages ./packages
 
-RUN npm install -g npm@8.19.3
 RUN npm install
 RUN npm install -ws
 RUN npm run build -ws

--- a/Dockerfile.account_space_updater
+++ b/Dockerfile.account_space_updater
@@ -7,7 +7,6 @@ COPY tsconfig.json ./
 COPY jest.config.js ./
 COPY packages ./packages
 
-RUN npm install -g npm@8.19.3
 RUN npm install
 RUN npm install -ws
 RUN npm run build -ws

--- a/Dockerfile.am_cleanup
+++ b/Dockerfile.am_cleanup
@@ -7,7 +7,6 @@ COPY tsconfig.json ./
 COPY jest.config.js ./
 COPY packages ./packages
 
-RUN npm install -g npm@8.19.3
 RUN npm install
 RUN npm install -ws
 RUN npm run build -ws

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -7,7 +7,6 @@ COPY tsconfig.json ./
 COPY jest.config.js ./
 COPY packages ./packages
 
-RUN npm install -g npm@8.19.3
 RUN npm install
 RUN npm install -ws
 RUN npm run build -ws

--- a/Dockerfile.file_url_refresh
+++ b/Dockerfile.file_url_refresh
@@ -7,7 +7,6 @@ COPY tsconfig.json ./
 COPY jest.config.js ./
 COPY packages ./packages
 
-RUN npm install -g npm@8.19.3
 RUN npm install
 RUN npm install -ws
 RUN npm run build -ws

--- a/Dockerfile.record_thumbnail_attacher
+++ b/Dockerfile.record_thumbnail_attacher
@@ -7,7 +7,6 @@ COPY tsconfig.json ./
 COPY jest.config.js ./
 COPY packages ./packages
 
-RUN npm install -g npm@8.19.3
 RUN npm install
 RUN npm install -ws
 RUN npm run build -ws

--- a/Dockerfile.thumbnail_refresh
+++ b/Dockerfile.thumbnail_refresh
@@ -7,7 +7,6 @@ COPY tsconfig.json ./
 COPY jest.config.js ./
 COPY packages ./packages
 
-RUN npm install -g npm@8.19.3
 RUN npm install
 RUN npm install -ws
 RUN npm run build -ws


### PR DESCRIPTION
It is not necessary to pin NPM in build containers, as their version of Node will come with a compatible version of NPM. Further, pinning NPM seems to be breaking our npm installs.