### PR TITLE
Log error if record_thumbnail_attacher doesn't update any rows

### DIFF
--- a/packages/record_thumbnail_attacher/src/index.ts
+++ b/packages/record_thumbnail_attacher/src/index.ts
@@ -22,11 +22,14 @@ export const handler: SQSHandler = Sentry.wrapHandler(
 				const thumbnailUrl = constructSignedCdnUrl(key);
 
 				try {
-					await db.sql("queries.update_record_thumbnail_data", {
+					const result = await db.sql("queries.update_record_thumbnail_data", {
 						fileId,
 						thumbnailUrl,
 						thumbnail256CloudPath: key,
 					});
+					if (result.rows.length === 0) {
+						logger.error(`Failed to updated record for file: ${fileId}`);
+					}
 				} catch (error) {
 					logger.error(error);
 					throw error;

--- a/packages/record_thumbnail_attacher/src/queries/update_record_thumbnail_data.sql
+++ b/packages/record_thumbnail_attacher/src/queries/update_record_thumbnail_data.sql
@@ -9,4 +9,6 @@ FROM
   record_file
 WHERE
   record.recordid = record_file.recordid
-  AND record_file.fileid = :fileId;
+  AND record_file.fileid = :fileId
+RETURNING
+record.recordid;


### PR DESCRIPTION
We're seeing cases in production where files are successfully processed by archivematica, and SQS messages about the existence of thumbnails are successfully proceesed by the record_thumbnail_attacher, but the records don't actually get thumbnails. It seems likely that this is coming from cases where, for some reason, the update query in the record_thumbnail_attacher doesn't update any rows. This commit adds logs for that case so we can see whether it's happening.