### PR TITLE
Remove docker-compose version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,3 @@
-version: "3.7"
 services:
   stela:
     build:


### PR DESCRIPTION
This PR removes the `version` specified in docker-compose.  Setting a version is deprecated apparently!