### PR TITLE
Update GET /record to return records in the order they were requested

### DIFF
--- a/packages/api/src/record/controller.test.ts
+++ b/packages/api/src/record/controller.test.ts
@@ -122,6 +122,15 @@ describe("GET /record", () => {
 		const { body: records } = response as { body: ArchiveRecord[] };
 		expect(records.length).toEqual(2);
 	});
+	test("expect to return multiple records in the order of the request", async () => {
+		const response = await agent
+			.get("/api/v2/record?recordIds[]=2&recordIds[]=1")
+			.expect(200);
+		const { body: records } = response as { body: ArchiveRecord[] };
+		expect(records.length).toEqual(2);
+		expect(records[0]?.recordId).toEqual("2");
+		expect(records[1]?.recordId).toEqual("1");
+	});
 	test("expect an empty response if the logged-in user does not own the record", async () => {
 		const response = await agent
 			.get("/api/v2/record?recordIds[]=7")

--- a/packages/api/src/record/service.ts
+++ b/packages/api/src/record/service.ts
@@ -33,7 +33,19 @@ export const getRecordById = async (requestQuery: {
 		size: +(row.size ?? 0),
 		imageRatio: +(row.imageRatio ?? 0),
 	}));
-	return records;
+
+	// Our API contract remains that the order in which this endpoint returns
+	// records is undefined. This ordering logic is implemented as a hotfix, and
+	// should be removed when our clients no longer rely on this endpoint returning
+	// records in a particular order.
+	const recordsById = new Map();
+	records.forEach((record: ArchiveRecord) =>
+		recordsById.set(record.recordId, record),
+	);
+	const recordsInOrder = requestQuery.recordIds
+		.map((recordId: string) => recordsById.get(recordId))
+		.filter((record: ArchiveRecord | undefined) => record !== undefined);
+	return recordsInOrder;
 };
 
 const validateCanPatchRecord = async (


### PR DESCRIPTION
Currently, the order in which GET /record returns records is undefined. This remains the API contract, but as a hotfix this commit updates the endpoint to return them in the order they're listed in the request, because that is what our web app currently expects. This change should be reverted when the web app no longer relies on this behavior.