### PR TITLE
Run Archivematica on copied files

### DIFF
--- a/packages/trigger_archivematica/src/index.test.ts
+++ b/packages/trigger_archivematica/src/index.test.ts
@@ -266,7 +266,7 @@ describe("handler", () => {
 						body: JSON.stringify({
 							Message: JSON.stringify({
 								entity: "record",
-								action: "create",
+								action: "copy",
 								body: { record: { recordId: "2" } },
 							}),
 						}),

--- a/packages/trigger_archivematica/src/index.ts
+++ b/packages/trigger_archivematica/src/index.ts
@@ -26,7 +26,7 @@ export const extractRecordIdFromRecordCreateMessage = (
 	}
 	const { action } = parsedMessage;
 
-	if (action === "create") {
+	if (action === "create" || action === "copy") {
 		if (parsedMessage.body.record === undefined) {
 			logger.error(
 				`record.create event missing record: ${JSON.stringify(

--- a/terraform/prod_cluster/trigger_archivematica_prod_lambda.tf
+++ b/terraform/prod_cluster/trigger_archivematica_prod_lambda.tf
@@ -39,7 +39,7 @@ resource "aws_sns_topic_subscription" "trigger_archivematica_prod_subscription" 
   endpoint  = aws_sqs_queue.trigger_archivematica_prod_queue.arn
   filter_policy = jsonencode({
     Entity = ["record"],
-    Action = ["create"]
+    Action = ["create", "copy"]
   })
 }
 

--- a/terraform/test_cluster/trigger_archivematica_dev_lambda.tf
+++ b/terraform/test_cluster/trigger_archivematica_dev_lambda.tf
@@ -43,7 +43,7 @@ resource "aws_sns_topic_subscription" "trigger_archivematica_dev_subscription" {
   endpoint  = aws_sqs_queue.trigger_archivematica_dev_queue.arn
   filter_policy = jsonencode({
     Entity = ["record"],
-    Action = ["create"]
+    Action = ["create", "copy"]
   })
 }
 

--- a/terraform/test_cluster/trigger_archivematica_staging_lambda.tf
+++ b/terraform/test_cluster/trigger_archivematica_staging_lambda.tf
@@ -43,7 +43,7 @@ resource "aws_sns_topic_subscription" "trigger_archivematica_staging_subscriptio
   endpoint  = aws_sqs_queue.trigger_archivematica_staging_queue.arn
   filter_policy = jsonencode({
     Entity = ["record"],
-    Action = ["create"]
+    Action = ["create", "copy"]
   })
 }
 


### PR DESCRIPTION
Copied files should have corresponding AIPs and DIPs just like directly uploaded files. Running them through Archivematica is the simplest way to achieve this.