### PR TITLE
Don't delete build on start in local API server

### DIFF
--- a/packages/api/Dockerfile.dev
+++ b/packages/api/Dockerfile.dev
@@ -10,7 +10,6 @@ COPY tsconfig.build.json ./
 COPY packages ./packages
 COPY .env ./
 
-RUN npm install -g npm@9.5.0
 RUN npm cache clean --force
 RUN npm install \
     && npm install --dev \

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -24,7 +24,7 @@
 		"lint-docs": "redocly lint docs/src/api.yaml",
 		"lint": "npm run check-format && npm run check-types && npm run eslint && npm run lint-sql && npm run lint-docs",
 		"build": "rm -rf dist/* && tsc -p tsconfig.build.json && tscp -p tsconfig.tscp.json",
-		"start:watch": "rm -rf dist/* && tsc-watch --onSuccess \"npm run start\"",
+		"start:watch": "tsc-watch --onSuccess \"npm run start\"",
 		"start": "tscp -p tsconfig.tscp.json && node dist/index.js",
 		"start-containers": "(cd ../..; docker compose up -d --build stela)",
 		"clear-database": "psql postgresql://postgres:permanent@localhost:5432 -c 'DROP DATABASE IF EXISTS test_permanent;'",


### PR DESCRIPTION
Presently, when we build the docker container for the local stela API, we build the project during the container build, but then when we start the container we delete the API dist folder and rebuild it, but incompletely, causing the server to fail to start. This was presumably introduced in recent dependency upgrades. This commit removes the step that deletes api/dist from the start script; this step has been unnecessary for some time.