### PR TITLE
Replace node-fetch with native fetch

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14051,13 +14051,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/ts-md5": {
-			"version": "1.3.1",
-			"license": "MIT",
-			"engines": {
-				"node": ">=12"
-			}
-		},
 		"node_modules/tsc-watch": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/tsc-watch/-/tsc-watch-7.1.1.tgz",
@@ -15114,7 +15107,6 @@
 				"memoizee": "^0.4.17",
 				"mixpanel": "^0.18.0",
 				"newrelic": "^12.22.0",
-				"node-fetch": "^2.6.9",
 				"pg": "^8.16.3",
 				"require-env-variable": "^4.0.2",
 				"tinypg": "^7.0.1",
@@ -15143,6 +15135,15 @@
 			},
 			"funding": {
 				"url": "https://dotenvx.com"
+			}
+		},
+		"packages/api/node_modules/ts-md5": {
+			"version": "1.3.1",
+			"resolved": "https://registry.npmjs.org/ts-md5/-/ts-md5-1.3.1.tgz",
+			"integrity": "sha512-DiwiXfwvcTeZ5wCE0z+2A9EseZsztaiZtGrtSaY5JOD7ekPnR/GoIVD5gXZAlK9Na9Kvpo9Waz5rW64WKAWApg==",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"packages/api/node_modules/uuid": {

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -55,7 +55,6 @@
 		"memoizee": "^0.4.17",
 		"mixpanel": "^0.18.0",
 		"newrelic": "^12.22.0",
-		"node-fetch": "^2.6.9",
 		"pg": "^8.16.3",
 		"require-env-variable": "^4.0.2",
 		"tinypg": "^7.0.1",

--- a/packages/api/src/directive/controller.test.ts
+++ b/packages/api/src/directive/controller.test.ts
@@ -1,6 +1,5 @@
 import request from "supertest";
 import type { Request, NextFunction } from "express";
-import type { Response } from "node-fetch";
 import { logger } from "@stela/logger";
 import { app } from "../app";
 import { db } from "../database";
@@ -195,7 +194,7 @@ describe("POST /directive", () => {
 			.expect(200);
 
 		const directiveResult = await db.query<Directive>(
-			`SELECT 
+			`SELECT
         directive_id "directiveId",
         archive_id "archiveId",
         type,
@@ -431,7 +430,7 @@ describe("PUT /directive/:directiveId", () => {
 			.expect(200);
 
 		const directiveResult = await db.query<Directive>(
-			`SELECT 
+			`SELECT
         directive_id "directiveId",
         archive_id "archiveId",
         type,
@@ -494,7 +493,7 @@ describe("PUT /directive/:directiveId", () => {
 			.expect(200);
 
 		const directiveResult = await db.query<Directive>(
-			`SELECT 
+			`SELECT
         directive_id "directiveId",
         archive_id "archiveId",
         type,

--- a/packages/api/src/idpuser/controller.test.ts
+++ b/packages/api/src/idpuser/controller.test.ts
@@ -19,9 +19,9 @@ interface TwoFactorRequest {
 }
 
 jest.mock("../database");
-jest.mock("node-fetch", () => jest.fn());
 jest.mock("../middleware");
 jest.mock("../fusionauth");
+global.fetch = jest.fn();
 
 describe("/idpuser", () => {
 	const agent = request(app);

--- a/packages/api/src/legacy_client.test.ts
+++ b/packages/api/src/legacy_client.test.ts
@@ -1,7 +1,6 @@
-import fetch from "node-fetch";
 import { legacyClient } from "./legacy_client";
 
-jest.mock("node-fetch");
+global.fetch = jest.fn();
 
 describe("transferArchiveOwnership", () => {
 	test("should submit the correct request", async () => {

--- a/packages/api/src/legacy_client.ts
+++ b/packages/api/src/legacy_client.ts
@@ -1,6 +1,3 @@
-import fetch from "node-fetch";
-import type { Response } from "node-fetch";
-
 const hostUrl = process.env["LEGACY_BACKEND_HOST_URL"] ?? "";
 const authenticationSecret = process.env["LEGACY_BACKEND_SHARED_SECRET"] ?? "";
 

--- a/packages/archivematica-utils/package.json
+++ b/packages/archivematica-utils/package.json
@@ -25,7 +25,6 @@
 		"test": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js -i --silent=false"
 	},
 	"dependencies": {
-		"@stela/logger": "^1.0.0",
-		"node-fetch": "^2.6.9"
+		"@stela/logger": "^1.0.0"
 	}
 }

--- a/packages/archivematica-utils/src/index.test.ts
+++ b/packages/archivematica-utils/src/index.test.ts
@@ -1,10 +1,9 @@
-import fetch from "node-fetch";
 import {
 	getOriginalFileIdFromInformationPackagePath,
 	triggerArchivematicaProcessing,
 } from "./index";
 
-jest.mock("node-fetch");
+global.fetch = jest.fn();
 
 describe("getFileIdFromInformationPackagePath", () => {
 	test("should return the file ID if the file ID is a number", () => {

--- a/packages/archivematica-utils/src/index.ts
+++ b/packages/archivematica-utils/src/index.ts
@@ -1,5 +1,3 @@
-import fetch from "node-fetch";
-import type { Response } from "node-fetch";
 import { logger } from "@stela/logger";
 
 export const getOriginalFileIdFromInformationPackagePath = (


### PR DESCRIPTION
Node 22 has a native fetch function, so we no longer need an extra dependency to provide one.