### PR TITLE
Create a dependabot group for Sentry updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -19,6 +19,9 @@ updates:
       eslint:
         patterns:
           - "*eslint*"
+      sentry:
+        patterns:
+          - "@sentry/*"
 
   - package-ecosystem: "npm"
     directory: "/packages/access_copy_attacher"


### PR DESCRIPTION
Dependabot recently tried to update one of the sentry packages we use, and its PR was broken because this created conflicts with other sentry packages that it declined to update. This commit seeks to avoid that problem in the future by instructing dependabot to update all sentry packages at once.