### PR TITLE
Correctly identify public record creation as publish events

### DIFF
--- a/packages/api/src/event/controller.test.ts
+++ b/packages/api/src/event/controller.test.ts
@@ -756,6 +756,16 @@ describe("GET /event/checklist", () => {
 		expect(item?.completed).toBe(true);
 	});
 
+	test("should communicate that a user has published content when they're uploaded directly to public workspace", async () => {
+		mockVerifyUserAuthentication(
+			"test@permanent.org",
+			"5862a229-5ea0-4432-b29e-7f069e99558a",
+		);
+		const response = await agent.get("/api/v2/event/checklist").expect(200);
+		const item = getChecklistItem(response.body as unknown, "publishContent");
+		expect(item?.completed).toBe(true);
+	});
+
 	test("should communicate that a user hasn't published content", async () => {
 		mockVerifyUserAuthentication(testNoProgressEmail, testSubject);
 		const response = await agent.get("/api/v2/event/checklist").expect(200);

--- a/packages/api/src/event/fixtures/create_test_accounts.sql
+++ b/packages/api/src/event/fixtures/create_test_accounts.sql
@@ -16,7 +16,7 @@ VALUES
   '{}',
   'type.account.standard',
   'Jack Rando',
-  null
+  '5862a229-5ea0-4432-b29e-7f069e99558a'
 ),
 (
   3,

--- a/packages/api/src/event/fixtures/create_test_events.sql
+++ b/packages/api/src/event/fixtures/create_test_events.sql
@@ -70,4 +70,13 @@ VALUES (
   '553f3cb8-b753-43ce-83af-4443a404741b',
   1,
   '{"public": true, "hasRecords": true}'
+),
+(
+	'record',
+	'create',
+	1,
+	'user',
+	'5862a229-5ea0-4432-b29e-7f069e99558a',
+	1,
+	'{"record": {"publicDT": "2020-01-01"}}'
 );

--- a/packages/api/src/event/queries/get_checklist_events.sql
+++ b/packages/api/src/event/queries/get_checklist_events.sql
@@ -74,8 +74,8 @@ SELECT
       AND (
         (
           account_events.entity = 'record'
-          AND account_events.action = 'submit'
-          AND (account_events.body ->> 'public')::boolean
+          AND account_events.action = 'create'
+          AND (account_events.body ->> 'record')::jsonb ->> 'publicDT' IS NOT NULL
         )
         OR
         (


### PR DESCRIPTION
Currently, for the purpose of the getting started checklist, the /checklist item looks for the wrong shape of event representing uploads directly to the public workspace. This commit fixes the endpoint to look for the event that is actually recorded.