### PR TITLE
Pin terraform-aws-modules/iam/aws//modules/iam-role-for-service-accou…

### DIFF
--- a/terraform/prod_cluster/load_balancer.tf
+++ b/terraform/prod_cluster/load_balancer.tf
@@ -1,5 +1,6 @@
 module "lb_role" {
-  source = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "5.60.0"
 
   role_name                              = "prod_eks_lb"
   attach_load_balancer_controller_policy = true

--- a/terraform/test_cluster/load_balancer.tf
+++ b/terraform/test_cluster/load_balancer.tf
@@ -1,5 +1,6 @@
 module "lb_role" {
-  source = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  source  = "terraform-aws-modules/iam/aws//modules/iam-role-for-service-accounts-eks"
+  version = "5.60.0"
 
   role_name                              = "dev_eks_lb"
   attach_load_balancer_controller_policy = true


### PR DESCRIPTION
…nts-eks version

The terraform-aws-modules source recently released its v6, in which the names of many of the submodules have been changed. This commit updates our Terraform specification to pin the version of this module so our deploys will continue to work.