### PR TITLE
Revert lambdas to Node 22

### DIFF
--- a/Dockerfile.access_copy_attacher
+++ b/Dockerfile.access_copy_attacher
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/nodejs:24 as builder
+FROM public.ecr.aws/lambda/nodejs:22 as builder
 WORKDIR /usr/local/apps/stela/
 
 COPY package.json ./
@@ -12,7 +12,7 @@ RUN npm install -ws
 RUN npm run build -ws
 
 
-FROM public.ecr.aws/lambda/nodejs:24 as final
+FROM public.ecr.aws/lambda/nodejs:22 as final
 
 ARG AWS_RDS_CERT_BUNDLE
 

--- a/Dockerfile.account_space_updater
+++ b/Dockerfile.account_space_updater
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/nodejs:24 as builder
+FROM public.ecr.aws/lambda/nodejs:22 as builder
 WORKDIR /usr/local/apps/stela/
 
 COPY package.json ./
@@ -12,7 +12,7 @@ RUN npm install -ws
 RUN npm run build -ws
 
 
-FROM public.ecr.aws/lambda/nodejs:24 as final
+FROM public.ecr.aws/lambda/nodejs:22 as final
 
 ARG AWS_RDS_CERT_BUNDLE
 

--- a/Dockerfile.record_thumbnail_attacher
+++ b/Dockerfile.record_thumbnail_attacher
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/nodejs:24 as builder
+FROM public.ecr.aws/lambda/nodejs:22 as builder
 WORKDIR /usr/local/apps/stela/
 
 COPY package.json ./
@@ -12,7 +12,7 @@ RUN npm install -ws
 RUN npm run build -ws
 
 
-FROM public.ecr.aws/lambda/nodejs:24 as final
+FROM public.ecr.aws/lambda/nodejs:22 as final
 
 ARG AWS_RDS_CERT_BUNDLE
 

--- a/Dockerfile.trigger_archivematica
+++ b/Dockerfile.trigger_archivematica
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/nodejs:18 as builder
+FROM public.ecr.aws/lambda/nodejs:22 as builder
 WORKDIR /usr/local/apps/stela/
 
 COPY package.json ./
@@ -12,7 +12,7 @@ RUN npm install -ws
 RUN npm run build -ws
 
 
-FROM public.ecr.aws/lambda/nodejs:18 as final
+FROM public.ecr.aws/lambda/nodejs:22 as final
 
 ARG AWS_RDS_CERT_BUNDLE
 

--- a/packages/access_copy_attacher/package.json
+++ b/packages/access_copy_attacher/package.json
@@ -13,7 +13,7 @@
 	},
 	"homepage": "https://permanent.org",
 	"engines": {
-		"node": ">=24.0"
+		"node": ">=22.0"
 	},
 	"main": "dist/index.js",
 	"scripts": {

--- a/packages/account_space_updater/package.json
+++ b/packages/account_space_updater/package.json
@@ -13,7 +13,7 @@
 	},
 	"homepage": "https://permanent.org",
 	"engines": {
-		"node": ">=24.0"
+		"node": ">=22.0"
 	},
 	"main": "dist/index.js",
 	"scripts": {

--- a/packages/record_thumbnail_attacher/package.json
+++ b/packages/record_thumbnail_attacher/package.json
@@ -13,7 +13,7 @@
 	},
 	"homepage": "https://permanent.org",
 	"engines": {
-		"node": ">=24.0"
+		"node": ">=22.0"
 	},
 	"main": "dist/index.js",
 	"scripts": {

--- a/packages/trigger_archivematica/package.json
+++ b/packages/trigger_archivematica/package.json
@@ -13,7 +13,7 @@
 	},
 	"homepage": "https://permanent.org",
 	"engines": {
-		"node": ">=18.0"
+		"node": ">=22.0"
 	},
 	"main": "dist/index.js",
 	"scripts": {


### PR DESCRIPTION
AWS hasn't yet released the Node 24 version of the docker image we use to build our lambdas, so this commit reverts our lambdas to Node 22 (except the trigger Archivematica lambda, which seems to have missed past updates and is thus here updated to Node 22 from Node 18).