### PR TITLE
Remove lingering node-fetch imports

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -35,7 +35,6 @@
 				"@types/jest-when": "^3.5.5",
 				"@types/mailchimp__mailchimp_transactional": "1.0.11",
 				"@types/node": "^12.20.55",
-				"@types/node-fetch": "^2.6.2",
 				"@types/pg": "^8.15.4",
 				"@types/supertest": "^6.0.3",
 				"@types/uuid": "^10.0.0",
@@ -240,63 +239,62 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-s3": {
-			"version": "3.842.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.842.0.tgz",
-			"integrity": "sha512-T5Rh72Rcq1xIaM8KkTr1Wpr7/WPCYO++KrM+/Em0rq2jxpjMMhj77ITpgH7eEmNxWmwIndTwqpgfmbpNfk7Gbw==",
+			"version": "3.844.0",
+			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha1-browser": "5.2.0",
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "3.840.0",
-				"@aws-sdk/credential-provider-node": "3.840.0",
+				"@aws-sdk/core": "3.844.0",
+				"@aws-sdk/credential-provider-node": "3.844.0",
 				"@aws-sdk/middleware-bucket-endpoint": "3.840.0",
 				"@aws-sdk/middleware-expect-continue": "3.840.0",
-				"@aws-sdk/middleware-flexible-checksums": "3.840.0",
+				"@aws-sdk/middleware-flexible-checksums": "3.844.0",
 				"@aws-sdk/middleware-host-header": "3.840.0",
 				"@aws-sdk/middleware-location-constraint": "3.840.0",
 				"@aws-sdk/middleware-logger": "3.840.0",
 				"@aws-sdk/middleware-recursion-detection": "3.840.0",
-				"@aws-sdk/middleware-sdk-s3": "3.840.0",
+				"@aws-sdk/middleware-sdk-s3": "3.844.0",
 				"@aws-sdk/middleware-ssec": "3.840.0",
-				"@aws-sdk/middleware-user-agent": "3.840.0",
+				"@aws-sdk/middleware-user-agent": "3.844.0",
 				"@aws-sdk/region-config-resolver": "3.840.0",
-				"@aws-sdk/signature-v4-multi-region": "3.840.0",
+				"@aws-sdk/signature-v4-multi-region": "3.844.0",
 				"@aws-sdk/types": "3.840.0",
-				"@aws-sdk/util-endpoints": "3.840.0",
+				"@aws-sdk/util-endpoints": "3.844.0",
 				"@aws-sdk/util-user-agent-browser": "3.840.0",
-				"@aws-sdk/util-user-agent-node": "3.840.0",
+				"@aws-sdk/util-user-agent-node": "3.844.0",
 				"@aws-sdk/xml-builder": "3.821.0",
 				"@smithy/config-resolver": "^4.1.4",
-				"@smithy/core": "^3.6.0",
+				"@smithy/core": "^3.7.0",
 				"@smithy/eventstream-serde-browser": "^4.0.4",
 				"@smithy/eventstream-serde-config-resolver": "^4.1.2",
 				"@smithy/eventstream-serde-node": "^4.0.4",
-				"@smithy/fetch-http-handler": "^5.0.4",
+				"@smithy/fetch-http-handler": "^5.1.0",
 				"@smithy/hash-blob-browser": "^4.0.4",
 				"@smithy/hash-node": "^4.0.4",
 				"@smithy/hash-stream-node": "^4.0.4",
 				"@smithy/invalid-dependency": "^4.0.4",
 				"@smithy/md5-js": "^4.0.4",
 				"@smithy/middleware-content-length": "^4.0.4",
-				"@smithy/middleware-endpoint": "^4.1.13",
-				"@smithy/middleware-retry": "^4.1.14",
+				"@smithy/middleware-endpoint": "^4.1.14",
+				"@smithy/middleware-retry": "^4.1.15",
 				"@smithy/middleware-serde": "^4.0.8",
 				"@smithy/middleware-stack": "^4.0.4",
 				"@smithy/node-config-provider": "^4.1.3",
-				"@smithy/node-http-handler": "^4.0.6",
+				"@smithy/node-http-handler": "^4.1.0",
 				"@smithy/protocol-http": "^5.1.2",
-				"@smithy/smithy-client": "^4.4.5",
+				"@smithy/smithy-client": "^4.4.6",
 				"@smithy/types": "^4.3.1",
 				"@smithy/url-parser": "^4.0.4",
 				"@smithy/util-base64": "^4.0.0",
 				"@smithy/util-body-length-browser": "^4.0.0",
 				"@smithy/util-body-length-node": "^4.0.0",
-				"@smithy/util-defaults-mode-browser": "^4.0.21",
-				"@smithy/util-defaults-mode-node": "^4.0.21",
+				"@smithy/util-defaults-mode-browser": "^4.0.22",
+				"@smithy/util-defaults-mode-node": "^4.0.22",
 				"@smithy/util-endpoints": "^3.0.6",
 				"@smithy/util-middleware": "^4.0.4",
 				"@smithy/util-retry": "^4.0.6",
-				"@smithy/util-stream": "^4.2.2",
+				"@smithy/util-stream": "^4.2.3",
 				"@smithy/util-utf8": "^4.0.0",
 				"@smithy/util-waiter": "^4.0.6",
 				"@types/uuid": "^9.0.1",
@@ -312,43 +310,43 @@
 			"license": "MIT"
 		},
 		"node_modules/@aws-sdk/client-sns": {
-			"version": "3.840.0",
+			"version": "3.844.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "3.840.0",
-				"@aws-sdk/credential-provider-node": "3.840.0",
+				"@aws-sdk/core": "3.844.0",
+				"@aws-sdk/credential-provider-node": "3.844.0",
 				"@aws-sdk/middleware-host-header": "3.840.0",
 				"@aws-sdk/middleware-logger": "3.840.0",
 				"@aws-sdk/middleware-recursion-detection": "3.840.0",
-				"@aws-sdk/middleware-user-agent": "3.840.0",
+				"@aws-sdk/middleware-user-agent": "3.844.0",
 				"@aws-sdk/region-config-resolver": "3.840.0",
 				"@aws-sdk/types": "3.840.0",
-				"@aws-sdk/util-endpoints": "3.840.0",
+				"@aws-sdk/util-endpoints": "3.844.0",
 				"@aws-sdk/util-user-agent-browser": "3.840.0",
-				"@aws-sdk/util-user-agent-node": "3.840.0",
+				"@aws-sdk/util-user-agent-node": "3.844.0",
 				"@smithy/config-resolver": "^4.1.4",
-				"@smithy/core": "^3.6.0",
-				"@smithy/fetch-http-handler": "^5.0.4",
+				"@smithy/core": "^3.7.0",
+				"@smithy/fetch-http-handler": "^5.1.0",
 				"@smithy/hash-node": "^4.0.4",
 				"@smithy/invalid-dependency": "^4.0.4",
 				"@smithy/middleware-content-length": "^4.0.4",
-				"@smithy/middleware-endpoint": "^4.1.13",
-				"@smithy/middleware-retry": "^4.1.14",
+				"@smithy/middleware-endpoint": "^4.1.14",
+				"@smithy/middleware-retry": "^4.1.15",
 				"@smithy/middleware-serde": "^4.0.8",
 				"@smithy/middleware-stack": "^4.0.4",
 				"@smithy/node-config-provider": "^4.1.3",
-				"@smithy/node-http-handler": "^4.0.6",
+				"@smithy/node-http-handler": "^4.1.0",
 				"@smithy/protocol-http": "^5.1.2",
-				"@smithy/smithy-client": "^4.4.5",
+				"@smithy/smithy-client": "^4.4.6",
 				"@smithy/types": "^4.3.1",
 				"@smithy/url-parser": "^4.0.4",
 				"@smithy/util-base64": "^4.0.0",
 				"@smithy/util-body-length-browser": "^4.0.0",
 				"@smithy/util-body-length-node": "^4.0.0",
-				"@smithy/util-defaults-mode-browser": "^4.0.21",
-				"@smithy/util-defaults-mode-node": "^4.0.21",
+				"@smithy/util-defaults-mode-browser": "^4.0.22",
+				"@smithy/util-defaults-mode-node": "^4.0.22",
 				"@smithy/util-endpoints": "^3.0.6",
 				"@smithy/util-middleware": "^4.0.4",
 				"@smithy/util-retry": "^4.0.6",
@@ -360,42 +358,42 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-sso": {
-			"version": "3.840.0",
+			"version": "3.844.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "3.840.0",
+				"@aws-sdk/core": "3.844.0",
 				"@aws-sdk/middleware-host-header": "3.840.0",
 				"@aws-sdk/middleware-logger": "3.840.0",
 				"@aws-sdk/middleware-recursion-detection": "3.840.0",
-				"@aws-sdk/middleware-user-agent": "3.840.0",
+				"@aws-sdk/middleware-user-agent": "3.844.0",
 				"@aws-sdk/region-config-resolver": "3.840.0",
 				"@aws-sdk/types": "3.840.0",
-				"@aws-sdk/util-endpoints": "3.840.0",
+				"@aws-sdk/util-endpoints": "3.844.0",
 				"@aws-sdk/util-user-agent-browser": "3.840.0",
-				"@aws-sdk/util-user-agent-node": "3.840.0",
+				"@aws-sdk/util-user-agent-node": "3.844.0",
 				"@smithy/config-resolver": "^4.1.4",
-				"@smithy/core": "^3.6.0",
-				"@smithy/fetch-http-handler": "^5.0.4",
+				"@smithy/core": "^3.7.0",
+				"@smithy/fetch-http-handler": "^5.1.0",
 				"@smithy/hash-node": "^4.0.4",
 				"@smithy/invalid-dependency": "^4.0.4",
 				"@smithy/middleware-content-length": "^4.0.4",
-				"@smithy/middleware-endpoint": "^4.1.13",
-				"@smithy/middleware-retry": "^4.1.14",
+				"@smithy/middleware-endpoint": "^4.1.14",
+				"@smithy/middleware-retry": "^4.1.15",
 				"@smithy/middleware-serde": "^4.0.8",
 				"@smithy/middleware-stack": "^4.0.4",
 				"@smithy/node-config-provider": "^4.1.3",
-				"@smithy/node-http-handler": "^4.0.6",
+				"@smithy/node-http-handler": "^4.1.0",
 				"@smithy/protocol-http": "^5.1.2",
-				"@smithy/smithy-client": "^4.4.5",
+				"@smithy/smithy-client": "^4.4.6",
 				"@smithy/types": "^4.3.1",
 				"@smithy/url-parser": "^4.0.4",
 				"@smithy/util-base64": "^4.0.0",
 				"@smithy/util-body-length-browser": "^4.0.0",
 				"@smithy/util-body-length-node": "^4.0.0",
-				"@smithy/util-defaults-mode-browser": "^4.0.21",
-				"@smithy/util-defaults-mode-node": "^4.0.21",
+				"@smithy/util-defaults-mode-browser": "^4.0.22",
+				"@smithy/util-defaults-mode-node": "^4.0.22",
 				"@smithy/util-endpoints": "^3.0.6",
 				"@smithy/util-middleware": "^4.0.4",
 				"@smithy/util-retry": "^4.0.6",
@@ -407,34 +405,60 @@
 			}
 		},
 		"node_modules/@aws-sdk/core": {
-			"version": "3.840.0",
+			"version": "3.844.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "3.840.0",
 				"@aws-sdk/xml-builder": "3.821.0",
-				"@smithy/core": "^3.6.0",
+				"@smithy/core": "^3.7.0",
 				"@smithy/node-config-provider": "^4.1.3",
 				"@smithy/property-provider": "^4.0.4",
 				"@smithy/protocol-http": "^5.1.2",
 				"@smithy/signature-v4": "^5.1.2",
-				"@smithy/smithy-client": "^4.4.5",
+				"@smithy/smithy-client": "^4.4.6",
 				"@smithy/types": "^4.3.1",
 				"@smithy/util-base64": "^4.0.0",
 				"@smithy/util-body-length-browser": "^4.0.0",
 				"@smithy/util-middleware": "^4.0.4",
 				"@smithy/util-utf8": "^4.0.0",
-				"fast-xml-parser": "4.4.1",
+				"fast-xml-parser": "5.2.5",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
 				"node": ">=18.0.0"
 			}
 		},
+		"node_modules/@aws-sdk/core/node_modules/fast-xml-parser": {
+			"version": "5.2.5",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT",
+			"dependencies": {
+				"strnum": "^2.1.0"
+			},
+			"bin": {
+				"fxparser": "src/cli/cli.js"
+			}
+		},
+		"node_modules/@aws-sdk/core/node_modules/strnum": {
+			"version": "2.1.1",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/NaturalIntelligence"
+				}
+			],
+			"license": "MIT"
+		},
 		"node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.840.0",
+			"version": "3.844.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "3.840.0",
+				"@aws-sdk/core": "3.844.0",
 				"@aws-sdk/types": "3.840.0",
 				"@smithy/property-provider": "^4.0.4",
 				"@smithy/types": "^4.3.1",
@@ -445,18 +469,18 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-http": {
-			"version": "3.840.0",
+			"version": "3.844.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "3.840.0",
+				"@aws-sdk/core": "3.844.0",
 				"@aws-sdk/types": "3.840.0",
-				"@smithy/fetch-http-handler": "^5.0.4",
-				"@smithy/node-http-handler": "^4.0.6",
+				"@smithy/fetch-http-handler": "^5.1.0",
+				"@smithy/node-http-handler": "^4.1.0",
 				"@smithy/property-provider": "^4.0.4",
 				"@smithy/protocol-http": "^5.1.2",
-				"@smithy/smithy-client": "^4.4.5",
+				"@smithy/smithy-client": "^4.4.6",
 				"@smithy/types": "^4.3.1",
-				"@smithy/util-stream": "^4.2.2",
+				"@smithy/util-stream": "^4.2.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -464,16 +488,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.840.0",
+			"version": "3.844.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "3.840.0",
-				"@aws-sdk/credential-provider-env": "3.840.0",
-				"@aws-sdk/credential-provider-http": "3.840.0",
-				"@aws-sdk/credential-provider-process": "3.840.0",
-				"@aws-sdk/credential-provider-sso": "3.840.0",
-				"@aws-sdk/credential-provider-web-identity": "3.840.0",
-				"@aws-sdk/nested-clients": "3.840.0",
+				"@aws-sdk/core": "3.844.0",
+				"@aws-sdk/credential-provider-env": "3.844.0",
+				"@aws-sdk/credential-provider-http": "3.844.0",
+				"@aws-sdk/credential-provider-process": "3.844.0",
+				"@aws-sdk/credential-provider-sso": "3.844.0",
+				"@aws-sdk/credential-provider-web-identity": "3.844.0",
+				"@aws-sdk/nested-clients": "3.844.0",
 				"@aws-sdk/types": "3.840.0",
 				"@smithy/credential-provider-imds": "^4.0.6",
 				"@smithy/property-provider": "^4.0.4",
@@ -486,15 +510,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.840.0",
+			"version": "3.844.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "3.840.0",
-				"@aws-sdk/credential-provider-http": "3.840.0",
-				"@aws-sdk/credential-provider-ini": "3.840.0",
-				"@aws-sdk/credential-provider-process": "3.840.0",
-				"@aws-sdk/credential-provider-sso": "3.840.0",
-				"@aws-sdk/credential-provider-web-identity": "3.840.0",
+				"@aws-sdk/credential-provider-env": "3.844.0",
+				"@aws-sdk/credential-provider-http": "3.844.0",
+				"@aws-sdk/credential-provider-ini": "3.844.0",
+				"@aws-sdk/credential-provider-process": "3.844.0",
+				"@aws-sdk/credential-provider-sso": "3.844.0",
+				"@aws-sdk/credential-provider-web-identity": "3.844.0",
 				"@aws-sdk/types": "3.840.0",
 				"@smithy/credential-provider-imds": "^4.0.6",
 				"@smithy/property-provider": "^4.0.4",
@@ -507,10 +531,10 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.840.0",
+			"version": "3.844.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "3.840.0",
+				"@aws-sdk/core": "3.844.0",
 				"@aws-sdk/types": "3.840.0",
 				"@smithy/property-provider": "^4.0.4",
 				"@smithy/shared-ini-file-loader": "^4.0.4",
@@ -522,12 +546,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.840.0",
+			"version": "3.844.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/client-sso": "3.840.0",
-				"@aws-sdk/core": "3.840.0",
-				"@aws-sdk/token-providers": "3.840.0",
+				"@aws-sdk/client-sso": "3.844.0",
+				"@aws-sdk/core": "3.844.0",
+				"@aws-sdk/token-providers": "3.844.0",
 				"@aws-sdk/types": "3.840.0",
 				"@smithy/property-provider": "^4.0.4",
 				"@smithy/shared-ini-file-loader": "^4.0.4",
@@ -539,11 +563,11 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.840.0",
+			"version": "3.844.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "3.840.0",
-				"@aws-sdk/nested-clients": "3.840.0",
+				"@aws-sdk/core": "3.844.0",
+				"@aws-sdk/nested-clients": "3.844.0",
 				"@aws-sdk/types": "3.840.0",
 				"@smithy/property-provider": "^4.0.4",
 				"@smithy/types": "^4.3.1",
@@ -583,20 +607,20 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-flexible-checksums": {
-			"version": "3.840.0",
+			"version": "3.844.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/crc32": "5.2.0",
 				"@aws-crypto/crc32c": "5.2.0",
 				"@aws-crypto/util": "5.2.0",
-				"@aws-sdk/core": "3.840.0",
+				"@aws-sdk/core": "3.844.0",
 				"@aws-sdk/types": "3.840.0",
 				"@smithy/is-array-buffer": "^4.0.0",
 				"@smithy/node-config-provider": "^4.1.3",
 				"@smithy/protocol-http": "^5.1.2",
 				"@smithy/types": "^4.3.1",
 				"@smithy/util-middleware": "^4.0.4",
-				"@smithy/util-stream": "^4.2.2",
+				"@smithy/util-stream": "^4.2.3",
 				"@smithy/util-utf8": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
@@ -655,21 +679,21 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-sdk-s3": {
-			"version": "3.840.0",
+			"version": "3.844.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "3.840.0",
+				"@aws-sdk/core": "3.844.0",
 				"@aws-sdk/types": "3.840.0",
 				"@aws-sdk/util-arn-parser": "3.804.0",
-				"@smithy/core": "^3.6.0",
+				"@smithy/core": "^3.7.0",
 				"@smithy/node-config-provider": "^4.1.3",
 				"@smithy/protocol-http": "^5.1.2",
 				"@smithy/signature-v4": "^5.1.2",
-				"@smithy/smithy-client": "^4.4.5",
+				"@smithy/smithy-client": "^4.4.6",
 				"@smithy/types": "^4.3.1",
 				"@smithy/util-config-provider": "^4.0.0",
 				"@smithy/util-middleware": "^4.0.4",
-				"@smithy/util-stream": "^4.2.2",
+				"@smithy/util-stream": "^4.2.3",
 				"@smithy/util-utf8": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
@@ -690,13 +714,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-user-agent": {
-			"version": "3.840.0",
+			"version": "3.844.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "3.840.0",
+				"@aws-sdk/core": "3.844.0",
 				"@aws-sdk/types": "3.840.0",
-				"@aws-sdk/util-endpoints": "3.840.0",
-				"@smithy/core": "^3.6.0",
+				"@aws-sdk/util-endpoints": "3.844.0",
+				"@smithy/core": "^3.7.0",
 				"@smithy/protocol-http": "^5.1.2",
 				"@smithy/types": "^4.3.1",
 				"tslib": "^2.6.2"
@@ -706,42 +730,42 @@
 			}
 		},
 		"node_modules/@aws-sdk/nested-clients": {
-			"version": "3.840.0",
+			"version": "3.844.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
 				"@aws-crypto/sha256-js": "5.2.0",
-				"@aws-sdk/core": "3.840.0",
+				"@aws-sdk/core": "3.844.0",
 				"@aws-sdk/middleware-host-header": "3.840.0",
 				"@aws-sdk/middleware-logger": "3.840.0",
 				"@aws-sdk/middleware-recursion-detection": "3.840.0",
-				"@aws-sdk/middleware-user-agent": "3.840.0",
+				"@aws-sdk/middleware-user-agent": "3.844.0",
 				"@aws-sdk/region-config-resolver": "3.840.0",
 				"@aws-sdk/types": "3.840.0",
-				"@aws-sdk/util-endpoints": "3.840.0",
+				"@aws-sdk/util-endpoints": "3.844.0",
 				"@aws-sdk/util-user-agent-browser": "3.840.0",
-				"@aws-sdk/util-user-agent-node": "3.840.0",
+				"@aws-sdk/util-user-agent-node": "3.844.0",
 				"@smithy/config-resolver": "^4.1.4",
-				"@smithy/core": "^3.6.0",
-				"@smithy/fetch-http-handler": "^5.0.4",
+				"@smithy/core": "^3.7.0",
+				"@smithy/fetch-http-handler": "^5.1.0",
 				"@smithy/hash-node": "^4.0.4",
 				"@smithy/invalid-dependency": "^4.0.4",
 				"@smithy/middleware-content-length": "^4.0.4",
-				"@smithy/middleware-endpoint": "^4.1.13",
-				"@smithy/middleware-retry": "^4.1.14",
+				"@smithy/middleware-endpoint": "^4.1.14",
+				"@smithy/middleware-retry": "^4.1.15",
 				"@smithy/middleware-serde": "^4.0.8",
 				"@smithy/middleware-stack": "^4.0.4",
 				"@smithy/node-config-provider": "^4.1.3",
-				"@smithy/node-http-handler": "^4.0.6",
+				"@smithy/node-http-handler": "^4.1.0",
 				"@smithy/protocol-http": "^5.1.2",
-				"@smithy/smithy-client": "^4.4.5",
+				"@smithy/smithy-client": "^4.4.6",
 				"@smithy/types": "^4.3.1",
 				"@smithy/url-parser": "^4.0.4",
 				"@smithy/util-base64": "^4.0.0",
 				"@smithy/util-body-length-browser": "^4.0.0",
 				"@smithy/util-body-length-node": "^4.0.0",
-				"@smithy/util-defaults-mode-browser": "^4.0.21",
-				"@smithy/util-defaults-mode-node": "^4.0.21",
+				"@smithy/util-defaults-mode-browser": "^4.0.22",
+				"@smithy/util-defaults-mode-node": "^4.0.22",
 				"@smithy/util-endpoints": "^3.0.6",
 				"@smithy/util-middleware": "^4.0.4",
 				"@smithy/util-retry": "^4.0.6",
@@ -768,10 +792,10 @@
 			}
 		},
 		"node_modules/@aws-sdk/signature-v4-multi-region": {
-			"version": "3.840.0",
+			"version": "3.844.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/middleware-sdk-s3": "3.840.0",
+				"@aws-sdk/middleware-sdk-s3": "3.844.0",
 				"@aws-sdk/types": "3.840.0",
 				"@smithy/protocol-http": "^5.1.2",
 				"@smithy/signature-v4": "^5.1.2",
@@ -783,11 +807,11 @@
 			}
 		},
 		"node_modules/@aws-sdk/token-providers": {
-			"version": "3.840.0",
+			"version": "3.844.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/core": "3.840.0",
-				"@aws-sdk/nested-clients": "3.840.0",
+				"@aws-sdk/core": "3.844.0",
+				"@aws-sdk/nested-clients": "3.844.0",
 				"@aws-sdk/types": "3.840.0",
 				"@smithy/property-provider": "^4.0.4",
 				"@smithy/shared-ini-file-loader": "^4.0.4",
@@ -820,11 +844,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-endpoints": {
-			"version": "3.840.0",
+			"version": "3.844.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "3.840.0",
 				"@smithy/types": "^4.3.1",
+				"@smithy/url-parser": "^4.0.4",
 				"@smithy/util-endpoints": "^3.0.6",
 				"tslib": "^2.6.2"
 			},
@@ -853,10 +878,10 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-user-agent-node": {
-			"version": "3.840.0",
+			"version": "3.844.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@aws-sdk/middleware-user-agent": "3.840.0",
+				"@aws-sdk/middleware-user-agent": "3.844.0",
 				"@aws-sdk/types": "3.840.0",
 				"@smithy/node-config-provider": "^4.1.3",
 				"@smithy/types": "^4.3.1",
@@ -899,7 +924,7 @@
 			}
 		},
 		"node_modules/@babel/compat-data": {
-			"version": "7.27.7",
+			"version": "7.28.0",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -907,20 +932,20 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.27.7",
+			"version": "7.28.0",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
 				"@babel/code-frame": "^7.27.1",
-				"@babel/generator": "^7.27.5",
+				"@babel/generator": "^7.28.0",
 				"@babel/helper-compilation-targets": "^7.27.2",
 				"@babel/helper-module-transforms": "^7.27.3",
 				"@babel/helpers": "^7.27.6",
-				"@babel/parser": "^7.27.7",
+				"@babel/parser": "^7.28.0",
 				"@babel/template": "^7.27.2",
-				"@babel/traverse": "^7.27.7",
-				"@babel/types": "^7.27.7",
+				"@babel/traverse": "^7.28.0",
+				"@babel/types": "^7.28.0",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -944,14 +969,14 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.27.5",
+			"version": "7.28.0",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/parser": "^7.27.5",
-				"@babel/types": "^7.27.3",
-				"@jridgewell/gen-mapping": "^0.3.5",
-				"@jridgewell/trace-mapping": "^0.3.25",
+				"@babel/parser": "^7.28.0",
+				"@babel/types": "^7.28.0",
+				"@jridgewell/gen-mapping": "^0.3.12",
+				"@jridgewell/trace-mapping": "^0.3.28",
 				"jsesc": "^3.0.2"
 			},
 			"engines": {
@@ -979,6 +1004,14 @@
 			"license": "ISC",
 			"bin": {
 				"semver": "bin/semver.js"
+			}
+		},
+		"node_modules/@babel/helper-globals": {
+			"version": "7.28.0",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@babel/helper-module-imports": {
@@ -1054,11 +1087,11 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.27.7",
+			"version": "7.28.0",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@babel/types": "^7.27.7"
+				"@babel/types": "^7.28.0"
 			},
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -1294,32 +1327,24 @@
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.27.7",
+			"version": "7.28.0",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@babel/code-frame": "^7.27.1",
-				"@babel/generator": "^7.27.5",
-				"@babel/parser": "^7.27.7",
+				"@babel/generator": "^7.28.0",
+				"@babel/helper-globals": "^7.28.0",
+				"@babel/parser": "^7.28.0",
 				"@babel/template": "^7.27.2",
-				"@babel/types": "^7.27.7",
-				"debug": "^4.3.1",
-				"globals": "^11.1.0"
+				"@babel/types": "^7.28.0",
+				"debug": "^4.3.1"
 			},
 			"engines": {
 				"node": ">=6.9.0"
 			}
 		},
-		"node_modules/@babel/traverse/node_modules/globals": {
-			"version": "11.12.0",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/@babel/types": {
-			"version": "7.27.7",
+			"version": "7.28.0",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1386,6 +1411,17 @@
 				"eslint": "^6.0.0 || ^7.0.0 || >=8.0.0"
 			}
 		},
+		"node_modules/@eslint-community/eslint-utils/node_modules/eslint-visitor-keys": {
+			"version": "3.4.3",
+			"dev": true,
+			"license": "Apache-2.0",
+			"engines": {
+				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+			},
+			"funding": {
+				"url": "https://opencollective.com/eslint"
+			}
+		},
 		"node_modules/@eslint-community/regexpp": {
 			"version": "4.12.1",
 			"dev": true,
@@ -1396,8 +1432,6 @@
 		},
 		"node_modules/@eslint/config-array": {
 			"version": "0.21.0",
-			"resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.21.0.tgz",
-			"integrity": "sha512-ENIdc4iLu0d93HeYirvKmrzshzofPw6VkZRKQGe9Nv46ZnWUzcF1xV01dcvEg/1wXUR61OmmlSfyeyO7EvjLxQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -1411,8 +1445,6 @@
 		},
 		"node_modules/@eslint/config-array/node_modules/brace-expansion": {
 			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1422,8 +1454,6 @@
 		},
 		"node_modules/@eslint/config-array/node_modules/minimatch": {
 			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -1435,8 +1465,6 @@
 		},
 		"node_modules/@eslint/config-helpers": {
 			"version": "0.3.0",
-			"resolved": "https://registry.npmjs.org/@eslint/config-helpers/-/config-helpers-0.3.0.tgz",
-			"integrity": "sha512-ViuymvFmcJi04qdZeDc2whTHryouGcDlaxPqarTD0ZE10ISpxGUVZGZDx4w01upyIynL3iu6IXH2bS1NhclQMw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -1444,9 +1472,7 @@
 			}
 		},
 		"node_modules/@eslint/core": {
-			"version": "0.14.0",
-			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.14.0.tgz",
-			"integrity": "sha512-qIbV0/JZr7iSDjqAc60IqbLdsj9GDt16xQtWD+B78d/HAlvysGdZZ6rpJHGAc2T0FQx1X6thsSPdnoiGKdNtdg==",
+			"version": "0.15.1",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -1458,8 +1484,6 @@
 		},
 		"node_modules/@eslint/eslintrc": {
 			"version": "3.3.1",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-3.3.1.tgz",
-			"integrity": "sha512-gtF186CXhIl1p4pJNGZw8Yc6RlshoePRvE0X91oPGb3vZ8pM3qOS9W9NGPat9LziaBV7XrJWGylNQXkGcnM3IQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1482,8 +1506,6 @@
 		},
 		"node_modules/@eslint/eslintrc/node_modules/ajv": {
 			"version": "6.12.6",
-			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
-			"integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1499,8 +1521,6 @@
 		},
 		"node_modules/@eslint/eslintrc/node_modules/brace-expansion": {
 			"version": "1.1.12",
-			"resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.12.tgz",
-			"integrity": "sha512-9T9UjW3r0UW5c1Q7GTwllptXwhvYmEzFhzMfZ9H7FQWt+uZePjZPjBP/W1ZEyZ1twGWom5/56TF4lPcqjnDHcg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -1508,27 +1528,13 @@
 				"concat-map": "0.0.1"
 			}
 		},
-		"node_modules/@eslint/eslintrc/node_modules/ignore": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
-			"integrity": "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4"
-			}
-		},
 		"node_modules/@eslint/eslintrc/node_modules/json-schema-traverse": {
 			"version": "0.4.1",
-			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
 			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/@eslint/eslintrc/node_modules/minimatch": {
 			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
-			"integrity": "sha512-J7p63hRiAjw1NDEww1W7i37+ByIrOWO5XQQAzZ3VOcL0PNybwpfmV/N05zFAzwQ9USyEcX6t3UO+K5aqBQOIHw==",
 			"dev": true,
 			"license": "ISC",
 			"dependencies": {
@@ -1539,9 +1545,7 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "9.30.1",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.30.1.tgz",
-			"integrity": "sha512-zXhuECFlyep42KZUhWjfvsmXGX39W8K8LFb8AWXM9gSV9dQB+MrJGLKvW6Zw0Ggnbpw0VHTtrhFXYe3Gym18jg==",
+			"version": "9.31.0",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -1553,8 +1557,6 @@
 		},
 		"node_modules/@eslint/object-schema": {
 			"version": "2.1.6",
-			"resolved": "https://registry.npmjs.org/@eslint/object-schema/-/object-schema-2.1.6.tgz",
-			"integrity": "sha512-RBMg5FRL0I0gs51M/guSAj5/e14VQ4tpZnQNWwuDT66P14I43ItmPfIZRhO9fUVIPOAQXU47atlywZ/czoqFPA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -1563,26 +1565,11 @@
 		},
 		"node_modules/@eslint/plugin-kit": {
 			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@eslint/plugin-kit/-/plugin-kit-0.3.3.tgz",
-			"integrity": "sha512-1+WqvgNMhmlAambTvT3KPtCl/Ibr68VldY2XY40SL1CE0ZXiakFR/cbTspaF5HsnpDMvcYYoJHfl4980NBjGag==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@eslint/core": "^0.15.1",
 				"levn": "^0.4.1"
-			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			}
-		},
-		"node_modules/@eslint/plugin-kit/node_modules/@eslint/core": {
-			"version": "0.15.1",
-			"resolved": "https://registry.npmjs.org/@eslint/core/-/core-0.15.1.tgz",
-			"integrity": "sha512-bkOp+iumZCCbt1K1CmWf0R9pM5yKpDv+ZXtvSyQpudrI9kuFLp+bM2WOPXImuD/ceQuaa8f5pj93Y7zyECIGNA==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"@types/json-schema": "^7.0.15"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1677,8 +1664,6 @@
 		},
 		"node_modules/@humanfs/core": {
 			"version": "0.19.1",
-			"resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-			"integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -1687,8 +1672,6 @@
 		},
 		"node_modules/@humanfs/node": {
 			"version": "0.16.6",
-			"resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.6.tgz",
-			"integrity": "sha512-YuI2ZHQL78Q5HbhDiBA1X4LmYdXCKCMQIfw0pw7piHJwyREFebJUvrQN4cMssyES6x+vfUbx1CIpaQUKYdQZOw==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"dependencies": {
@@ -1701,8 +1684,6 @@
 		},
 		"node_modules/@humanfs/node/node_modules/@humanwhocodes/retry": {
 			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.3.1.tgz",
-			"integrity": "sha512-JBxkERygn7Bv/GbN5Rv8Ul6LVknS+5Bp6RgDC/O8gEBU/yeH5Ui5C/OlWrTb6qct7LjjfT6Re2NxB0ln0yYybA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -1735,8 +1716,6 @@
 		},
 		"node_modules/@humanwhocodes/retry": {
 			"version": "0.4.3",
-			"resolved": "https://registry.npmjs.org/@humanwhocodes/retry/-/retry-0.4.3.tgz",
-			"integrity": "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -1951,6 +1930,41 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
+		"node_modules/@jest/console/node_modules/jest-message-util": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.12.13",
+				"@jest/types": "^29.6.3",
+				"@types/stack-utils": "^2.0.0",
+				"chalk": "^4.0.0",
+				"graceful-fs": "^4.2.9",
+				"micromatch": "^4.0.4",
+				"pretty-format": "^29.7.0",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@jest/console/node_modules/jest-util": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"ci-info": "^3.2.0",
+				"graceful-fs": "^4.2.9",
+				"picomatch": "^2.2.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
 		"node_modules/@jest/core": {
 			"version": "29.7.0",
 			"dev": true,
@@ -1997,33 +2011,7 @@
 				}
 			}
 		},
-		"node_modules/@jest/environment": {
-			"version": "29.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/fake-timers": "^29.7.0",
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"jest-mock": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/expect": {
-			"version": "29.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"expect": "^29.7.0",
-				"jest-snapshot": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/@jest/expect-utils": {
+		"node_modules/@jest/core/node_modules/@jest/expect-utils": {
 			"version": "29.7.0",
 			"dev": true,
 			"license": "MIT",
@@ -2034,31 +2022,89 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
-		"node_modules/@jest/fake-timers": {
+		"node_modules/@jest/core/node_modules/expect": {
 			"version": "29.7.0",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@sinonjs/fake-timers": "^10.0.2",
-				"@types/node": "*",
+				"@jest/expect-utils": "^29.7.0",
+				"jest-get-type": "^29.6.3",
+				"jest-matcher-utils": "^29.7.0",
 				"jest-message-util": "^29.7.0",
-				"jest-mock": "^29.7.0",
 				"jest-util": "^29.7.0"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
-		"node_modules/@jest/globals": {
+		"node_modules/@jest/core/node_modules/jest-message-util": {
 			"version": "29.7.0",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@jest/environment": "^29.7.0",
-				"@jest/expect": "^29.7.0",
+				"@babel/code-frame": "^7.12.13",
 				"@jest/types": "^29.6.3",
-				"jest-mock": "^29.7.0"
+				"@types/stack-utils": "^2.0.0",
+				"chalk": "^4.0.0",
+				"graceful-fs": "^4.2.9",
+				"micromatch": "^4.0.4",
+				"pretty-format": "^29.7.0",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@jest/core/node_modules/jest-regex-util": {
+			"version": "29.6.3",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@jest/core/node_modules/jest-snapshot": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/core": "^7.11.6",
+				"@babel/generator": "^7.7.2",
+				"@babel/plugin-syntax-jsx": "^7.7.2",
+				"@babel/plugin-syntax-typescript": "^7.7.2",
+				"@babel/types": "^7.3.3",
+				"@jest/expect-utils": "^29.7.0",
+				"@jest/transform": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"babel-preset-current-node-syntax": "^1.0.0",
+				"chalk": "^4.0.0",
+				"expect": "^29.7.0",
+				"graceful-fs": "^4.2.9",
+				"jest-diff": "^29.7.0",
+				"jest-get-type": "^29.6.3",
+				"jest-matcher-utils": "^29.7.0",
+				"jest-message-util": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"natural-compare": "^1.4.0",
+				"pretty-format": "^29.7.0",
+				"semver": "^7.5.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@jest/core/node_modules/jest-util": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"ci-info": "^3.2.0",
+				"graceful-fs": "^4.2.9",
+				"picomatch": "^2.2.3"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -2106,12 +2152,36 @@
 				}
 			}
 		},
-		"node_modules/@jest/schemas": {
-			"version": "29.6.3",
+		"node_modules/@jest/reporters/node_modules/jest-message-util": {
+			"version": "29.7.0",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@sinclair/typebox": "^0.27.8"
+				"@babel/code-frame": "^7.12.13",
+				"@jest/types": "^29.6.3",
+				"@types/stack-utils": "^2.0.0",
+				"chalk": "^4.0.0",
+				"graceful-fs": "^4.2.9",
+				"micromatch": "^4.0.4",
+				"pretty-format": "^29.7.0",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@jest/reporters/node_modules/jest-util": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"ci-info": "^3.2.0",
+				"graceful-fs": "^4.2.9",
+				"picomatch": "^2.2.3"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -2183,6 +2253,30 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
+		"node_modules/@jest/transform/node_modules/jest-regex-util": {
+			"version": "29.6.3",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@jest/transform/node_modules/jest-util": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"ci-info": "^3.2.0",
+				"graceful-fs": "^4.2.9",
+				"picomatch": "^2.2.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
 		"node_modules/@jest/types": {
 			"version": "29.6.3",
 			"dev": true,
@@ -2198,6 +2292,22 @@
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
+		},
+		"node_modules/@jest/types/node_modules/@jest/schemas": {
+			"version": "29.6.3",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sinclair/typebox": "^0.27.8"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@jest/types/node_modules/@sinclair/typebox": {
+			"version": "0.27.8",
+			"dev": true,
+			"license": "MIT"
 		},
 		"node_modules/@jridgewell/gen-mapping": {
 			"version": "0.3.12",
@@ -2376,6 +2486,25 @@
 			"engines": {
 				"node": ">=18",
 				"npm": ">=6.0.0"
+			}
+		},
+		"node_modules/@newrelic/security-agent/node_modules/ws": {
+			"version": "8.18.3",
+			"license": "MIT",
+			"engines": {
+				"node": ">=10.0.0"
+			},
+			"peerDependencies": {
+				"bufferutil": "^4.0.1",
+				"utf-8-validate": ">=5.0.2"
+			},
+			"peerDependenciesMeta": {
+				"bufferutil": {
+					"optional": true
+				},
+				"utf-8-validate": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/@noble/hashes": {
@@ -2614,7 +2743,7 @@
 			}
 		},
 		"node_modules/@opentelemetry/exporter-metrics-otlp-http/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.34.0",
+			"version": "1.36.0",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=14"
@@ -2753,7 +2882,7 @@
 			}
 		},
 		"node_modules/@opentelemetry/exporter-metrics-otlp-proto/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.34.0",
+			"version": "1.36.0",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=14"
@@ -3391,7 +3520,7 @@
 			}
 		},
 		"node_modules/@prisma/instrumentation": {
-			"version": "6.10.1",
+			"version": "6.11.1",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/instrumentation": "^0.52.0 || ^0.53.0 || ^0.54.0 || ^0.55.0 || ^0.56.0 || ^0.57.0"
@@ -3505,18 +3634,6 @@
 				"npm": ">=9.5.0"
 			}
 		},
-		"node_modules/@redocly/cli/node_modules/dotenv": {
-			"version": "16.4.7",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
-			"integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://dotenvx.com"
-			}
-		},
 		"node_modules/@redocly/config": {
 			"version": "0.22.2",
 			"dev": true,
@@ -3577,18 +3694,6 @@
 			"dev": true,
 			"license": "MIT"
 		},
-		"node_modules/@redocly/respect-core/node_modules/dotenv": {
-			"version": "16.4.7",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
-			"integrity": "sha512-47qPchRCykZC03FhkYAhrvwU4xDBFIj1QPqaarj6mdM/hgUzfPHcpkHJOn3mJAufFeeAxAzeGsr5X0M4k6fLZQ==",
-			"dev": true,
-			"engines": {
-				"node": ">=12"
-			},
-			"funding": {
-				"url": "https://dotenvx.com"
-			}
-		},
 		"node_modules/@redocly/respect-core/node_modules/form-data": {
 			"version": "4.0.0",
 			"dev": true,
@@ -3624,15 +3729,15 @@
 			}
 		},
 		"node_modules/@sentry/aws-serverless": {
-			"version": "9.34.0",
+			"version": "9.38.0",
 			"license": "MIT",
 			"dependencies": {
 				"@opentelemetry/api": "^1.9.0",
 				"@opentelemetry/instrumentation": "^0.57.2",
 				"@opentelemetry/instrumentation-aws-lambda": "0.50.3",
 				"@opentelemetry/instrumentation-aws-sdk": "0.49.1",
-				"@sentry/core": "9.34.0",
-				"@sentry/node": "9.34.0",
+				"@sentry/core": "9.38.0",
+				"@sentry/node": "9.38.0",
 				"@types/aws-lambda": "^8.10.62"
 			},
 			"engines": {
@@ -3640,14 +3745,14 @@
 			}
 		},
 		"node_modules/@sentry/core": {
-			"version": "9.34.0",
+			"version": "9.38.0",
 			"license": "MIT",
 			"engines": {
 				"node": ">=18"
 			}
 		},
 		"node_modules/@sentry/node": {
-			"version": "9.34.0",
+			"version": "9.38.0",
 			"license": "MIT",
 			"dependencies": {
 				"@opentelemetry/api": "^1.9.0",
@@ -3679,9 +3784,10 @@
 				"@opentelemetry/resources": "^1.30.1",
 				"@opentelemetry/sdk-trace-base": "^1.30.1",
 				"@opentelemetry/semantic-conventions": "^1.34.0",
-				"@prisma/instrumentation": "6.10.1",
-				"@sentry/core": "9.34.0",
-				"@sentry/opentelemetry": "9.34.0",
+				"@prisma/instrumentation": "6.11.1",
+				"@sentry/core": "9.38.0",
+				"@sentry/node-core": "9.38.0",
+				"@sentry/opentelemetry": "9.38.0",
 				"import-in-the-middle": "^1.14.2",
 				"minimatch": "^9.0.0"
 			},
@@ -3763,17 +3869,19 @@
 			}
 		},
 		"node_modules/@sentry/node/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.34.0",
+			"version": "1.36.0",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=14"
 			}
 		},
-		"node_modules/@sentry/node/node_modules/@sentry/opentelemetry": {
-			"version": "9.34.0",
+		"node_modules/@sentry/node/node_modules/@sentry/node-core": {
+			"version": "9.38.0",
 			"license": "MIT",
 			"dependencies": {
-				"@sentry/core": "9.34.0"
+				"@sentry/core": "9.38.0",
+				"@sentry/opentelemetry": "9.38.0",
+				"import-in-the-middle": "^1.14.2"
 			},
 			"engines": {
 				"node": ">=18"
@@ -3782,7 +3890,26 @@
 				"@opentelemetry/api": "^1.9.0",
 				"@opentelemetry/context-async-hooks": "^1.30.1 || ^2.0.0",
 				"@opentelemetry/core": "^1.30.1 || ^2.0.0",
-				"@opentelemetry/instrumentation": "^0.57.1 || ^0.200.0",
+				"@opentelemetry/instrumentation": "^0.57.1 || ^0.202.0",
+				"@opentelemetry/resources": "^1.30.1 || ^2.0.0",
+				"@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.0.0",
+				"@opentelemetry/semantic-conventions": "^1.34.0"
+			}
+		},
+		"node_modules/@sentry/node/node_modules/@sentry/opentelemetry": {
+			"version": "9.38.0",
+			"license": "MIT",
+			"dependencies": {
+				"@sentry/core": "9.38.0"
+			},
+			"engines": {
+				"node": ">=18"
+			},
+			"peerDependencies": {
+				"@opentelemetry/api": "^1.9.0",
+				"@opentelemetry/context-async-hooks": "^1.30.1 || ^2.0.0",
+				"@opentelemetry/core": "^1.30.1 || ^2.0.0",
+				"@opentelemetry/instrumentation": "^0.57.1 || ^0.202.0",
 				"@opentelemetry/sdk-trace-base": "^1.30.1 || ^2.0.0",
 				"@opentelemetry/semantic-conventions": "^1.34.0"
 			}
@@ -3801,12 +3928,12 @@
 			}
 		},
 		"node_modules/@sentry/profiling-node": {
-			"version": "9.34.0",
+			"version": "9.38.0",
 			"license": "MIT",
 			"dependencies": {
 				"@sentry-internal/node-cpu-profiler": "^2.2.0",
-				"@sentry/core": "9.34.0",
-				"@sentry/node": "9.34.0"
+				"@sentry/core": "9.38.0",
+				"@sentry/node": "9.38.0"
 			},
 			"bin": {
 				"sentry-prune-profiler-binaries": "scripts/prune-profiler-binaries.js"
@@ -3830,25 +3957,12 @@
 			"version": "2.0.0",
 			"license": "BSD-3-Clause"
 		},
-		"node_modules/@sinclair/typebox": {
-			"version": "0.27.8",
-			"dev": true,
-			"license": "MIT"
-		},
 		"node_modules/@sinonjs/commons": {
 			"version": "3.0.1",
 			"dev": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"type-detect": "4.0.8"
-			}
-		},
-		"node_modules/@sinonjs/fake-timers": {
-			"version": "10.3.0",
-			"dev": true,
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"@sinonjs/commons": "^3.0.0"
 			}
 		},
 		"node_modules/@smithy/abort-controller": {
@@ -3898,7 +4012,7 @@
 			}
 		},
 		"node_modules/@smithy/core": {
-			"version": "3.6.0",
+			"version": "3.7.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/middleware-serde": "^4.0.8",
@@ -3907,7 +4021,7 @@
 				"@smithy/util-base64": "^4.0.0",
 				"@smithy/util-body-length-browser": "^4.0.0",
 				"@smithy/util-middleware": "^4.0.4",
-				"@smithy/util-stream": "^4.2.2",
+				"@smithy/util-stream": "^4.2.3",
 				"@smithy/util-utf8": "^4.0.0",
 				"tslib": "^2.6.2"
 			},
@@ -3990,7 +4104,7 @@
 			}
 		},
 		"node_modules/@smithy/fetch-http-handler": {
-			"version": "5.0.4",
+			"version": "5.1.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/protocol-http": "^5.1.2",
@@ -4087,10 +4201,10 @@
 			}
 		},
 		"node_modules/@smithy/middleware-endpoint": {
-			"version": "4.1.13",
+			"version": "4.1.14",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.6.0",
+				"@smithy/core": "^3.7.0",
 				"@smithy/middleware-serde": "^4.0.8",
 				"@smithy/node-config-provider": "^4.1.3",
 				"@smithy/shared-ini-file-loader": "^4.0.4",
@@ -4104,13 +4218,13 @@
 			}
 		},
 		"node_modules/@smithy/middleware-retry": {
-			"version": "4.1.14",
+			"version": "4.1.15",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/node-config-provider": "^4.1.3",
 				"@smithy/protocol-http": "^5.1.2",
 				"@smithy/service-error-classification": "^4.0.6",
-				"@smithy/smithy-client": "^4.4.5",
+				"@smithy/smithy-client": "^4.4.6",
 				"@smithy/types": "^4.3.1",
 				"@smithy/util-middleware": "^4.0.4",
 				"@smithy/util-retry": "^4.0.6",
@@ -4158,7 +4272,7 @@
 			}
 		},
 		"node_modules/@smithy/node-http-handler": {
-			"version": "4.0.6",
+			"version": "4.1.0",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/abort-controller": "^4.0.4",
@@ -4255,15 +4369,15 @@
 			}
 		},
 		"node_modules/@smithy/smithy-client": {
-			"version": "4.4.5",
+			"version": "4.4.6",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/core": "^3.6.0",
-				"@smithy/middleware-endpoint": "^4.1.13",
+				"@smithy/core": "^3.7.0",
+				"@smithy/middleware-endpoint": "^4.1.14",
 				"@smithy/middleware-stack": "^4.0.4",
 				"@smithy/protocol-http": "^5.1.2",
 				"@smithy/types": "^4.3.1",
-				"@smithy/util-stream": "^4.2.2",
+				"@smithy/util-stream": "^4.2.3",
 				"tslib": "^2.6.2"
 			},
 			"engines": {
@@ -4346,11 +4460,11 @@
 			}
 		},
 		"node_modules/@smithy/util-defaults-mode-browser": {
-			"version": "4.0.21",
+			"version": "4.0.22",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/property-provider": "^4.0.4",
-				"@smithy/smithy-client": "^4.4.5",
+				"@smithy/smithy-client": "^4.4.6",
 				"@smithy/types": "^4.3.1",
 				"bowser": "^2.11.0",
 				"tslib": "^2.6.2"
@@ -4360,14 +4474,14 @@
 			}
 		},
 		"node_modules/@smithy/util-defaults-mode-node": {
-			"version": "4.0.21",
+			"version": "4.0.22",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/config-resolver": "^4.1.4",
 				"@smithy/credential-provider-imds": "^4.0.6",
 				"@smithy/node-config-provider": "^4.1.3",
 				"@smithy/property-provider": "^4.0.4",
-				"@smithy/smithy-client": "^4.4.5",
+				"@smithy/smithy-client": "^4.4.6",
 				"@smithy/types": "^4.3.1",
 				"tslib": "^2.6.2"
 			},
@@ -4421,11 +4535,11 @@
 			}
 		},
 		"node_modules/@smithy/util-stream": {
-			"version": "4.2.2",
+			"version": "4.2.3",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@smithy/fetch-http-handler": "^5.0.4",
-				"@smithy/node-http-handler": "^4.0.6",
+				"@smithy/fetch-http-handler": "^5.1.0",
+				"@smithy/node-http-handler": "^4.1.0",
 				"@smithy/types": "^4.3.1",
 				"@smithy/util-base64": "^4.0.0",
 				"@smithy/util-buffer-from": "^4.0.0",
@@ -4615,8 +4729,6 @@
 		},
 		"node_modules/@types/estree": {
 			"version": "1.0.8",
-			"resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-			"integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -4631,7 +4743,7 @@
 			}
 		},
 		"node_modules/@types/express-serve-static-core": {
-			"version": "5.0.6",
+			"version": "5.0.7",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4705,6 +4817,67 @@
 			"license": "MIT",
 			"dependencies": {
 				"@types/jest": "*"
+			}
+		},
+		"node_modules/@types/jest/node_modules/@jest/expect-utils": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"jest-get-type": "^29.6.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@types/jest/node_modules/expect": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/expect-utils": "^29.7.0",
+				"jest-get-type": "^29.6.3",
+				"jest-matcher-utils": "^29.7.0",
+				"jest-message-util": "^29.7.0",
+				"jest-util": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@types/jest/node_modules/jest-message-util": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.12.13",
+				"@jest/types": "^29.6.3",
+				"@types/stack-utils": "^2.0.0",
+				"chalk": "^4.0.0",
+				"graceful-fs": "^4.2.9",
+				"micromatch": "^4.0.4",
+				"pretty-format": "^29.7.0",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/@types/jest/node_modules/jest-util": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"ci-info": "^3.2.0",
+				"graceful-fs": "^4.2.9",
+				"picomatch": "^2.2.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
 		"node_modules/@types/json-schema": {
@@ -4897,15 +5070,15 @@
 			"license": "MIT"
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
-			"version": "8.35.1",
+			"version": "8.37.0",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/regexpp": "^4.10.0",
-				"@typescript-eslint/scope-manager": "8.35.1",
-				"@typescript-eslint/type-utils": "8.35.1",
-				"@typescript-eslint/utils": "8.35.1",
-				"@typescript-eslint/visitor-keys": "8.35.1",
+				"@typescript-eslint/scope-manager": "8.37.0",
+				"@typescript-eslint/type-utils": "8.37.0",
+				"@typescript-eslint/utils": "8.37.0",
+				"@typescript-eslint/visitor-keys": "8.37.0",
 				"graphemer": "^1.4.0",
 				"ignore": "^7.0.0",
 				"natural-compare": "^1.4.0",
@@ -4919,20 +5092,28 @@
 				"url": "https://opencollective.com/typescript-eslint"
 			},
 			"peerDependencies": {
-				"@typescript-eslint/parser": "^8.35.1",
+				"@typescript-eslint/parser": "^8.37.0",
 				"eslint": "^8.57.0 || ^9.0.0",
 				"typescript": ">=4.8.4 <5.9.0"
 			}
 		},
+		"node_modules/@typescript-eslint/eslint-plugin/node_modules/ignore": {
+			"version": "7.0.5",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4"
+			}
+		},
 		"node_modules/@typescript-eslint/parser": {
-			"version": "8.35.1",
+			"version": "8.37.0",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/scope-manager": "8.35.1",
-				"@typescript-eslint/types": "8.35.1",
-				"@typescript-eslint/typescript-estree": "8.35.1",
-				"@typescript-eslint/visitor-keys": "8.35.1",
+				"@typescript-eslint/scope-manager": "8.37.0",
+				"@typescript-eslint/types": "8.37.0",
+				"@typescript-eslint/typescript-estree": "8.37.0",
+				"@typescript-eslint/visitor-keys": "8.37.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -4948,12 +5129,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/project-service": {
-			"version": "8.35.1",
+			"version": "8.37.0",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/tsconfig-utils": "^8.35.1",
-				"@typescript-eslint/types": "^8.35.1",
+				"@typescript-eslint/tsconfig-utils": "^8.37.0",
+				"@typescript-eslint/types": "^8.37.0",
 				"debug": "^4.3.4"
 			},
 			"engines": {
@@ -4968,12 +5149,12 @@
 			}
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "8.35.1",
+			"version": "8.37.0",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.35.1",
-				"@typescript-eslint/visitor-keys": "8.35.1"
+				"@typescript-eslint/types": "8.37.0",
+				"@typescript-eslint/visitor-keys": "8.37.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -4984,7 +5165,7 @@
 			}
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
-			"version": "8.35.1",
+			"version": "8.37.0",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4999,12 +5180,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "8.35.1",
+			"version": "8.37.0",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "8.35.1",
-				"@typescript-eslint/utils": "8.35.1",
+				"@typescript-eslint/types": "8.37.0",
+				"@typescript-eslint/typescript-estree": "8.37.0",
+				"@typescript-eslint/utils": "8.37.0",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^2.1.0"
 			},
@@ -5021,7 +5203,7 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "8.35.1",
+			"version": "8.37.0",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -5033,14 +5215,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "8.35.1",
+			"version": "8.37.0",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/project-service": "8.35.1",
-				"@typescript-eslint/tsconfig-utils": "8.35.1",
-				"@typescript-eslint/types": "8.35.1",
-				"@typescript-eslint/visitor-keys": "8.35.1",
+				"@typescript-eslint/project-service": "8.37.0",
+				"@typescript-eslint/tsconfig-utils": "8.37.0",
+				"@typescript-eslint/types": "8.37.0",
+				"@typescript-eslint/visitor-keys": "8.37.0",
 				"debug": "^4.3.4",
 				"fast-glob": "^3.3.2",
 				"is-glob": "^4.0.3",
@@ -5074,14 +5256,14 @@
 			}
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "8.35.1",
+			"version": "8.37.0",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.7.0",
-				"@typescript-eslint/scope-manager": "8.35.1",
-				"@typescript-eslint/types": "8.35.1",
-				"@typescript-eslint/typescript-estree": "8.35.1"
+				"@typescript-eslint/scope-manager": "8.37.0",
+				"@typescript-eslint/types": "8.37.0",
+				"@typescript-eslint/typescript-estree": "8.37.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5096,11 +5278,11 @@
 			}
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "8.35.1",
+			"version": "8.37.0",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/types": "8.35.1",
+				"@typescript-eslint/types": "8.37.0",
 				"eslint-visitor-keys": "^4.2.1"
 			},
 			"engines": {
@@ -5109,17 +5291,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/typescript-eslint"
-			}
-		},
-		"node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
-			"version": "4.2.1",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
 			}
 		},
 		"node_modules/@tyriar/fibonacci-heap": {
@@ -5135,34 +5306,6 @@
 			},
 			"engines": {
 				"node": ">=6.5"
-			}
-		},
-		"node_modules/accepts": {
-			"version": "2.0.0",
-			"license": "MIT",
-			"dependencies": {
-				"mime-types": "^3.0.0",
-				"negotiator": "^1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/accepts/node_modules/mime-db": {
-			"version": "1.54.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
-		"node_modules/accepts/node_modules/mime-types": {
-			"version": "3.0.1",
-			"license": "MIT",
-			"dependencies": {
-				"mime-db": "^1.54.0"
-			},
-			"engines": {
-				"node": ">= 0.6"
 			}
 		},
 		"node_modules/acorn": {
@@ -5184,8 +5327,6 @@
 		},
 		"node_modules/acorn-jsx": {
 			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
-			"integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
 			"dev": true,
 			"license": "MIT",
 			"peerDependencies": {
@@ -5193,7 +5334,7 @@
 			}
 		},
 		"node_modules/agent-base": {
-			"version": "7.1.3",
+			"version": "7.1.4",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 14"
@@ -5222,17 +5363,6 @@
 			},
 			"engines": {
 				"node": ">=8"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
-			}
-		},
-		"node_modules/ansi-escapes/node_modules/type-fest": {
-			"version": "0.21.3",
-			"dev": true,
-			"license": "(MIT OR CC0-1.0)",
-			"engines": {
-				"node": ">=10"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -5689,7 +5819,7 @@
 			}
 		},
 		"node_modules/bignumber.js": {
-			"version": "9.3.0",
+			"version": "9.3.1",
 			"license": "MIT",
 			"engines": {
 				"node": "*"
@@ -5717,37 +5847,22 @@
 			}
 		},
 		"node_modules/body-parser": {
-			"version": "1.20.3",
+			"version": "2.2.0",
 			"license": "MIT",
 			"dependencies": {
-				"bytes": "3.1.2",
-				"content-type": "~1.0.5",
-				"debug": "2.6.9",
-				"depd": "2.0.0",
-				"destroy": "1.2.0",
-				"http-errors": "2.0.0",
-				"iconv-lite": "0.4.24",
-				"on-finished": "2.4.1",
-				"qs": "6.13.0",
-				"raw-body": "2.5.2",
-				"type-is": "~1.6.18",
-				"unpipe": "1.0.0"
+				"bytes": "^3.1.2",
+				"content-type": "^1.0.5",
+				"debug": "^4.4.0",
+				"http-errors": "^2.0.0",
+				"iconv-lite": "^0.6.3",
+				"on-finished": "^2.4.1",
+				"qs": "^6.14.0",
+				"raw-body": "^3.0.0",
+				"type-is": "^2.0.0"
 			},
 			"engines": {
-				"node": ">= 0.8",
-				"npm": "1.2.8000 || >= 1.4.16"
+				"node": ">=18"
 			}
-		},
-		"node_modules/body-parser/node_modules/debug": {
-			"version": "2.6.9",
-			"license": "MIT",
-			"dependencies": {
-				"ms": "2.0.0"
-			}
-		},
-		"node_modules/body-parser/node_modules/ms": {
-			"version": "2.0.0",
-			"license": "MIT"
 		},
 		"node_modules/bowser": {
 			"version": "2.11.0",
@@ -5960,7 +6075,7 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001726",
+			"version": "1.0.30001727",
 			"dev": true,
 			"funding": [
 				{
@@ -6036,9 +6151,12 @@
 			}
 		},
 		"node_modules/chownr": {
-			"version": "1.1.4",
+			"version": "2.0.0",
+			"dev": true,
 			"license": "ISC",
-			"optional": true
+			"engines": {
+				"node": ">=10"
+			}
 		},
 		"node_modules/ci-info": {
 			"version": "3.9.0",
@@ -6240,16 +6358,6 @@
 				"typedarray": "^0.0.6"
 			}
 		},
-		"node_modules/content-disposition": {
-			"version": "1.0.0",
-			"license": "MIT",
-			"dependencies": {
-				"safe-buffer": "5.2.1"
-			},
-			"engines": {
-				"node": ">= 0.6"
-			}
-		},
 		"node_modules/content-type": {
 			"version": "1.0.5",
 			"license": "MIT",
@@ -6289,7 +6397,7 @@
 			}
 		},
 		"node_modules/core-js": {
-			"version": "3.43.0",
+			"version": "3.44.0",
 			"dev": true,
 			"hasInstallScript": true,
 			"license": "MIT",
@@ -6361,6 +6469,22 @@
 			},
 			"bin": {
 				"create-jest": "bin/create-jest.js"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/create-jest/node_modules/jest-util": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"ci-info": "^3.2.0",
+				"graceful-fs": "^4.2.9",
+				"picomatch": "^2.2.3"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -6619,6 +6743,8 @@
 		},
 		"node_modules/depd": {
 			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
+			"integrity": "sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
@@ -6626,6 +6752,8 @@
 		},
 		"node_modules/destroy": {
 			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+			"integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8",
@@ -6693,6 +6821,17 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/doctrine": {
+			"version": "2.1.0",
+			"dev": true,
+			"license": "Apache-2.0",
+			"dependencies": {
+				"esutils": "^2.0.2"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/dompurify": {
 			"version": "3.2.6",
 			"dev": true,
@@ -6702,9 +6841,8 @@
 			}
 		},
 		"node_modules/dotenv": {
-			"version": "17.2.0",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.2.0.tgz",
-			"integrity": "sha512-Q4sgBT60gzd0BB0lSyYD3xM4YxrXA9y4uBDof1JNYGzOXrQdQ6yX+7XIAqoFOGQFOTK1D3Hts5OllpxMDZFONQ==",
+			"version": "16.4.7",
+			"dev": true,
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=12"
@@ -6754,7 +6892,7 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.5.178",
+			"version": "1.5.182",
 			"dev": true,
 			"license": "ISC"
 		},
@@ -7003,9 +7141,7 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "9.30.1",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-9.30.1.tgz",
-			"integrity": "sha512-zmxXPNMOXmwm9E0yQLi5uqXHs7uq2UIiqEKo3Gq+3fwo1XrJ+hijAZImyF7hclW3E6oHz43Yk3RP8at6OTKflQ==",
+			"version": "9.31.0",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7013,9 +7149,9 @@
 				"@eslint-community/regexpp": "^4.12.1",
 				"@eslint/config-array": "^0.21.0",
 				"@eslint/config-helpers": "^0.3.0",
-				"@eslint/core": "^0.14.0",
+				"@eslint/core": "^0.15.0",
 				"@eslint/eslintrc": "^3.3.1",
-				"@eslint/js": "9.30.1",
+				"@eslint/js": "9.31.0",
 				"@eslint/plugin-kit": "^0.3.1",
 				"@humanfs/node": "^0.16.6",
 				"@humanwhocodes/module-importer": "^1.0.1",
@@ -7168,17 +7304,6 @@
 				"ms": "^2.1.1"
 			}
 		},
-		"node_modules/eslint-plugin-import/node_modules/doctrine": {
-			"version": "2.1.0",
-			"dev": true,
-			"license": "Apache-2.0",
-			"dependencies": {
-				"esutils": "^2.0.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/eslint-plugin-import/node_modules/minimatch": {
 			"version": "3.1.2",
 			"dev": true,
@@ -7224,8 +7349,6 @@
 		},
 		"node_modules/eslint-scope": {
 			"version": "8.4.0",
-			"resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-8.4.0.tgz",
-			"integrity": "sha512-sNXOfKCn74rt8RICKMvJS7XKV/Xk9kA7DyJr8mJik3S7Cwgy3qlkkmyS2uQB3jiJg6VNdZd/pDBJu0nvG2NlTg==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
@@ -7240,11 +7363,11 @@
 			}
 		},
 		"node_modules/eslint-visitor-keys": {
-			"version": "3.4.3",
+			"version": "4.2.1",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
-				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
+				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
 			"funding": {
 				"url": "https://opencollective.com/eslint"
@@ -7274,19 +7397,6 @@
 				"concat-map": "0.0.1"
 			}
 		},
-		"node_modules/eslint/node_modules/eslint-visitor-keys": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-			"dev": true,
-			"license": "Apache-2.0",
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
 		"node_modules/eslint/node_modules/glob-parent": {
 			"version": "6.0.2",
 			"dev": true,
@@ -7296,14 +7406,6 @@
 			},
 			"engines": {
 				"node": ">=10.13.0"
-			}
-		},
-		"node_modules/eslint/node_modules/ignore": {
-			"version": "5.3.2",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4"
 			}
 		},
 		"node_modules/eslint/node_modules/json-schema-traverse": {
@@ -7337,8 +7439,6 @@
 		},
 		"node_modules/espree": {
 			"version": "10.4.0",
-			"resolved": "https://registry.npmjs.org/espree/-/espree-10.4.0.tgz",
-			"integrity": "sha512-j6PAQ2uUr79PZhBjP5C5fhl8e39FmRnOjsD5lGnWrFU8i2G776tBK7+nP8KuQUTTyAZUwfQqXAgrVH5MbH9CYQ==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
@@ -7346,19 +7446,6 @@
 				"acorn-jsx": "^5.3.2",
 				"eslint-visitor-keys": "^4.2.1"
 			},
-			"engines": {
-				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-			},
-			"funding": {
-				"url": "https://opencollective.com/eslint"
-			}
-		},
-		"node_modules/espree/node_modules/eslint-visitor-keys": {
-			"version": "4.2.1",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-4.2.1.tgz",
-			"integrity": "sha512-Uhdk5sfqcee/9H/rCOJikYz67o0a2Tw2hGRPOG2Y1R2dg7brRe1uG0yaNQDHu+TO/uQPF/5eCapvYSmHUjt7JQ==",
-			"dev": true,
-			"license": "Apache-2.0",
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
 			},
@@ -7391,8 +7478,6 @@
 		},
 		"node_modules/esrecurse": {
 			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.3.0.tgz",
-			"integrity": "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==",
 			"dev": true,
 			"license": "BSD-2-Clause",
 			"dependencies": {
@@ -7525,6 +7610,17 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/expand-brackets/node_modules/extend-shallow": {
+			"version": "2.0.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-extendable": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/expand-brackets/node_modules/is-descriptor": {
 			"version": "0.1.7",
 			"dev": true,
@@ -7537,25 +7633,18 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/expand-brackets/node_modules/is-extendable": {
+			"version": "0.1.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/expand-brackets/node_modules/ms": {
 			"version": "2.0.0",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/expect": {
-			"version": "29.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/expect-utils": "^29.7.0",
-				"jest-get-type": "^29.6.3",
-				"jest-matcher-utils": "^29.7.0",
-				"jest-message-util": "^29.7.0",
-				"jest-util": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
 		},
 		"node_modules/express": {
 			"version": "5.1.0",
@@ -7668,39 +7757,42 @@
 				"node": ">=4"
 			}
 		},
-		"node_modules/express/node_modules/body-parser": {
-			"version": "2.2.0",
+		"node_modules/express/node_modules/accepts": {
+			"version": "2.0.0",
 			"license": "MIT",
 			"dependencies": {
-				"bytes": "^3.1.2",
-				"content-type": "^1.0.5",
-				"debug": "^4.4.0",
-				"http-errors": "^2.0.0",
-				"iconv-lite": "^0.6.3",
-				"on-finished": "^2.4.1",
-				"qs": "^6.14.0",
-				"raw-body": "^3.0.0",
-				"type-is": "^2.0.0"
+				"mime-types": "^3.0.0",
+				"negotiator": "^1.0.0"
 			},
 			"engines": {
-				"node": ">=18"
+				"node": ">= 0.6"
 			}
 		},
-		"node_modules/express/node_modules/iconv-lite": {
-			"version": "0.6.3",
+		"node_modules/express/node_modules/content-disposition": {
+			"version": "1.0.0",
 			"license": "MIT",
 			"dependencies": {
-				"safer-buffer": ">= 2.1.2 < 3.0.0"
+				"safe-buffer": "5.2.1"
 			},
 			"engines": {
-				"node": ">=0.10.0"
+				"node": ">= 0.6"
 			}
 		},
-		"node_modules/express/node_modules/media-typer": {
-			"version": "1.1.0",
+		"node_modules/express/node_modules/fresh": {
+			"version": "2.0.0",
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.8"
+			}
+		},
+		"node_modules/express/node_modules/merge-descriptors": {
+			"version": "2.0.0",
+			"license": "MIT",
+			"engines": {
+				"node": ">=18"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/express/node_modules/mime-db": {
@@ -7720,40 +7812,9 @@
 				"node": ">= 0.6"
 			}
 		},
-		"node_modules/express/node_modules/qs": {
-			"version": "6.14.0",
-			"license": "BSD-3-Clause",
-			"dependencies": {
-				"side-channel": "^1.1.0"
-			},
-			"engines": {
-				"node": ">=0.6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/ljharb"
-			}
-		},
-		"node_modules/express/node_modules/raw-body": {
-			"version": "3.0.0",
+		"node_modules/express/node_modules/negotiator": {
+			"version": "1.0.0",
 			"license": "MIT",
-			"dependencies": {
-				"bytes": "3.1.2",
-				"http-errors": "2.0.0",
-				"iconv-lite": "0.6.3",
-				"unpipe": "1.0.0"
-			},
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
-		"node_modules/express/node_modules/type-is": {
-			"version": "2.0.1",
-			"license": "MIT",
-			"dependencies": {
-				"content-type": "^1.0.5",
-				"media-typer": "^1.1.0",
-				"mime-types": "^3.0.0"
-			},
 			"engines": {
 				"node": ">= 0.6"
 			}
@@ -7770,10 +7831,12 @@
 			"license": "MIT"
 		},
 		"node_modules/extend-shallow": {
-			"version": "2.0.1",
+			"version": "3.0.2",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"is-extendable": "^0.1.0"
+				"assign-symbols": "^1.0.0",
+				"is-extendable": "^1.0.1"
 			},
 			"engines": {
 				"node": ">=0.10.0"
@@ -7804,6 +7867,25 @@
 			"dependencies": {
 				"is-descriptor": "^1.0.0"
 			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/extglob/node_modules/extend-shallow": {
+			"version": "2.0.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-extendable": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/extglob/node_modules/is-extendable": {
+			"version": "0.1.1",
+			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -7856,20 +7938,17 @@
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/fast-xml-parser": {
-			"version": "4.4.1",
+			"version": "4.5.3",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
 					"url": "https://github.com/sponsors/NaturalIntelligence"
-				},
-				{
-					"type": "paypal",
-					"url": "https://paypal.me/naturalintelligence"
 				}
 			],
 			"license": "MIT",
 			"dependencies": {
-				"strnum": "^1.0.5"
+				"strnum": "^1.1.1"
 			},
 			"bin": {
 				"fxparser": "src/cli/cli.js"
@@ -7897,8 +7976,6 @@
 		},
 		"node_modules/file-entry-cache": {
 			"version": "8.0.0",
-			"resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-8.0.0.tgz",
-			"integrity": "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -7963,8 +8040,6 @@
 		},
 		"node_modules/flat-cache": {
 			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-4.0.1.tgz",
-			"integrity": "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8097,13 +8172,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/fresh": {
-			"version": "2.0.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.8"
-			}
-		},
 		"node_modules/from": {
 			"version": "0.1.7",
 			"dev": true,
@@ -8115,15 +8183,16 @@
 			"optional": true
 		},
 		"node_modules/fs-extra": {
-			"version": "8.1.0",
+			"version": "11.3.0",
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"graceful-fs": "^4.2.0",
-				"jsonfile": "^4.0.0",
-				"universalify": "^0.1.0"
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
 			},
 			"engines": {
-				"node": ">=6 <7 || >=8"
+				"node": ">=14.14"
 			}
 		},
 		"node_modules/fs-minipass": {
@@ -8244,7 +8313,7 @@
 			}
 		},
 		"node_modules/get-port-please": {
-			"version": "3.1.2",
+			"version": "3.2.0",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -8348,8 +8417,6 @@
 		},
 		"node_modules/globals": {
 			"version": "14.0.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-14.0.0.tgz",
-			"integrity": "sha512-oahGvuMGQlPw/ivIYBjVSrWAfWLBeku5tpPE2fOPLi+WHffIWbuh2tCjhyQhTBPMf5E9jDEH4FOmTYgYwbKwtQ==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -8420,6 +8487,17 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/globby/node_modules/braces/node_modules/extend-shallow": {
+			"version": "2.0.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-extendable": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/globby/node_modules/fast-glob": {
 			"version": "2.2.7",
 			"dev": true,
@@ -8445,6 +8523,17 @@
 				"is-number": "^3.0.0",
 				"repeat-string": "^1.6.1",
 				"to-regex-range": "^2.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/globby/node_modules/fill-range/node_modules/extend-shallow": {
+			"version": "2.0.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-extendable": "^0.1.0"
 			},
 			"engines": {
 				"node": ">=0.10.0"
@@ -8479,12 +8568,9 @@
 			}
 		},
 		"node_modules/globby/node_modules/is-extendable": {
-			"version": "1.0.1",
+			"version": "0.1.1",
 			"dev": true,
 			"license": "MIT",
-			"dependencies": {
-				"is-plain-object": "^2.0.4"
-			},
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -8529,18 +8615,6 @@
 				"regex-not": "^1.0.0",
 				"snapdragon": "^0.8.1",
 				"to-regex": "^3.0.2"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/globby/node_modules/micromatch/node_modules/extend-shallow": {
-			"version": "3.0.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"assign-symbols": "^1.0.0",
-				"is-extendable": "^1.0.1"
 			},
 			"engines": {
 				"node": ">=0.10.0"
@@ -8878,10 +8952,10 @@
 			}
 		},
 		"node_modules/iconv-lite": {
-			"version": "0.4.24",
+			"version": "0.6.3",
 			"license": "MIT",
 			"dependencies": {
-				"safer-buffer": ">= 2.1.2 < 3"
+				"safer-buffer": ">= 2.1.2 < 3.0.0"
 			},
 			"engines": {
 				"node": ">=0.10.0"
@@ -8907,7 +8981,7 @@
 			"optional": true
 		},
 		"node_modules/ignore": {
-			"version": "7.0.5",
+			"version": "5.3.2",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -9185,8 +9259,12 @@
 			}
 		},
 		"node_modules/is-extendable": {
-			"version": "0.1.1",
+			"version": "1.0.1",
+			"dev": true,
 			"license": "MIT",
+			"dependencies": {
+				"is-plain-object": "^2.0.4"
+			},
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -9690,6 +9768,22 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
+		"node_modules/jest-changed-files/node_modules/jest-util": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"ci-info": "^3.2.0",
+				"graceful-fs": "^4.2.9",
+				"picomatch": "^2.2.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
 		"node_modules/jest-circus": {
 			"version": "29.7.0",
 			"dev": true,
@@ -9715,6 +9809,160 @@
 				"pure-rand": "^6.0.0",
 				"slash": "^3.0.0",
 				"stack-utils": "^2.0.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-circus/node_modules/@jest/environment": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/fake-timers": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"jest-mock": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-circus/node_modules/@jest/expect": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"expect": "^29.7.0",
+				"jest-snapshot": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-circus/node_modules/@jest/expect-utils": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"jest-get-type": "^29.6.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-circus/node_modules/@jest/fake-timers": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@sinonjs/fake-timers": "^10.0.2",
+				"@types/node": "*",
+				"jest-message-util": "^29.7.0",
+				"jest-mock": "^29.7.0",
+				"jest-util": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-circus/node_modules/@sinonjs/fake-timers": {
+			"version": "10.3.0",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@sinonjs/commons": "^3.0.0"
+			}
+		},
+		"node_modules/jest-circus/node_modules/expect": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/expect-utils": "^29.7.0",
+				"jest-get-type": "^29.6.3",
+				"jest-matcher-utils": "^29.7.0",
+				"jest-message-util": "^29.7.0",
+				"jest-util": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-circus/node_modules/jest-message-util": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.12.13",
+				"@jest/types": "^29.6.3",
+				"@types/stack-utils": "^2.0.0",
+				"chalk": "^4.0.0",
+				"graceful-fs": "^4.2.9",
+				"micromatch": "^4.0.4",
+				"pretty-format": "^29.7.0",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-circus/node_modules/jest-mock": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"jest-util": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-circus/node_modules/jest-snapshot": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/core": "^7.11.6",
+				"@babel/generator": "^7.7.2",
+				"@babel/plugin-syntax-jsx": "^7.7.2",
+				"@babel/plugin-syntax-typescript": "^7.7.2",
+				"@babel/types": "^7.3.3",
+				"@jest/expect-utils": "^29.7.0",
+				"@jest/transform": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"babel-preset-current-node-syntax": "^1.0.0",
+				"chalk": "^4.0.0",
+				"expect": "^29.7.0",
+				"graceful-fs": "^4.2.9",
+				"jest-diff": "^29.7.0",
+				"jest-get-type": "^29.6.3",
+				"jest-matcher-utils": "^29.7.0",
+				"jest-message-util": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"natural-compare": "^1.4.0",
+				"pretty-format": "^29.7.0",
+				"semver": "^7.5.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-circus/node_modules/jest-util": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"ci-info": "^3.2.0",
+				"graceful-fs": "^4.2.9",
+				"picomatch": "^2.2.3"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -9763,6 +10011,22 @@
 			},
 			"engines": {
 				"node": ">=12"
+			}
+		},
+		"node_modules/jest-cli/node_modules/jest-util": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"ci-info": "^3.2.0",
+				"graceful-fs": "^4.2.9",
+				"picomatch": "^2.2.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
 		"node_modules/jest-cli/node_modules/yargs": {
@@ -9826,6 +10090,30 @@
 				}
 			}
 		},
+		"node_modules/jest-config/node_modules/jest-regex-util": {
+			"version": "29.6.3",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-config/node_modules/jest-util": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"ci-info": "^3.2.0",
+				"graceful-fs": "^4.2.9",
+				"picomatch": "^2.2.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
 		"node_modules/jest-diff": {
 			"version": "29.7.0",
 			"dev": true,
@@ -9866,6 +10154,22 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
+		"node_modules/jest-each/node_modules/jest-util": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"ci-info": "^3.2.0",
+				"graceful-fs": "^4.2.9",
+				"picomatch": "^2.2.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
 		"node_modules/jest-environment-node": {
 			"version": "29.7.0",
 			"dev": true,
@@ -9877,6 +10181,92 @@
 				"@types/node": "*",
 				"jest-mock": "^29.7.0",
 				"jest-util": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-environment-node/node_modules/@jest/environment": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/fake-timers": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"jest-mock": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-environment-node/node_modules/@jest/fake-timers": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@sinonjs/fake-timers": "^10.0.2",
+				"@types/node": "*",
+				"jest-message-util": "^29.7.0",
+				"jest-mock": "^29.7.0",
+				"jest-util": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-environment-node/node_modules/@sinonjs/fake-timers": {
+			"version": "10.3.0",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@sinonjs/commons": "^3.0.0"
+			}
+		},
+		"node_modules/jest-environment-node/node_modules/jest-message-util": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.12.13",
+				"@jest/types": "^29.6.3",
+				"@types/stack-utils": "^2.0.0",
+				"chalk": "^4.0.0",
+				"graceful-fs": "^4.2.9",
+				"micromatch": "^4.0.4",
+				"pretty-format": "^29.7.0",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-environment-node/node_modules/jest-mock": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"jest-util": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-environment-node/node_modules/jest-util": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"ci-info": "^3.2.0",
+				"graceful-fs": "^4.2.9",
+				"picomatch": "^2.2.3"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -9914,6 +10304,30 @@
 				"fsevents": "^2.3.2"
 			}
 		},
+		"node_modules/jest-haste-map/node_modules/jest-regex-util": {
+			"version": "29.6.3",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-haste-map/node_modules/jest-util": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"ci-info": "^3.2.0",
+				"graceful-fs": "^4.2.9",
+				"picomatch": "^2.2.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
 		"node_modules/jest-leak-detector": {
 			"version": "29.7.0",
 			"dev": true,
@@ -9940,38 +10354,6 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
-		"node_modules/jest-message-util": {
-			"version": "29.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@babel/code-frame": "^7.12.13",
-				"@jest/types": "^29.6.3",
-				"@types/stack-utils": "^2.0.0",
-				"chalk": "^4.0.0",
-				"graceful-fs": "^4.2.9",
-				"micromatch": "^4.0.4",
-				"pretty-format": "^29.7.0",
-				"slash": "^3.0.0",
-				"stack-utils": "^2.0.3"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
-		"node_modules/jest-mock": {
-			"version": "29.7.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"@jest/types": "^29.6.3",
-				"@types/node": "*",
-				"jest-util": "^29.7.0"
-			},
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
-			}
-		},
 		"node_modules/jest-pnp-resolver": {
 			"version": "1.2.3",
 			"dev": true,
@@ -9986,14 +10368,6 @@
 				"jest-resolve": {
 					"optional": true
 				}
-			}
-		},
-		"node_modules/jest-regex-util": {
-			"version": "29.6.3",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
 		"node_modules/jest-resolve": {
@@ -10027,6 +10401,121 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
+		"node_modules/jest-resolve-dependencies/node_modules/@jest/expect-utils": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"jest-get-type": "^29.6.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-resolve-dependencies/node_modules/expect": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/expect-utils": "^29.7.0",
+				"jest-get-type": "^29.6.3",
+				"jest-matcher-utils": "^29.7.0",
+				"jest-message-util": "^29.7.0",
+				"jest-util": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-resolve-dependencies/node_modules/jest-message-util": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.12.13",
+				"@jest/types": "^29.6.3",
+				"@types/stack-utils": "^2.0.0",
+				"chalk": "^4.0.0",
+				"graceful-fs": "^4.2.9",
+				"micromatch": "^4.0.4",
+				"pretty-format": "^29.7.0",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-resolve-dependencies/node_modules/jest-regex-util": {
+			"version": "29.6.3",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-resolve-dependencies/node_modules/jest-snapshot": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/core": "^7.11.6",
+				"@babel/generator": "^7.7.2",
+				"@babel/plugin-syntax-jsx": "^7.7.2",
+				"@babel/plugin-syntax-typescript": "^7.7.2",
+				"@babel/types": "^7.3.3",
+				"@jest/expect-utils": "^29.7.0",
+				"@jest/transform": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"babel-preset-current-node-syntax": "^1.0.0",
+				"chalk": "^4.0.0",
+				"expect": "^29.7.0",
+				"graceful-fs": "^4.2.9",
+				"jest-diff": "^29.7.0",
+				"jest-get-type": "^29.6.3",
+				"jest-matcher-utils": "^29.7.0",
+				"jest-message-util": "^29.7.0",
+				"jest-util": "^29.7.0",
+				"natural-compare": "^1.4.0",
+				"pretty-format": "^29.7.0",
+				"semver": "^7.5.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-resolve-dependencies/node_modules/jest-util": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"ci-info": "^3.2.0",
+				"graceful-fs": "^4.2.9",
+				"picomatch": "^2.2.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-resolve/node_modules/jest-util": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"ci-info": "^3.2.0",
+				"graceful-fs": "^4.2.9",
+				"picomatch": "^2.2.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
 		"node_modules/jest-runner": {
 			"version": "29.7.0",
 			"dev": true,
@@ -10053,6 +10542,92 @@
 				"jest-worker": "^29.7.0",
 				"p-limit": "^3.1.0",
 				"source-map-support": "0.5.13"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-runner/node_modules/@jest/environment": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/fake-timers": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"jest-mock": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-runner/node_modules/@jest/fake-timers": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@sinonjs/fake-timers": "^10.0.2",
+				"@types/node": "*",
+				"jest-message-util": "^29.7.0",
+				"jest-mock": "^29.7.0",
+				"jest-util": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-runner/node_modules/@sinonjs/fake-timers": {
+			"version": "10.3.0",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@sinonjs/commons": "^3.0.0"
+			}
+		},
+		"node_modules/jest-runner/node_modules/jest-message-util": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.12.13",
+				"@jest/types": "^29.6.3",
+				"@types/stack-utils": "^2.0.0",
+				"chalk": "^4.0.0",
+				"graceful-fs": "^4.2.9",
+				"micromatch": "^4.0.4",
+				"pretty-format": "^29.7.0",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-runner/node_modules/jest-mock": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"jest-util": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-runner/node_modules/jest-util": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"ci-info": "^3.2.0",
+				"graceful-fs": "^4.2.9",
+				"picomatch": "^2.2.3"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -10090,7 +10665,137 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
-		"node_modules/jest-snapshot": {
+		"node_modules/jest-runtime/node_modules/@jest/environment": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/fake-timers": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"jest-mock": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-runtime/node_modules/@jest/expect": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"expect": "^29.7.0",
+				"jest-snapshot": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-runtime/node_modules/@jest/expect-utils": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"jest-get-type": "^29.6.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-runtime/node_modules/@jest/fake-timers": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@sinonjs/fake-timers": "^10.0.2",
+				"@types/node": "*",
+				"jest-message-util": "^29.7.0",
+				"jest-mock": "^29.7.0",
+				"jest-util": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-runtime/node_modules/@jest/globals": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/environment": "^29.7.0",
+				"@jest/expect": "^29.7.0",
+				"@jest/types": "^29.6.3",
+				"jest-mock": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-runtime/node_modules/@sinonjs/fake-timers": {
+			"version": "10.3.0",
+			"dev": true,
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"@sinonjs/commons": "^3.0.0"
+			}
+		},
+		"node_modules/jest-runtime/node_modules/expect": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/expect-utils": "^29.7.0",
+				"jest-get-type": "^29.6.3",
+				"jest-matcher-utils": "^29.7.0",
+				"jest-message-util": "^29.7.0",
+				"jest-util": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-runtime/node_modules/jest-message-util": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@babel/code-frame": "^7.12.13",
+				"@jest/types": "^29.6.3",
+				"@types/stack-utils": "^2.0.0",
+				"chalk": "^4.0.0",
+				"graceful-fs": "^4.2.9",
+				"micromatch": "^4.0.4",
+				"pretty-format": "^29.7.0",
+				"slash": "^3.0.0",
+				"stack-utils": "^2.0.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-runtime/node_modules/jest-mock": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"jest-util": "^29.7.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-runtime/node_modules/jest-regex-util": {
+			"version": "29.6.3",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-runtime/node_modules/jest-snapshot": {
 			"version": "29.7.0",
 			"dev": true,
 			"license": "MIT",
@@ -10120,7 +10825,7 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
-		"node_modules/jest-util": {
+		"node_modules/jest-runtime/node_modules/jest-util": {
 			"version": "29.7.0",
 			"dev": true,
 			"license": "MIT",
@@ -10181,6 +10886,22 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
+		"node_modules/jest-watcher/node_modules/jest-util": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"ci-info": "^3.2.0",
+				"graceful-fs": "^4.2.9",
+				"picomatch": "^2.2.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
 		"node_modules/jest-when": {
 			"version": "3.7.0",
 			"dev": true,
@@ -10198,6 +10919,22 @@
 				"jest-util": "^29.7.0",
 				"merge-stream": "^2.0.0",
 				"supports-color": "^8.0.0"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/jest-worker/node_modules/jest-util": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"ci-info": "^3.2.0",
+				"graceful-fs": "^4.2.9",
+				"picomatch": "^2.2.3"
 			},
 			"engines": {
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
@@ -10279,8 +11016,6 @@
 		},
 		"node_modules/json-buffer": {
 			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
-			"integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -10322,8 +11057,12 @@
 			}
 		},
 		"node_modules/jsonfile": {
-			"version": "4.0.0",
+			"version": "6.1.0",
+			"dev": true,
 			"license": "MIT",
+			"dependencies": {
+				"universalify": "^2.0.0"
+			},
 			"optionalDependencies": {
 				"graceful-fs": "^4.1.6"
 			}
@@ -10362,8 +11101,6 @@
 		},
 		"node_modules/keyv": {
 			"version": "4.5.4",
-			"resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
-			"integrity": "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -10592,10 +11329,10 @@
 			}
 		},
 		"node_modules/media-typer": {
-			"version": "0.3.0",
+			"version": "1.1.0",
 			"license": "MIT",
 			"engines": {
-				"node": ">= 0.6"
+				"node": ">= 0.8"
 			}
 		},
 		"node_modules/memoizee": {
@@ -10613,16 +11350,6 @@
 			},
 			"engines": {
 				"node": ">=0.12"
-			}
-		},
-		"node_modules/merge-descriptors": {
-			"version": "2.0.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">=18"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/merge-stream": {
@@ -10763,17 +11490,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/mixin-deep/node_modules/is-extendable": {
-			"version": "1.0.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-plain-object": "^2.0.4"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/mixpanel": {
 			"version": "0.18.1",
 			"license": "MIT",
@@ -10887,7 +11603,7 @@
 			"license": "MIT"
 		},
 		"node_modules/nan": {
-			"version": "2.22.2",
+			"version": "2.23.0",
 			"license": "MIT",
 			"optional": true
 		},
@@ -10929,40 +11645,10 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/nanomatch/node_modules/extend-shallow": {
-			"version": "3.0.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"assign-symbols": "^1.0.0",
-				"is-extendable": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/nanomatch/node_modules/is-extendable": {
-			"version": "1.0.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-plain-object": "^2.0.4"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/natural-compare": {
 			"version": "1.4.0",
 			"dev": true,
 			"license": "MIT"
-		},
-		"node_modules/negotiator": {
-			"version": "1.0.0",
-			"license": "MIT",
-			"engines": {
-				"node": ">= 0.6"
-			}
 		},
 		"node_modules/neo-async": {
 			"version": "2.6.2",
@@ -10971,8 +11657,6 @@
 		},
 		"node_modules/newrelic": {
 			"version": "12.25.0",
-			"resolved": "https://registry.npmjs.org/newrelic/-/newrelic-12.25.0.tgz",
-			"integrity": "sha512-WqYv7EvOcOQhvnMbPvjhZzcihO36qj2iNOO6jTfaixku+f558KFawXdNjw3Gl3kL1ycrTfO7N0ywrIZ1ggKGbA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@grpc/grpc-js": "^1.13.2",
@@ -11066,7 +11750,7 @@
 			}
 		},
 		"node_modules/newrelic/node_modules/@opentelemetry/semantic-conventions": {
-			"version": "1.34.0",
+			"version": "1.36.0",
 			"license": "Apache-2.0",
 			"engines": {
 				"node": ">=14"
@@ -11468,23 +12152,6 @@
 				"@types/json-schema": "^7.0.7",
 				"fast-xml-parser": "^4.5.0",
 				"json-pointer": "0.6.2"
-			}
-		},
-		"node_modules/openapi-sampler/node_modules/fast-xml-parser": {
-			"version": "4.5.3",
-			"dev": true,
-			"funding": [
-				{
-					"type": "github",
-					"url": "https://github.com/sponsors/NaturalIntelligence"
-				}
-			],
-			"license": "MIT",
-			"dependencies": {
-				"strnum": "^1.1.1"
-			},
-			"bin": {
-				"fxparser": "src/cli/cli.js"
 			}
 		},
 		"node_modules/optionator": {
@@ -12049,6 +12716,22 @@
 				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
 			}
 		},
+		"node_modules/pretty-format/node_modules/@jest/schemas": {
+			"version": "29.6.3",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@sinclair/typebox": "^0.27.8"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
+		"node_modules/pretty-format/node_modules/@sinclair/typebox": {
+			"version": "0.27.8",
+			"dev": true,
+			"license": "MIT"
+		},
 		"node_modules/pretty-format/node_modules/ansi-styles": {
 			"version": "5.2.0",
 			"dev": true,
@@ -12137,7 +12820,7 @@
 			}
 		},
 		"node_modules/protobufjs/node_modules/@types/node": {
-			"version": "24.0.10",
+			"version": "24.0.13",
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~7.8.0"
@@ -12205,10 +12888,10 @@
 			"license": "MIT"
 		},
 		"node_modules/qs": {
-			"version": "6.13.0",
+			"version": "6.14.0",
 			"license": "BSD-3-Clause",
 			"dependencies": {
-				"side-channel": "^1.0.6"
+				"side-channel": "^1.1.0"
 			},
 			"engines": {
 				"node": ">=0.6"
@@ -12252,12 +12935,12 @@
 			}
 		},
 		"node_modules/raw-body": {
-			"version": "2.5.2",
+			"version": "3.0.0",
 			"license": "MIT",
 			"dependencies": {
 				"bytes": "3.1.2",
 				"http-errors": "2.0.0",
-				"iconv-lite": "0.4.24",
+				"iconv-lite": "0.6.3",
 				"unpipe": "1.0.0"
 			},
 			"engines": {
@@ -12403,29 +13086,6 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/regex-not/node_modules/extend-shallow": {
-			"version": "3.0.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"assign-symbols": "^1.0.0",
-				"is-extendable": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/regex-not/node_modules/is-extendable": {
-			"version": "1.0.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-plain-object": "^2.0.4"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/regexp.prototype.flags": {
 			"version": "1.5.4",
 			"dev": true,
@@ -12474,8 +13134,7 @@
 		},
 		"node_modules/require-env-variable": {
 			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/require-env-variable/-/require-env-variable-4.0.2.tgz",
-			"integrity": "sha512-gdVmg7tVno0u5MokVSVeuRDSez1XyktsGaNCJfdEqrU40OUXw1oG7MWVPr8PLC7UJul6L98hjULh1e2pmGwdPg=="
+			"license": "MIT"
 		},
 		"node_modules/require-from-string": {
 			"version": "2.0.2",
@@ -12574,6 +13233,61 @@
 		"node_modules/rfdc": {
 			"version": "1.4.1",
 			"license": "MIT"
+		},
+		"node_modules/rimraf": {
+			"version": "5.0.10",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"glob": "^10.3.7"
+			},
+			"bin": {
+				"rimraf": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/rimraf/node_modules/glob": {
+			"version": "10.4.5",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"foreground-child": "^3.1.0",
+				"jackspeak": "^3.1.2",
+				"minimatch": "^9.0.4",
+				"minipass": "^7.1.2",
+				"package-json-from-dist": "^1.0.0",
+				"path-scurry": "^1.11.1"
+			},
+			"bin": {
+				"glob": "dist/esm/bin.mjs"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/rimraf/node_modules/minimatch": {
+			"version": "9.0.5",
+			"dev": true,
+			"license": "ISC",
+			"dependencies": {
+				"brace-expansion": "^2.0.1"
+			},
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/isaacs"
+			}
+		},
+		"node_modules/rimraf/node_modules/minipass": {
+			"version": "7.1.2",
+			"dev": true,
+			"license": "ISC",
+			"engines": {
+				"node": ">=16 || 14 >=14.17"
+			}
 		},
 		"node_modules/ringbufferjs": {
 			"version": "2.0.0",
@@ -12751,6 +13465,13 @@
 				"node": ">= 18"
 			}
 		},
+		"node_modules/send/node_modules/fresh": {
+			"version": "2.0.0",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
 		"node_modules/send/node_modules/mime-db": {
 			"version": "1.54.0",
 			"license": "MIT",
@@ -12839,6 +13560,25 @@
 				"is-plain-object": "^2.0.3",
 				"split-string": "^3.0.1"
 			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/set-value/node_modules/extend-shallow": {
+			"version": "2.0.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-extendable": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/set-value/node_modules/is-extendable": {
+			"version": "0.1.1",
+			"dev": true,
+			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
 			}
@@ -13029,26 +13769,6 @@
 				"ws": "^7.4.2"
 			}
 		},
-		"node_modules/simple-websocket/node_modules/ws": {
-			"version": "7.5.10",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">=8.3.0"
-			},
-			"peerDependencies": {
-				"bufferutil": "^4.0.1",
-				"utf-8-validate": "^5.0.2"
-			},
-			"peerDependenciesMeta": {
-				"bufferutil": {
-					"optional": true
-				},
-				"utf-8-validate": {
-					"optional": true
-				}
-			}
-		},
 		"node_modules/sisteransi": {
 			"version": "1.0.5",
 			"dev": true,
@@ -13153,6 +13873,17 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/snapdragon/node_modules/extend-shallow": {
+			"version": "2.0.1",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"is-extendable": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/snapdragon/node_modules/is-descriptor": {
 			"version": "0.1.7",
 			"dev": true,
@@ -13163,6 +13894,14 @@
 			},
 			"engines": {
 				"node": ">= 0.4"
+			}
+		},
+		"node_modules/snapdragon/node_modules/is-extendable": {
+			"version": "0.1.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/snapdragon/node_modules/ms": {
@@ -13237,29 +13976,6 @@
 			"license": "MIT",
 			"dependencies": {
 				"extend-shallow": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/split-string/node_modules/extend-shallow": {
-			"version": "3.0.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"assign-symbols": "^1.0.0",
-				"is-extendable": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/split-string/node_modules/is-extendable": {
-			"version": "1.0.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-plain-object": "^2.0.4"
 			},
 			"engines": {
 				"node": ">=0.10.0"
@@ -13379,6 +14095,32 @@
 			},
 			"engines": {
 				"node": ">=8.0"
+			}
+		},
+		"node_modules/streamroller/node_modules/fs-extra": {
+			"version": "8.1.0",
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^4.0.0",
+				"universalify": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=6 <7 || >=8"
+			}
+		},
+		"node_modules/streamroller/node_modules/jsonfile": {
+			"version": "4.0.0",
+			"license": "MIT",
+			"optionalDependencies": {
+				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/streamroller/node_modules/universalify": {
+			"version": "0.1.2",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 4.0.0"
 			}
 		},
 		"node_modules/strict-event-emitter": {
@@ -13546,6 +14288,7 @@
 		},
 		"node_modules/strnum": {
 			"version": "1.1.2",
+			"dev": true,
 			"funding": [
 				{
 					"type": "github",
@@ -13580,11 +14323,6 @@
 				"react": ">= 16.8.0",
 				"react-dom": ">= 16.8.0"
 			}
-		},
-		"node_modules/styled-components/node_modules/tslib": {
-			"version": "2.6.2",
-			"dev": true,
-			"license": "0BSD"
 		},
 		"node_modules/stylis": {
 			"version": "4.3.2",
@@ -13664,12 +14402,12 @@
 			"license": "MIT"
 		},
 		"node_modules/supertest": {
-			"version": "7.1.1",
+			"version": "7.1.3",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"methods": "^1.1.2",
-				"superagent": "^10.2.1"
+				"superagent": "^10.2.2"
 			},
 			"engines": {
 				"node": ">=14.18.0"
@@ -13703,7 +14441,7 @@
 			}
 		},
 		"node_modules/supertest/node_modules/superagent": {
-			"version": "10.2.1",
+			"version": "10.2.2",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -13814,6 +14552,11 @@
 				"tar-stream": "^2.1.4"
 			}
 		},
+		"node_modules/tar-fs/node_modules/chownr": {
+			"version": "1.1.4",
+			"license": "ISC",
+			"optional": true
+		},
 		"node_modules/tar-stream": {
 			"version": "2.2.0",
 			"license": "MIT",
@@ -13827,14 +14570,6 @@
 			},
 			"engines": {
 				"node": ">=6"
-			}
-		},
-		"node_modules/tar/node_modules/chownr": {
-			"version": "2.0.0",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=10"
 			}
 		},
 		"node_modules/tar/node_modules/yallist": {
@@ -14062,29 +14797,6 @@
 				"node": ">=8.0"
 			}
 		},
-		"node_modules/to-regex/node_modules/extend-shallow": {
-			"version": "3.0.2",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"assign-symbols": "^1.0.0",
-				"is-extendable": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/to-regex/node_modules/is-extendable": {
-			"version": "1.0.1",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"is-plain-object": "^2.0.4"
-			},
-			"engines": {
-				"node": ">=0.10.0"
-			}
-		},
 		"node_modules/toidentifier": {
 			"version": "1.0.1",
 			"license": "MIT",
@@ -14162,6 +14874,22 @@
 				}
 			}
 		},
+		"node_modules/ts-jest/node_modules/jest-util": {
+			"version": "29.7.0",
+			"dev": true,
+			"license": "MIT",
+			"dependencies": {
+				"@jest/types": "^29.6.3",
+				"@types/node": "*",
+				"chalk": "^4.0.0",
+				"ci-info": "^3.2.0",
+				"graceful-fs": "^4.2.9",
+				"picomatch": "^2.2.3"
+			},
+			"engines": {
+				"node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+			}
+		},
 		"node_modules/ts-jest/node_modules/type-fest": {
 			"version": "4.41.0",
 			"dev": true,
@@ -14173,11 +14901,17 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
+		"node_modules/ts-md5": {
+			"version": "1.3.1",
+			"license": "MIT",
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/tsc-watch": {
 			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/tsc-watch/-/tsc-watch-7.1.1.tgz",
-			"integrity": "sha512-r6t37Dkk4vK44HwxOe+OzjpE/gDamZAwqXhtcAJD/hPVblcjJK45NxbK0HcDASXG0U4pEnCh640JZbeDVSC6yA==",
 			"dev": true,
+			"license": "MIT",
 			"dependencies": {
 				"cross-spawn": "^7.0.6",
 				"node-cleanup": "^2.1.2",
@@ -14225,7 +14959,7 @@
 			}
 		},
 		"node_modules/tslib": {
-			"version": "2.8.1",
+			"version": "2.6.2",
 			"license": "0BSD"
 		},
 		"node_modules/tslint-tinypg": {
@@ -14261,12 +14995,41 @@
 				"node": ">=4"
 			}
 		},
+		"node_modules/type-fest": {
+			"version": "0.21.3",
+			"dev": true,
+			"license": "(MIT OR CC0-1.0)",
+			"engines": {
+				"node": ">=10"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/type-is": {
-			"version": "1.6.18",
+			"version": "2.0.1",
 			"license": "MIT",
 			"dependencies": {
-				"media-typer": "0.3.0",
-				"mime-types": "~2.1.24"
+				"content-type": "^1.0.5",
+				"media-typer": "^1.1.0",
+				"mime-types": "^3.0.0"
+			},
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/type-is/node_modules/mime-db": {
+			"version": "1.54.0",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"node_modules/type-is/node_modules/mime-types": {
+			"version": "3.0.1",
+			"license": "MIT",
+			"dependencies": {
+				"mime-db": "^1.54.0"
 			},
 			"engines": {
 				"node": ">= 0.6"
@@ -14398,38 +15161,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/typescript-cp/node_modules/fs-extra": {
-			"version": "11.3.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"graceful-fs": "^4.2.0",
-				"jsonfile": "^6.0.1",
-				"universalify": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=14.14"
-			}
-		},
-		"node_modules/typescript-cp/node_modules/glob": {
-			"version": "10.4.5",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"foreground-child": "^3.1.0",
-				"jackspeak": "^3.1.2",
-				"minimatch": "^9.0.4",
-				"minipass": "^7.1.2",
-				"package-json-from-dist": "^1.0.0",
-				"path-scurry": "^1.11.1"
-			},
-			"bin": {
-				"glob": "dist/esm/bin.mjs"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
 		"node_modules/typescript-cp/node_modules/globby": {
 			"version": "11.1.0",
 			"dev": true,
@@ -14449,47 +15180,6 @@
 				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
-		"node_modules/typescript-cp/node_modules/ignore": {
-			"version": "5.3.2",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 4"
-			}
-		},
-		"node_modules/typescript-cp/node_modules/jsonfile": {
-			"version": "6.1.0",
-			"dev": true,
-			"license": "MIT",
-			"dependencies": {
-				"universalify": "^2.0.0"
-			},
-			"optionalDependencies": {
-				"graceful-fs": "^4.1.6"
-			}
-		},
-		"node_modules/typescript-cp/node_modules/minimatch": {
-			"version": "9.0.5",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"brace-expansion": "^2.0.1"
-			},
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/typescript-cp/node_modules/minipass": {
-			"version": "7.1.2",
-			"dev": true,
-			"license": "ISC",
-			"engines": {
-				"node": ">=16 || 14 >=14.17"
-			}
-		},
 		"node_modules/typescript-cp/node_modules/path-type": {
 			"version": "4.0.0",
 			"dev": true,
@@ -14498,38 +15188,15 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/typescript-cp/node_modules/rimraf": {
-			"version": "5.0.10",
-			"dev": true,
-			"license": "ISC",
-			"dependencies": {
-				"glob": "^10.3.7"
-			},
-			"bin": {
-				"rimraf": "dist/esm/bin.mjs"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/isaacs"
-			}
-		},
-		"node_modules/typescript-cp/node_modules/universalify": {
-			"version": "2.0.1",
-			"dev": true,
-			"license": "MIT",
-			"engines": {
-				"node": ">= 10.0.0"
-			}
-		},
 		"node_modules/typescript-eslint": {
-			"version": "8.35.1",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.35.1.tgz",
-			"integrity": "sha512-xslJjFzhOmHYQzSB/QTeASAHbjmxOGEP6Coh93TXmUBFQoJ1VU35UHIDmG06Jd6taf3wqqC1ntBnCMeymy5Ovw==",
+			"version": "8.37.0",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
-				"@typescript-eslint/eslint-plugin": "8.35.1",
-				"@typescript-eslint/parser": "8.35.1",
-				"@typescript-eslint/utils": "8.35.1"
+				"@typescript-eslint/eslint-plugin": "8.37.0",
+				"@typescript-eslint/parser": "8.37.0",
+				"@typescript-eslint/typescript-estree": "8.37.0",
+				"@typescript-eslint/utils": "8.37.0"
 			},
 			"engines": {
 				"node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -14650,6 +15317,23 @@
 				"string.fromcodepoint": "^0.2.1"
 			}
 		},
+		"node_modules/unescape/node_modules/extend-shallow": {
+			"version": "2.0.1",
+			"license": "MIT",
+			"dependencies": {
+				"is-extendable": "^0.1.0"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/unescape/node_modules/is-extendable": {
+			"version": "0.1.1",
+			"license": "MIT",
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
 		"node_modules/union-value": {
 			"version": "1.0.1",
 			"dev": true,
@@ -14664,11 +15348,20 @@
 				"node": ">=0.10.0"
 			}
 		},
-		"node_modules/universalify": {
-			"version": "0.1.2",
+		"node_modules/union-value/node_modules/is-extendable": {
+			"version": "0.1.1",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">= 4.0.0"
+				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/universalify": {
+			"version": "2.0.1",
+			"dev": true,
+			"license": "MIT",
+			"engines": {
+				"node": ">= 10.0.0"
 			}
 		},
 		"node_modules/unpipe": {
@@ -15039,14 +15732,15 @@
 			}
 		},
 		"node_modules/ws": {
-			"version": "8.18.3",
+			"version": "7.5.10",
+			"dev": true,
 			"license": "MIT",
 			"engines": {
-				"node": ">=10.0.0"
+				"node": ">=8.3.0"
 			},
 			"peerDependencies": {
 				"bufferutil": "^4.0.1",
-				"utf-8-validate": ">=5.0.2"
+				"utf-8-validate": "^5.0.2"
 			},
 			"peerDependenciesMeta": {
 				"bufferutil": {
@@ -15160,6 +15854,16 @@
 				"node": ">=22.0"
 			}
 		},
+		"packages/access_copy_attacher/node_modules/dotenv": {
+			"version": "17.2.0",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
+			}
+		},
 		"packages/access_copy_attacher/node_modules/mime-db": {
 			"version": "1.54.0",
 			"license": "MIT",
@@ -15196,6 +15900,16 @@
 			},
 			"engines": {
 				"node": ">=22.0"
+			}
+		},
+		"packages/account_space_updater/node_modules/dotenv": {
+			"version": "17.2.0",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
 			}
 		},
 		"packages/api": {
@@ -15241,13 +15955,117 @@
 				"node": ">=22.0"
 			}
 		},
-		"packages/api/node_modules/ts-md5": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/ts-md5/-/ts-md5-1.3.1.tgz",
-			"integrity": "sha512-DiwiXfwvcTeZ5wCE0z+2A9EseZsztaiZtGrtSaY5JOD7ekPnR/GoIVD5gXZAlK9Na9Kvpo9Waz5rW64WKAWApg==",
+		"packages/api/node_modules/body-parser": {
+			"version": "1.20.3",
+			"resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+			"integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
 			"license": "MIT",
+			"dependencies": {
+				"bytes": "3.1.2",
+				"content-type": "~1.0.5",
+				"debug": "2.6.9",
+				"depd": "2.0.0",
+				"destroy": "1.2.0",
+				"http-errors": "2.0.0",
+				"iconv-lite": "0.4.24",
+				"on-finished": "2.4.1",
+				"qs": "6.13.0",
+				"raw-body": "2.5.2",
+				"type-is": "~1.6.18",
+				"unpipe": "1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8",
+				"npm": "1.2.8000 || >= 1.4.16"
+			}
+		},
+		"packages/api/node_modules/debug": {
+			"version": "2.6.9",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+			"integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+			"license": "MIT",
+			"dependencies": {
+				"ms": "2.0.0"
+			}
+		},
+		"packages/api/node_modules/dotenv": {
+			"version": "17.2.0",
+			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
+			}
+		},
+		"packages/api/node_modules/iconv-lite": {
+			"version": "0.4.24",
+			"resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+			"integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+			"license": "MIT",
+			"dependencies": {
+				"safer-buffer": ">= 2.1.2 < 3"
+			},
+			"engines": {
+				"node": ">=0.10.0"
+			}
+		},
+		"packages/api/node_modules/media-typer": {
+			"version": "0.3.0",
+			"resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+			"integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+			"license": "MIT",
+			"engines": {
+				"node": ">= 0.6"
+			}
+		},
+		"packages/api/node_modules/ms": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+			"integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+			"license": "MIT"
+		},
+		"packages/api/node_modules/qs": {
+			"version": "6.13.0",
+			"resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+			"integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+			"license": "BSD-3-Clause",
+			"dependencies": {
+				"side-channel": "^1.0.6"
+			},
+			"engines": {
+				"node": ">=0.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
+		"packages/api/node_modules/raw-body": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+			"integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+			"license": "MIT",
+			"dependencies": {
+				"bytes": "3.1.2",
+				"http-errors": "2.0.0",
+				"iconv-lite": "0.4.24",
+				"unpipe": "1.0.0"
+			},
+			"engines": {
+				"node": ">= 0.8"
+			}
+		},
+		"packages/api/node_modules/type-is": {
+			"version": "1.6.18",
+			"resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+			"integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+			"license": "MIT",
+			"dependencies": {
+				"media-typer": "0.3.0",
+				"mime-types": "~2.1.24"
+			},
+			"engines": {
+				"node": ">= 0.6"
 			}
 		},
 		"packages/api/node_modules/uuid": {
@@ -15270,11 +16088,20 @@
 				"@sentry/profiling-node": "^9.34.0",
 				"@stela/logger": "^1.0.0",
 				"dotenv": "^17.2.0",
-				"node-fetch": "^2.6.9",
 				"require-env-variable": "^4.0.2"
 			},
 			"engines": {
 				"node": ">=22.0"
+			}
+		},
+		"packages/archivematica_cleanup/node_modules/dotenv": {
+			"version": "17.2.0",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
 			}
 		},
 		"packages/archivematica-utils": {
@@ -15316,6 +16143,16 @@
 			},
 			"engines": {
 				"node": ">=22.0"
+			}
+		},
+		"packages/file_url_refresh/node_modules/dotenv": {
+			"version": "17.2.0",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
 			}
 		},
 		"packages/file-utils": {
@@ -15372,6 +16209,16 @@
 				"node": ">=22.0"
 			}
 		},
+		"packages/record_thumbnail_attacher/node_modules/dotenv": {
+			"version": "17.2.0",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
+			}
+		},
 		"packages/s3-utils": {
 			"name": "@stela/s3-utils",
 			"version": "1.0.0",
@@ -15405,6 +16252,16 @@
 				"node": ">=22.0"
 			}
 		},
+		"packages/thumbnail_refresh/node_modules/dotenv": {
+			"version": "17.2.0",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
+			}
+		},
 		"packages/trigger_archivematica": {
 			"name": "@stela/trigger_archivematica",
 			"version": "1.0.0",
@@ -15421,6 +16278,16 @@
 			},
 			"engines": {
 				"node": ">=18.0"
+			}
+		},
+		"packages/trigger_archivematica/node_modules/dotenv": {
+			"version": "17.2.0",
+			"license": "BSD-2-Clause",
+			"engines": {
+				"node": ">=12"
+			},
+			"funding": {
+				"url": "https://dotenvx.com"
 			}
 		}
 	}

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
 		"@types/jest-when": "^3.5.5",
 		"@types/mailchimp__mailchimp_transactional": "1.0.11",
 		"@types/node": "^12.20.55",
-		"@types/node-fetch": "^2.6.2",
 		"@types/pg": "^8.15.4",
 		"@types/supertest": "^6.0.3",
 		"@types/uuid": "^10.0.0",

--- a/packages/archivematica_cleanup/package.json
+++ b/packages/archivematica_cleanup/package.json
@@ -30,7 +30,6 @@
 		"@sentry/profiling-node": "^9.34.0",
 		"@stela/logger": "^1.0.0",
 		"dotenv": "^17.2.0",
-		"node-fetch": "^2.6.9",
 		"require-env-variable": "^4.0.2"
 	}
 }

--- a/packages/trigger_archivematica/src/index.test.ts
+++ b/packages/trigger_archivematica/src/index.test.ts
@@ -1,5 +1,4 @@
 import type { Context } from "aws-lambda";
-import type { Response } from "node-fetch";
 import { logger } from "@stela/logger";
 import { triggerArchivematicaProcessing } from "@stela/archivematica-utils";
 import { db } from "./database";


### PR DESCRIPTION
We recently stopped using node-fetch in favor of node's built in fetch API. However there is still one place where we needlessly import node-fetch, and one place where we needlessly use a node-fetch type. This commit fixes these cases.