### PR TITLE
Disable major version upgrades to ts-md5

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,8 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "@typescript-eslint/parser"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "ts-md5"
+        update-types: ["version-update:semver-major"]
     groups:
       eslint:
         patterns:


### PR DESCRIPTION
ts-md5 is ESM only in future major versions, so we can't do major version upgrades unless this project converts to ESM. To avoid unhelpful dependabot PRs, this commit tells dependabot to ignore major version upgrades to this package.