### PR TITLE
Fix Fusionauth client

### DIFF
--- a/packages/api/src/fusionauth.ts
+++ b/packages/api/src/fusionauth.ts
@@ -1,21 +1,17 @@
 import { FusionAuthClient } from "@fusionauth/typescript-client";
 import memoize from "memoizee";
 
-const baseFusionAuthClient = new FusionAuthClient(
+class MemoizedFusionAuthClient extends FusionAuthClient {
+	override introspectAccessToken = memoize(
+		super.introspectAccessToken.bind(this),
+		{ maxAge: 10000 },
+	);
+}
+
+const fusionAuthClient = new MemoizedFusionAuthClient(
 	process.env["FUSIONAUTH_API_KEY"] ?? "",
 	process.env["FUSIONAUTH_HOST"] ?? "",
 	process.env["FUSIONAUTH_TENANT"] ?? "",
 );
-
-const memoizedIntrospectAccessToken = memoize(
-	baseFusionAuthClient.introspectAccessToken.bind(baseFusionAuthClient),
-	{ maxAge: 10000 },
-);
-
-const fusionAuthClient: Omit<FusionAuthClient, "introspectAccessToken"> & {
-	introspectAccessToken: typeof memoizedIntrospectAccessToken;
-} = Object.assign({}, baseFusionAuthClient, {
-	introspectAccessToken: memoizedIntrospectAccessToken,
-});
 
 export { fusionAuthClient };


### PR DESCRIPTION
When applying some new linting rules, we updated the Fusionauth client in a way that seemed purely cosmetic, but which in fact removed all its methods except the memoized introspectAccessTokens. This commit updates the client to retain its expected methods while still obeying our linting rules.