### PR TITLE
Use EKS add-ons for DNS

### DIFF
--- a/terraform/test_cluster/eks-cluster.tf
+++ b/terraform/test_cluster/eks-cluster.tf
@@ -22,6 +22,24 @@ module "eks" {
     }
   }
 
+  addons = {
+    coredns = {
+      most_recent                 = true
+      resolve_conflicts_on_create = "OVERWRITE"
+      resolve_conflicts           = "OVERWRITE"
+    }
+    kube-proxy = {
+      most_recent                 = true
+      resolve_conflicts_on_create = "OVERWRITE"
+      resolve_conflicts           = "OVERWRITE"
+    }
+    vpc-cni = {
+      most_recent                 = true
+      resolve_conflicts_on_create = "OVERWRITE"
+      resolve_conflicts           = "OVERWRITE"
+    }
+  }
+
   eks_managed_node_groups = {
     one = {
       ami_type = "AL2023_x86_64_STANDARD"


### PR DESCRIPTION
Our recent updates to EKS caused problems with the cluster's DNS. Using EKS add-ons for DNS management helps prevent version mismatches, that can cause such problems, and has indeed solved the particular problem we were experiencing.