### PR TITLE
Add GET /archives endpoint to support archive search

### DIFF
--- a/packages/api/docs/src/api.yaml
+++ b/packages/api/docs/src/api.yaml
@@ -55,6 +55,8 @@ paths:
     $ref: "./paths/folder.yaml#/folders-id-share-links"
   /archive/{id}/folders/shared:
     $ref: "./paths/archive.yaml#/archive-id-folders-shared"
+  /archives:
+    $ref: "./paths/archive.yaml#/archives"
   /applications:
     $ref: "./paths/application.yaml#/applications"
   /applications/{id}:

--- a/packages/api/docs/src/models/archive.yaml
+++ b/packages/api/docs/src/models/archive.yaml
@@ -1,0 +1,67 @@
+archive:
+  description: Archive object
+  type: object
+  required:
+    - archiveId
+    - rootFolderId
+    - name
+    - public
+    - allowPublicDownload
+    - thumbnailUrls
+    - status
+    - type
+    - createdAt
+    - updatedAt
+  properties:
+    archiveId:
+      type: string
+    rootFolderId:
+      type: string
+    description:
+      type: string
+    name:
+      type: string
+    payerAccountId:
+      type: string
+    public:
+      type: boolean
+    publicAt:
+      type: string
+      format: date-time
+    allowPublicDownload:
+      type: boolean
+    thumbnailUrls:
+      type: object
+      properties:
+        width200:
+          type: string
+        width500:
+          type: string
+        width1000:
+          type: string
+        width2000:
+          type: string
+    owner:
+      type: object
+      description: Owner information. Only returned for admin-authenticated requests.
+      required:
+        - name
+        - email
+      properties:
+        name:
+          type: string
+        email:
+          type: string
+          format: email
+        phoneNumber:
+          type: string
+    status:
+      type: string
+    type:
+      type: string
+    createdAt:
+      type: string
+      format: date-time
+    updatedAt:
+      type: string
+      format: date-time

--- a/packages/api/docs/src/paths/archive.yaml
+++ b/packages/api/docs/src/paths/archive.yaml
@@ -1,3 +1,38 @@
+archives:
+  parameters:
+    - name: searchQuery
+      in: query
+      required: true
+      schema:
+        type: string
+  get:
+    summary: Get archives whose names match the search query
+    description: |
+      Unauthenticated requests return only public archives.
+      Admin-authenticated requests return public archives with owner contact information.
+      User-authenticated requests return public archives and archives of which the caller is a member.
+    security:
+      - {}
+      - bearerHttpAuthentication: []
+    tags:
+      - archives
+    operationId: get-archives
+    responses:
+      "200":
+        description: A list of archives.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                items:
+                  type: array
+                  items:
+                    $ref: "../models/archive.yaml#/archive"
+      "400":
+        $ref: "../errors.yaml#/400"
+      "500":
+        $ref: "../errors.yaml#/500"
 archive-id-folders-shared:
   parameters:
     - name: id

--- a/packages/api/src/archive/controller/search_archives.test.ts
+++ b/packages/api/src/archive/controller/search_archives.test.ts
@@ -1,0 +1,187 @@
+import request from "supertest";
+import { logger } from "@stela/logger";
+import { app } from "../../app";
+import { db } from "../../database";
+import type { Archive } from "../models";
+import {
+	mockExtractUserIsAdminFromAuthToken,
+	mockExtractUserEmailFromAuthToken,
+} from "../../../test/middleware_mocks";
+
+jest.mock("../../database");
+jest.mock("@stela/logger");
+jest.mock("../../middleware");
+
+const loadFixtures = async (): Promise<void> => {
+	await db.sql("archive.fixtures.create_test_accounts");
+	await db.sql("archive.fixtures.create_test_archives");
+	await db.sql("archive.fixtures.create_test_folders");
+	await db.sql("archive.fixtures.create_test_text_data");
+	await db.sql("archive.fixtures.create_test_profile_items");
+	await db.sql("archive.fixtures.create_test_account_archives");
+};
+
+const clearDatabase = async (): Promise<void> => {
+	await db.query(
+		"TRUNCATE account, archive, folder, profile_item, text_data, account_archive CASCADE",
+	);
+};
+
+describe("searchArchives", () => {
+	const agent = request(app);
+
+	beforeEach(async () => {
+		await loadFixtures();
+	});
+
+	afterEach(async () => {
+		await clearDatabase();
+		jest.clearAllMocks();
+	});
+
+	test("should search archives without authentication and return only public archives", async () => {
+		mockExtractUserIsAdminFromAuthToken(false);
+		mockExtractUserEmailFromAuthToken(undefined);
+		const result = await agent
+			.get("/api/v2/archive?searchQuery=Rando&pageSize=1")
+			.expect(200);
+
+		const {
+			body: { items, pagination },
+		} = result as {
+			body: {
+				items: Archive[];
+				pagination: {
+					nextCursor: string | undefined;
+					nextPage: string | undefined;
+					totalPages: number;
+				};
+			};
+		};
+		expect(items).toHaveLength(1);
+		expect(pagination.totalPages).toBe(2);
+		expect(pagination.nextCursor).toBe("3");
+		expect(pagination.nextPage).toBe(
+			"https:///api/v2/archive?searchQuery=Rando&pageSize=1&cursor=3",
+		);
+
+		const [archive] = items;
+		if (archive !== undefined) {
+			expect(archive.archiveId).toBe("3");
+			expect(archive.rootFolderId).toBe("102");
+			expect(archive.name).toBe("Jay Rando");
+			expect(archive.description).toBe(
+				"This is Jay Rando's public archive description",
+			);
+			expect(archive.payerAccountId).toBeNull();
+			expect(archive.public).toBe(true);
+			expect(archive.publicAt).toBeNull();
+			expect(archive.allowPublicDownload).toBe(true);
+			expect(archive.thumbnailUrls).toEqual({
+				width200: "https://test-archive-thumbnail",
+				width500: null,
+				width1000: null,
+				width2000: null,
+			});
+			expect(archive.owner).toBeNull();
+			expect(archive.status).toBe("status.generic.ok");
+			expect(archive.type).toBe("type.archive.person");
+			expect(archive.createdAt).toBeDefined();
+			expect(archive.updatedAt).toBeDefined();
+		}
+	});
+
+	test("should not return deleted archives", async () => {
+		mockExtractUserIsAdminFromAuthToken(false);
+		mockExtractUserEmailFromAuthToken(undefined);
+		const result = await agent
+			.get("/api/v2/archive?searchQuery=Janet&pageSize=10")
+			.expect(200);
+
+		const {
+			body: { items },
+		} = result as { body: { items: Archive[] } };
+		expect(items).toHaveLength(0);
+	});
+
+	test("should return owner information for admin-authenticated requests", async () => {
+		mockExtractUserIsAdminFromAuthToken(true);
+		mockExtractUserEmailFromAuthToken(undefined);
+
+		const result = await agent
+			.get("/api/v2/archive?searchQuery=Jay&pageSize=10")
+			.set("Authorization", "Bearer admin-token")
+			.expect(200);
+
+		const {
+			body: { items },
+		} = result as { body: { items: Archive[] } };
+		expect(items[0]?.owner).not.toBeNull();
+		expect(items[0]?.owner?.name).toBe("Jack Rando");
+		expect(items[0]?.owner?.email).toBe("test@permanent.org");
+	});
+
+	test("should return callers private archives if caller is authenticated non-admin", async () => {
+		mockExtractUserIsAdminFromAuthToken(false);
+		mockExtractUserEmailFromAuthToken("test@permanent.org");
+
+		const result = await agent
+			.get("/api/v2/archive?searchQuery=Rando&pageSize=10")
+			.set("Authorization", "Bearer user-token")
+			.expect(200);
+
+		const {
+			body: { items },
+		} = result as { body: { items: Archive[] } };
+		expect(items).toHaveLength(3);
+	});
+
+	test("should not return callers private archives if caller is authenticated admin", async () => {
+		mockExtractUserIsAdminFromAuthToken(true);
+		mockExtractUserEmailFromAuthToken("test@permanent.org");
+
+		const result = await agent
+			.get("/api/v2/archive?searchQuery=Rando&pageSize=10")
+			.set("Authorization", "Bearer user-token")
+			.expect(200);
+
+		const {
+			body: { items },
+		} = result as { body: { items: Archive[] } };
+		expect(items).toHaveLength(2);
+	});
+
+	test("should populate archive description when present", async () => {
+		mockExtractUserIsAdminFromAuthToken(false);
+		mockExtractUserEmailFromAuthToken(undefined);
+
+		const result = await agent
+			.get("/api/v2/archive?searchQuery=Jay&pageSize=10")
+			.expect(200);
+
+		const {
+			body: { items },
+		} = result as { body: { items: Archive[] } };
+		expect(items).toHaveLength(1);
+		expect(items[0]?.archiveId).toBe("3");
+		expect(items[0]?.name).toBe("Jay Rando");
+		expect(items[0]?.description).toBe(
+			"This is Jay Rando's public archive description",
+		);
+	});
+
+	test("should return 400 if searchQuery is missing", async () => {
+		mockExtractUserIsAdminFromAuthToken(false);
+		mockExtractUserEmailFromAuthToken(undefined);
+		await agent.get("/api/v2/archive").expect(400);
+	});
+
+	test("should throw InternalServerError if database query fails", async () => {
+		mockExtractUserIsAdminFromAuthToken(false);
+		mockExtractUserEmailFromAuthToken(undefined);
+		const testError = new Error("error: out of cheese - redo from start");
+		jest.spyOn(db, "sql").mockRejectedValueOnce(testError);
+		await agent.get("/api/v2/archive?searchQuery=test&pageSize=10").expect(500);
+		expect(logger.error).toHaveBeenCalledWith(testError);
+	});
+});

--- a/packages/api/src/archive/fixtures/create_test_account_archives.sql
+++ b/packages/api/src/archive/fixtures/create_test_account_archives.sql
@@ -71,4 +71,22 @@ VALUES
   0,
   'type.account.standard',
   'status.generic.deleted'
+),
+(
+  36,
+  2,
+  3,
+  'access.role.owner',
+  0,
+  'type.account.standard',
+  'status.generic.ok'
+),
+(
+  37,
+  2,
+  5,
+  'access.role.owner',
+  0,
+  'type.account.standard',
+  'status.generic.ok'
 );

--- a/packages/api/src/archive/fixtures/create_test_archives.sql
+++ b/packages/api/src/archive/fixtures/create_test_archives.sql
@@ -22,4 +22,13 @@ VALUES
   'type.archive.person',
   'https://test-archive-thumbnail',
   'status.generic.deleted'
+),
+(
+  5,
+  '0001-0005',
+  null,
+  true,
+  'type.archive.person',
+  'https://test-archive-thumbnail',
+  'status.generic.ok'
 );

--- a/packages/api/src/archive/fixtures/create_test_folders.sql
+++ b/packages/api/src/archive/fixtures/create_test_folders.sql
@@ -131,4 +131,59 @@ VALUES
   CURRENT_TIMESTAMP,
   'type.folder.root.private',
   'https://test-folder-thumbnail'
+),
+(
+  100,
+  1,
+  NULL,
+  'Root',
+  NULL,
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  'type.folder.root.root',
+  NULL
+),
+(
+  101,
+  2,
+  NULL,
+  'Root',
+  NULL,
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  'type.folder.root.root',
+  NULL
+),
+(
+  102,
+  3,
+  NULL,
+  'Root',
+  NULL,
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  'type.folder.root.root',
+  NULL
+),
+(
+  103,
+  4,
+  NULL,
+  'Root',
+  NULL,
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  'type.folder.root.root',
+  NULL
+),
+(
+  104,
+  5,
+  NULL,
+  'Root',
+  NULL,
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  'type.folder.root.root',
+  NULL
 );

--- a/packages/api/src/archive/fixtures/create_test_profile_items.sql
+++ b/packages/api/src/archive/fixtures/create_test_profile_items.sql
@@ -1,31 +1,74 @@
 INSERT INTO
-profile_item (archiveid, fieldnameui, string1, status, type)
+profile_item (
+  profile_itemid,
+  archiveid,
+  fieldnameui,
+  string1,
+  text_dataid1,
+  status,
+  type
+)
 VALUES
 (
   1,
+  1,
   'profile.basic',
   'Jack Rando',
-  'status.generic.ok',
-  'type.profile_item.basic'
-),
-(
-  3,
-  'profile.basic',
-  'Jay Rando',
+  NULL,
   'status.generic.ok',
   'type.profile_item.basic'
 ),
 (
   2,
+  3,
+  'profile.basic',
+  'Jay Rando',
+  NULL,
+  'status.generic.ok',
+  'type.profile_item.basic'
+),
+(
+  3,
+  2,
   'profile.basic',
   'Jane Rando',
+  NULL,
   'status.generic.ok',
   'type.profile_item.basic'
 ),
 (
   4,
+  4,
   'profile.basic',
   'Janet Rando',
+  NULL,
+  'status.generic.ok',
+  'type.profile_item.basic'
+),
+(
+  5,
+  1,
+  'profile.description',
+  NULL,
+  1,
+  'status.generic.ok',
+  'type.profile_item.description'
+),
+(
+  6,
+  3,
+  'profile.description',
+  NULL,
+  2,
+  'status.generic.ok',
+  'type.profile_item.description'
+),
+(
+  7,
+  5,
+  'profile.basic',
+  'John Rando',
+  NULL,
   'status.generic.ok',
   'type.profile_item.basic'
 );

--- a/packages/api/src/archive/fixtures/create_test_text_data.sql
+++ b/packages/api/src/archive/fixtures/create_test_text_data.sql
@@ -1,0 +1,32 @@
+INSERT INTO
+text_data (
+  text_dataid,
+  valuetext,
+  status,
+  type,
+  reftable,
+  refid,
+  createddt,
+  updateddt
+)
+VALUES
+(
+  1,
+  'This is Jack Rando''s archive description',
+  'status.generic.ok',
+  'type.generic.placeholder',
+  'profile_item',
+  5,
+  NOW(),
+  NOW()
+),
+(
+  2,
+  'This is Jay Rando''s public archive description',
+  'status.generic.ok',
+  'type.generic.placeholder',
+  'profile_item',
+  6,
+  NOW(),
+  NOW()
+);

--- a/packages/api/src/archive/models.ts
+++ b/packages/api/src/archive/models.ts
@@ -29,3 +29,42 @@ export interface FeaturedArchive {
 	profileImage: string;
 	bannerImage: string;
 }
+
+export interface ThumbnailUrls {
+	width200: string | null;
+	width500: string | null;
+	width1000: string | null;
+	width2000: string | null;
+}
+
+export interface ArchiveOwner {
+	name: string;
+	email: string;
+	phoneNumber?: string | null;
+}
+
+export interface Archive {
+	archiveId: string;
+	rootFolderId: string;
+	description?: string | null;
+	name: string;
+	payerAccountId?: string | null;
+	public: boolean;
+	publicAt?: string | null;
+	allowPublicDownload: boolean;
+	thumbnailUrls: ThumbnailUrls;
+	owner?: ArchiveOwner | null;
+	status: string;
+	type: string;
+	createdAt: string;
+	updatedAt: string;
+}
+
+export interface GetArchivesResponse {
+	items: Archive[];
+	pagination: {
+		nextCursor: string | undefined;
+		nextPage: string | undefined;
+		totalPages: number;
+	};
+}

--- a/packages/api/src/archive/queries/search_archives.sql
+++ b/packages/api/src/archive/queries/search_archives.sql
@@ -1,0 +1,125 @@
+WITH all_archives AS (
+  SELECT
+    archive.archiveid AS "archiveId",
+    archive.archivenbr AS "archiveNbr",
+    basic_profile_item.string1 AS name,
+    text_data.valuetext AS description,
+    archive.public,
+    archive.publicdt AS "publicAt",
+    archive.allowpublicdownload AS "allowPublicDownload",
+    jsonb_build_object(
+      'width200', archive.thumburl200,
+      'width500', archive.thumburl500,
+      'width1000', archive.thumburl1000,
+      'width2000', archive.thumburl2000
+    ) AS "thumbnailUrls",
+    archive.status,
+    archive.type,
+    archive.createddt AS "createdAt",
+    archive.updateddt AS "updatedAt",
+    root_folder.folderid AS "rootFolderId",
+    CASE
+      WHEN :isAdmin
+        THEN
+          jsonb_build_object(
+            'name', owner_account.fullname,
+            'email', owner_account.primaryemail,
+            'phoneNumber', owner_account.primaryphone
+          )
+      ELSE NULL
+    END AS owner,
+    archive.payeraccountid AS "payerAccountId",
+    row_number() OVER (
+      ORDER BY
+        ts_rank(
+          to_tsvector('english', basic_profile_item.string1),
+          plainto_tsquery('english', :searchQuery)
+        ) DESC,
+        basic_profile_item.string1
+    ) AS rank
+  FROM
+    archive
+  INNER JOIN
+    profile_item AS basic_profile_item
+    ON
+      archive.archiveid = basic_profile_item.archiveid
+      AND basic_profile_item.fieldnameui = 'profile.basic'
+      AND basic_profile_item.status != 'status.generic.deleted'
+  LEFT JOIN
+    profile_item AS description_profile_item
+    ON
+      archive.archiveid = description_profile_item.archiveid
+      AND description_profile_item.fieldnameui = 'profile.description'
+      AND basic_profile_item.status != 'status.generic.deleted'
+  LEFT JOIN
+    text_data
+    ON
+      description_profile_item.text_dataid1 = text_data.text_dataid
+  INNER JOIN
+    folder AS root_folder
+    ON
+      archive.archiveid = root_folder.archiveid
+      AND root_folder.type = 'type.folder.root.root'
+  LEFT JOIN
+    account_archive AS owner_account_archive
+    ON
+      archive.archiveid = owner_account_archive.archiveid
+      AND owner_account_archive.accessrole = 'access.role.owner'
+      AND owner_account_archive.status = 'status.generic.ok'
+  LEFT JOIN
+    account AS owner_account
+    ON owner_account_archive.accountid = owner_account.accountid
+  WHERE
+    plainto_tsquery('english', :searchQuery)
+    @@ to_tsvector('english', basic_profile_item.string1)
+    AND archive.status != 'status.generic.deleted'
+    AND (
+      (archive.public IS NOT NULL AND archive.public)
+      OR (NOT :isAdmin AND EXISTS (
+        SELECT 1
+        FROM account_archive
+        INNER JOIN account
+          ON account_archive.accountid = account.accountid
+        WHERE
+          account_archive.archiveid = archive.archiveid
+          AND account.primaryemail = :userEmail
+          AND account_archive.status = 'status.generic.ok'
+      ))
+    )
+),
+
+cursor AS (
+  SELECT rank
+  FROM
+    all_archives
+  WHERE
+    "archiveId" = :cursor
+),
+
+total_pages AS (
+  SELECT ceiling(count(*) / :pageSize::numeric)::int AS total_pages
+  FROM all_archives
+)
+
+SELECT
+  "archiveId",
+  "archiveNbr",
+  name,
+  description,
+  public,
+  "publicAt",
+  "allowPublicDownload",
+  "thumbnailUrls",
+  status,
+  type,
+  "createdAt",
+  "updatedAt",
+  "rootFolderId",
+  owner,
+  "payerAccountId",
+  (SELECT total_pages.total_pages FROM total_pages) AS "totalPages"
+FROM all_archives
+WHERE
+  rank > coalesce((SELECT cursor.rank FROM cursor), 0)
+ORDER BY rank ASC
+LIMIT :pageSize;

--- a/packages/api/src/archive/service/index.ts
+++ b/packages/api/src/archive/service/index.ts
@@ -5,6 +5,7 @@ import { unfeature } from "./unfeature";
 import { getFeatured } from "./get_featured";
 import { getSharedFolders } from "./get_shared_folders";
 import { backfillLedger } from "./backfill_ledger";
+import { searchArchives } from "./search_archives";
 
 export const archiveService = {
 	getPublicTags,
@@ -14,4 +15,5 @@ export const archiveService = {
 	getFeatured,
 	getSharedFolders,
 	backfillLedger,
+	searchArchives,
 };

--- a/packages/api/src/archive/service/search_archives.ts
+++ b/packages/api/src/archive/service/search_archives.ts
@@ -1,0 +1,44 @@
+import createError from "http-errors";
+import { logger } from "@stela/logger";
+import { db } from "../../database";
+import type { Archive, GetArchivesResponse } from "../models";
+
+export const searchArchives = async (
+	searchQuery: string,
+	pagination: {
+		pageSize: number;
+		cursor: string | undefined;
+	},
+	isAdmin: boolean,
+	userEmail: string | undefined,
+): Promise<GetArchivesResponse> => {
+	const result = await db
+		.sql<Archive & { totalPages: number }>("archive.queries.search_archives", {
+			searchQuery,
+			isAdmin,
+			pageSize: pagination.pageSize,
+			cursor: pagination.cursor,
+			userEmail,
+		})
+		.catch((err: unknown) => {
+			logger.error(err);
+			throw new createError.InternalServerError("Failed to search archives");
+		});
+
+	const { rows: archives } = result;
+	const nextCursor = archives[archives.length - 1]?.archiveId;
+
+	return {
+		items: archives,
+		pagination: {
+			nextCursor,
+			nextPage:
+				nextCursor === undefined
+					? undefined
+					: `https://${
+							process.env["SITE_URL"] ?? ""
+						}/api/v2/archive?searchQuery=${encodeURIComponent(searchQuery)}&pageSize=${pagination.pageSize}&cursor=${nextCursor}`,
+			totalPages: result.rows[0] === undefined ? 0 : result.rows[0].totalPages,
+		},
+	};
+};

--- a/packages/api/src/archive/validators.ts
+++ b/packages/api/src/archive/validators.ts
@@ -15,3 +15,26 @@ export const validateArchiveIdFromParams: (
 		throw validation.error;
 	}
 };
+
+export const validateSearchQuery: (data: unknown) => asserts data is {
+	searchQuery: string;
+	pageSize: number;
+	cursor?: string;
+} = (
+	data: unknown,
+): asserts data is {
+	searchQuery: string;
+	pageSize: number;
+	cursor?: string;
+} => {
+	const validation = Joi.object()
+		.keys({
+			searchQuery: Joi.string().required(),
+			pageSize: Joi.number().integer().min(1).required(),
+			cursor: Joi.string().optional(),
+		})
+		.validate(data);
+	if (validation.error !== undefined) {
+		throw validation.error;
+	}
+};


### PR DESCRIPTION
This commit adds a GET /archives endpoint to the API server. The archive object it returns includes contact information for the archive owner if the caller is a Permanent administrator; this is to support a streamlined workflow for identifying candidates for featured archives in the admin dashboard.