### PR TITLE
Group `@aws-sdk` dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,9 @@ updates:
       sentry:
         patterns:
           - "@sentry/*"
+      aws-sdk:
+        patterns:
+          - "@aws-sdk/*"
 
   - package-ecosystem: "npm"
     directory: "/packages/access_copy_attacher"


### PR DESCRIPTION
This PR adds a group to combine updates to `@aws-sdk` dependencies; this should lower the noise and also prevent peer dependency issues that might crop up without it.