### PR TITLE
Point this project at our new Archivematica instances

### DIFF
--- a/terraform/prod_cluster/variables.tf
+++ b/terraform/prod_cluster/variables.tf
@@ -237,5 +237,5 @@ variable "site_url" {
 variable "archivematica_original_location_id" {
   description = "Location ID where original copies are stored for the prod instance of Archivematica"
   type        = string
-  default     = "b1f64b1a-4f19-4885-8093-f6812e3f5810"
+  default     = "b725c4d9-2fb3-4978-91ef-a325c578ece1"
 }

--- a/terraform/test_cluster/trigger_archivematica_staging_lambda.tf
+++ b/terraform/test_cluster/trigger_archivematica_staging_lambda.tf
@@ -107,9 +107,9 @@ resource "aws_lambda_function" "trigger_archivematica_staging_lambda" {
       ENV                                = var.staging_env
       SENTRY_DSN                         = var.sentry_dsn
       DATABASE_URL                       = var.staging_database_url
-      ARCHIVEMATICA_HOST_URL             = var.dev_archivematica_base_url
-      ARCHIVEMATICA_API_KEY              = var.dev_archivematica_api_key
-      ARCHIVEMATICA_ORIGINAL_LOCATION_ID = var.dev_archivematica_original_location_id
+      ARCHIVEMATICA_HOST_URL             = var.staging_archivematica_base_url
+      ARCHIVEMATICA_API_KEY              = var.staging_archivematica_api_key
+      ARCHIVEMATICA_ORIGINAL_LOCATION_ID = var.staging_archivematica_original_location_id
     }
   }
 }

--- a/terraform/test_cluster/variables.tf
+++ b/terraform/test_cluster/variables.tf
@@ -333,11 +333,11 @@ variable "staging_site_url" {
 variable "dev_archivematica_original_location_id" {
   description = "Location ID where original copies are stored for the dev instance of Archivematica"
   type        = string
-  default     = "59ca35b5-6cb2-47d2-ab1c-5912d3bb4ce2"
+  default     = "beea0208-8d17-4dbf-8c8d-e7c2b9beb82f"
 }
 
 variable "staging_archivematica_original_location_id" {
   description = "Location ID where original copies are stored for the staging instance of Archivematica"
   type        = string
-  default     = "b3a5a89f-34c0-4ebd-a037-e70140d49ff9"
+  default     = "e0aa5ff7-6295-4ffd-80b3-0615e38c9868"
 }


### PR DESCRIPTION
We have new kubernetes-hosted Archivematica instances deployed to all our environments now; this commit updates stela to use these instances rather than the old EC2-hosted ones.