### PR TITLE
Update metadata attacher lambda to handle video

### DIFF
--- a/packages/metadata_attacher/src/fixtures/minimal_mets.xml
+++ b/packages/metadata_attacher/src/fixtures/minimal_mets.xml
@@ -9,8 +9,9 @@
             <premis:objectCharacteristics>
               <premis:objectCharacteristicsExtension>
                 <rdf:RDF>
-                  <rdf:Description>
+                  <rdf:Description xmlns:File="http://ns.exiftool.org/File/1.0/">
                     <ExifTool:ExifToolVersion>12.40</ExifTool:ExifToolVersion>
+                    <File:MIMEType>image/jpeg</File:MIMEType>
                   </rdf:Description>
                 </rdf:RDF>
               </premis:objectCharacteristicsExtension>

--- a/packages/metadata_attacher/src/fixtures/video_mediainfo.xml
+++ b/packages/metadata_attacher/src/fixtures/video_mediainfo.xml
@@ -1,0 +1,87 @@
+<mets:mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mets="http://www.loc.gov/METS/" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/version1121/mets.xsd">
+<mets:metsHdr CREATEDATE="2025-10-28T19:07:44"/>
+<mets:dmdSec ID="dmdSec_1" CREATED="2025-10-28T19:07:44" STATUS="original">
+<mets:mdWrap MDTYPE="PREMIS:OBJECT">
+<mets:xmlData>
+<premis:object xmlns:premis="http://www.loc.gov/premis/v3" xsi:type="premis:intellectualEntity" xsi:schemaLocation="http://www.loc.gov/premis/v3 http://www.loc.gov/standards/premis/v3/premis.xsd" version="3.0">
+<premis:objectIdentifier>
+<premis:objectIdentifierType>UUID</premis:objectIdentifierType>
+<premis:objectIdentifierValue>4a64ba7c-ceac-4547-ac13-c487b2711d5a</premis:objectIdentifierValue>
+</premis:objectIdentifier>
+<premis:originalName>test_video_upload-4a64ba7c-ceac-4547-ac13-c487b2711d5a</premis:originalName>
+</premis:object>
+</mets:xmlData>
+</mets:mdWrap>
+</mets:dmdSec>
+<mets:amdSec ID="amdSec_1">
+<mets:techMD ID="techMD_1">
+<mets:mdWrap MDTYPE="PREMIS:OBJECT">
+<mets:xmlData>
+<premis:object xmlns:premis="http://www.loc.gov/premis/v3" xsi:type="premis:file" xsi:schemaLocation="http://www.loc.gov/premis/v3 http://www.loc.gov/standards/premis/v3/premis.xsd" version="3.0">
+<premis:objectIdentifier>
+<premis:objectIdentifierType>UUID</premis:objectIdentifierType>
+<premis:objectIdentifierValue>b3c97850-9697-451a-8ad5-9f085188e890</premis:objectIdentifierValue>
+</premis:objectIdentifier>
+<premis:objectCharacteristics>
+<premis:compositionLevel>0</premis:compositionLevel>
+<premis:fixity>
+<premis:messageDigestAlgorithm>sha256</premis:messageDigestAlgorithm>
+<premis:messageDigest>abc123def456789</premis:messageDigest>
+</premis:fixity>
+<premis:size>5242880</premis:size>
+<premis:format>
+<premis:formatDesignation>
+<premis:formatName>MPEG-4 Media File</premis:formatName>
+<premis:formatVersion>2</premis:formatVersion>
+</premis:formatDesignation>
+<premis:formatRegistry>
+<premis:formatRegistryName>PRONOM</premis:formatRegistryName>
+<premis:formatRegistryKey>fmt/199</premis:formatRegistryKey>
+</premis:formatRegistry>
+</premis:format>
+<premis:creatingApplication>
+<premis:dateCreatedByApplication>2024-03-15T10:30:00Z</premis:dateCreatedByApplication>
+</premis:creatingApplication>
+<premis:objectCharacteristicsExtension>
+<MediaInfo xmlns="https://mediaarea.net/mediainfo" xsi:schemaLocation="https://mediaarea.net/mediainfo https://mediaarea.net/mediainfo/mediainfo_2_0.xsd" version="2.0">
+<creatingLibrary version="25.09" url="https://mediaarea.net/MediaInfo">MediaInfoLib</creatingLibrary>
+<media ref="/var/archivematica/test_video.mp4">
+<track type="General">
+<Count>300</Count>
+<StreamCount>2</StreamCount>
+<StreamKind>General</StreamKind>
+<StreamKind_String>General</StreamKind_String>
+<StreamKindID>0</StreamKindID>
+<VideoCount>1</VideoCount>
+<AudioCount>1</AudioCount>
+<Format>MPEG-4</Format>
+<Format_String>MPEG-4</Format_String>
+<InternetMediaType>video/mp4</InternetMediaType>
+<FileSize>5242880</FileSize>
+<Duration>120.5</Duration>
+<File_Created_Date>2024-03-15 10:30:00 UTC</File_Created_Date>
+<Recorded_Date>2024-03-15 10:30:00 UTC</Recorded_Date>
+</track>
+<track type="Video">
+<StreamKind>Video</StreamKind>
+<Format>AVC</Format>
+<Width>1920</Width>
+<Height>1080</Height>
+<FrameRate>30.000</FrameRate>
+</track>
+</media>
+</MediaInfo>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<rdf:Description xmlns:File="http://ns.exiftool.org/File/1.0/" rdf:about="/var/archivematica/test_video.mp4">
+<File:MIMEType>video/mp4</File:MIMEType>
+</rdf:Description>
+</rdf:RDF>
+</premis:objectCharacteristicsExtension>
+</premis:objectCharacteristics>
+<premis:originalName>%transferDirectory%objects/4a64ba7c-ceac-4547-ac13-c487b2711d5a</premis:originalName>
+</premis:object>
+</mets:xmlData>
+</mets:mdWrap>
+</mets:techMD>
+</mets:amdSec>
+</mets:mets>

--- a/packages/metadata_attacher/src/fixtures/video_no_timestamp.xml
+++ b/packages/metadata_attacher/src/fixtures/video_no_timestamp.xml
@@ -1,0 +1,85 @@
+<mets:mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mets="http://www.loc.gov/METS/" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/version1121/mets.xsd">
+<mets:metsHdr CREATEDATE="2025-10-28T19:07:44"/>
+<mets:dmdSec ID="dmdSec_1" CREATED="2025-10-28T19:07:44" STATUS="original">
+<mets:mdWrap MDTYPE="PREMIS:OBJECT">
+<mets:xmlData>
+<premis:object xmlns:premis="http://www.loc.gov/premis/v3" xsi:type="premis:intellectualEntity" xsi:schemaLocation="http://www.loc.gov/premis/v3 http://www.loc.gov/standards/premis/v3/premis.xsd" version="3.0">
+<premis:objectIdentifier>
+<premis:objectIdentifierType>UUID</premis:objectIdentifierType>
+<premis:objectIdentifierValue>6c64ba7c-ceac-4547-ac13-c487b2711d5c</premis:objectIdentifierValue>
+</premis:objectIdentifier>
+<premis:originalName>video_no_timestamp_upload-6c64ba7c-ceac-4547-ac13-c487b2711d5c</premis:originalName>
+</premis:object>
+</mets:xmlData>
+</mets:mdWrap>
+</mets:dmdSec>
+<mets:amdSec ID="amdSec_1">
+<mets:techMD ID="techMD_1">
+<mets:mdWrap MDTYPE="PREMIS:OBJECT">
+<mets:xmlData>
+<premis:object xmlns:premis="http://www.loc.gov/premis/v3" xsi:type="premis:file" xsi:schemaLocation="http://www.loc.gov/premis/v3 http://www.loc.gov/standards/premis/v3/premis.xsd" version="3.0">
+<premis:objectIdentifier>
+<premis:objectIdentifierType>UUID</premis:objectIdentifierType>
+<premis:objectIdentifierValue>d3c97850-9697-451a-8ad5-9f085188e892</premis:objectIdentifierValue>
+</premis:objectIdentifier>
+<premis:objectCharacteristics>
+<premis:compositionLevel>0</premis:compositionLevel>
+<premis:fixity>
+<premis:messageDigestAlgorithm>sha256</premis:messageDigestAlgorithm>
+<premis:messageDigest>xyz789ghi456jkl</premis:messageDigest>
+</premis:fixity>
+<premis:size>3145728</premis:size>
+<premis:format>
+<premis:formatDesignation>
+<premis:formatName>MPEG-4 Media File</premis:formatName>
+<premis:formatVersion>2</premis:formatVersion>
+</premis:formatDesignation>
+<premis:formatRegistry>
+<premis:formatRegistryName>PRONOM</premis:formatRegistryName>
+<premis:formatRegistryKey>fmt/199</premis:formatRegistryKey>
+</premis:formatRegistry>
+</premis:format>
+<premis:creatingApplication>
+<premis:dateCreatedByApplication>2024-01-10T08:00:00Z</premis:dateCreatedByApplication>
+</premis:creatingApplication>
+<premis:objectCharacteristicsExtension>
+<MediaInfo xmlns="https://mediaarea.net/mediainfo" xsi:schemaLocation="https://mediaarea.net/mediainfo https://mediaarea.net/mediainfo/mediainfo_2_0.xsd" version="2.0">
+<creatingLibrary version="25.09" url="https://mediaarea.net/MediaInfo">MediaInfoLib</creatingLibrary>
+<media ref="/var/archivematica/video_no_timestamp.mp4">
+<track type="General">
+<Count>300</Count>
+<StreamCount>2</StreamCount>
+<StreamKind>General</StreamKind>
+<StreamKind_String>General</StreamKind_String>
+<StreamKindID>0</StreamKindID>
+<VideoCount>1</VideoCount>
+<AudioCount>1</AudioCount>
+<Format>MPEG-4</Format>
+<Format_String>MPEG-4</Format_String>
+<InternetMediaType>video/mp4</InternetMediaType>
+<FileSize>3145728</FileSize>
+<Duration>60.0</Duration>
+</track>
+<track type="Video">
+<StreamKind>Video</StreamKind>
+<Format>AVC</Format>
+<Width>1280</Width>
+<Height>720</Height>
+<FrameRate>30.000</FrameRate>
+</track>
+</media>
+</MediaInfo>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<rdf:Description xmlns:File="http://ns.exiftool.org/File/1.0/" rdf:about="/var/archivematica/video_no_timestamp.mp4">
+<File:MIMEType>video/mp4</File:MIMEType>
+</rdf:Description>
+</rdf:RDF>
+</premis:objectCharacteristicsExtension>
+</premis:objectCharacteristics>
+<premis:originalName>%transferDirectory%objects/6c64ba7c-ceac-4547-ac13-c487b2711d5c</premis:originalName>
+</premis:object>
+</mets:xmlData>
+</mets:mdWrap>
+</mets:techMD>
+</mets:amdSec>
+</mets:mets>

--- a/packages/metadata_attacher/src/fixtures/video_quicktime.xml
+++ b/packages/metadata_attacher/src/fixtures/video_quicktime.xml
@@ -1,0 +1,86 @@
+<mets:mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mets="http://www.loc.gov/METS/" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/version1121/mets.xsd">
+<mets:metsHdr CREATEDATE="2025-10-28T19:07:44"/>
+<mets:dmdSec ID="dmdSec_1" CREATED="2025-10-28T19:07:44" STATUS="original">
+<mets:mdWrap MDTYPE="PREMIS:OBJECT">
+<mets:xmlData>
+<premis:object xmlns:premis="http://www.loc.gov/premis/v3" xsi:type="premis:intellectualEntity" xsi:schemaLocation="http://www.loc.gov/premis/v3 http://www.loc.gov/standards/premis/v3/premis.xsd" version="3.0">
+<premis:objectIdentifier>
+<premis:objectIdentifierType>UUID</premis:objectIdentifierType>
+<premis:objectIdentifierValue>5b64ba7c-ceac-4547-ac13-c487b2711d5b</premis:objectIdentifierValue>
+</premis:objectIdentifier>
+<premis:originalName>quicktime_video_upload-5b64ba7c-ceac-4547-ac13-c487b2711d5b</premis:originalName>
+</premis:object>
+</mets:xmlData>
+</mets:mdWrap>
+</mets:dmdSec>
+<mets:amdSec ID="amdSec_1">
+<mets:techMD ID="techMD_1">
+<mets:mdWrap MDTYPE="PREMIS:OBJECT">
+<mets:xmlData>
+<premis:object xmlns:premis="http://www.loc.gov/premis/v3" xsi:type="premis:file" xsi:schemaLocation="http://www.loc.gov/premis/v3 http://www.loc.gov/standards/premis/v3/premis.xsd" version="3.0">
+<premis:objectIdentifier>
+<premis:objectIdentifierType>UUID</premis:objectIdentifierType>
+<premis:objectIdentifierValue>c3c97850-9697-451a-8ad5-9f085188e891</premis:objectIdentifierValue>
+</premis:objectIdentifier>
+<premis:objectCharacteristics>
+<premis:compositionLevel>0</premis:compositionLevel>
+<premis:fixity>
+<premis:messageDigestAlgorithm>sha256</premis:messageDigestAlgorithm>
+<premis:messageDigest>def456abc789012</premis:messageDigest>
+</premis:fixity>
+<premis:size>7340032</premis:size>
+<premis:format>
+<premis:formatDesignation>
+<premis:formatName>Quicktime</premis:formatName>
+<premis:formatVersion></premis:formatVersion>
+</premis:formatDesignation>
+<premis:formatRegistry>
+<premis:formatRegistryName>PRONOM</premis:formatRegistryName>
+<premis:formatRegistryKey>x-fmt/384</premis:formatRegistryKey>
+</premis:formatRegistry>
+</premis:format>
+<premis:creatingApplication>
+<premis:dateCreatedByApplication>2023-08-20T14:15:30Z</premis:dateCreatedByApplication>
+</premis:creatingApplication>
+<premis:objectCharacteristicsExtension>
+<MediaInfo xmlns="https://mediaarea.net/mediainfo" xsi:schemaLocation="https://mediaarea.net/mediainfo https://mediaarea.net/mediainfo/mediainfo_2_0.xsd" version="2.0">
+<creatingLibrary version="25.09" url="https://mediaarea.net/MediaInfo">MediaInfoLib</creatingLibrary>
+<media ref="/var/archivematica/quicktime_video.mov">
+<track type="General">
+<Count>300</Count>
+<StreamCount>2</StreamCount>
+<StreamKind>General</StreamKind>
+<StreamKind_String>General</StreamKind_String>
+<StreamKindID>0</StreamKindID>
+<VideoCount>1</VideoCount>
+<AudioCount>1</AudioCount>
+<Format>QuickTime</Format>
+<Format_String>QuickTime</Format_String>
+<InternetMediaType>video/quicktime</InternetMediaType>
+<FileSize>7340032</FileSize>
+<Duration>90.0</Duration>
+</track>
+<track type="Video">
+<StreamKind>Video</StreamKind>
+<Format>AVC</Format>
+<Width>1280</Width>
+<Height>720</Height>
+<FrameRate>24.000</FrameRate>
+</track>
+</media>
+</MediaInfo>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<rdf:Description xmlns:File="http://ns.exiftool.org/File/1.0/" xmlns:QuickTime="http://ns.exiftool.org/QuickTime/QuickTime/1.0/" rdf:about="/var/archivematica/quicktime_video.mov">
+<File:MIMEType>video/quicktime</File:MIMEType>
+<QuickTime:CreationDate>2023:08:20 14:15:30+00:00</QuickTime:CreationDate>
+</rdf:Description>
+</rdf:RDF>
+</premis:objectCharacteristicsExtension>
+</premis:objectCharacteristics>
+<premis:originalName>%transferDirectory%objects/5b64ba7c-ceac-4547-ac13-c487b2711d5b</premis:originalName>
+</premis:object>
+</mets:xmlData>
+</mets:mdWrap>
+</mets:techMD>
+</mets:amdSec>
+</mets:mets>

--- a/packages/metadata_attacher/src/index.ts
+++ b/packages/metadata_attacher/src/index.ts
@@ -13,8 +13,14 @@ import type {
 	MetsMetadata,
 	MetsAdministrativeSection,
 	EmbeddedMetadata,
+	TrackMetadata,
 } from "./models";
 import { validateMetsMetadata } from "./validators";
+import {
+	getISOStringFromExifTimestamp,
+	getISOStringFromMediaInfoTimestamp,
+	getISOStringFromQuicktimeTimestamp,
+} from "./timestamps";
 
 const getOriginalAdministrativeSectionFromMetsFile = (
 	fileId: string,
@@ -53,25 +59,6 @@ const getOriginalAdministrativeSectionFromMetsFile = (
 		return originalAdministrativeSections[0];
 	}
 	return administrativeSections;
-};
-
-const getISOStringFromExifTimestamp = (
-	exifTimestamp: string,
-	exifOffset: string | undefined,
-): string | undefined => {
-	const timestampPieces = exifTimestamp.split(" ");
-	if (timestampPieces[0] === undefined || timestampPieces[1] === undefined) {
-		logger.warn(`Invalid timestamp: ${exifTimestamp}`);
-		return undefined;
-	}
-	const dateComponent = timestampPieces[0].replaceAll(":", "-");
-	const [, timeComponent] = timestampPieces;
-	return (
-		dateComponent +
-		"T" +
-		timeComponent +
-		(exifOffset === undefined ? "" : exifOffset === "+00:00" ? "Z" : exifOffset)
-	);
 };
 
 const getEmbeddedMetadataFromS3 = async (
@@ -116,10 +103,133 @@ const getEmbeddedMetadataFromS3 = async (
 		},
 	} = administrativeSection;
 
-	return objectCharacteristicsExtensionSection === undefined
-		? undefined
-		: objectCharacteristicsExtensionSection["rdf:RDF"]["rdf:Description"];
+	return objectCharacteristicsExtensionSection;
 };
+
+const getPhotoMetadata = (
+	embeddedMetadata: EmbeddedMetadata,
+): {
+	creationTime: Date | undefined;
+	creationTimeInEdtf: string | undefined;
+	tags: string[] | undefined;
+	description: string | undefined;
+	title: string | undefined;
+	altText: string | undefined;
+} => {
+	const {
+		"rdf:RDF": { "rdf:Description": rdfMetadata },
+	} = embeddedMetadata;
+
+	const timestamp =
+		rdfMetadata["ExifIFD:DateTimeOriginal"] === undefined
+			? undefined
+			: getISOStringFromExifTimestamp(
+					rdfMetadata["ExifIFD:DateTimeOriginal"],
+					rdfMetadata["ExifIFD:OffsetTimeOriginal"],
+				);
+	const tags =
+		rdfMetadata["IPTC:Keywords"] === undefined
+			? undefined
+			: rdfMetadata["IPTC:Keywords"]["rdf:Bag"]["rdf:li"];
+
+	return {
+		creationTime:
+			rdfMetadata["ExifIFD:OffsetTimeOriginal"] === undefined ||
+			timestamp === undefined
+				? undefined
+				: new Date(timestamp),
+		creationTimeInEdtf: timestamp,
+		tags,
+		description:
+			rdfMetadata["IPTC:Caption-Abstract"] ??
+			rdfMetadata["ExifIFD:UserComment"] ??
+			rdfMetadata["ExifIFD:Comments"],
+		title: rdfMetadata["IPTC:ObjectName"] ?? rdfMetadata["ExifIFD:Title"],
+		altText: rdfMetadata["XMP-iptcCore:AltTextAccessibility"],
+	};
+};
+
+const getVideoMetadataFromMediaInfo = (
+	embeddedMetadata: EmbeddedMetadata,
+):
+	| {
+			creationTime: Date | undefined;
+			creationTimeInEdtf: string | undefined;
+	  }
+	| undefined => {
+	const tracks = embeddedMetadata.MediaInfo?.media.track;
+	if (tracks === undefined) {
+		return undefined;
+	}
+
+	const generalTracks = tracks.filter(
+		(track: TrackMetadata) => track.StreamKind === "General",
+	);
+	if (generalTracks.length > 1) {
+		logger.info(
+			`Video Metadata contains too many general tracks, expected 1; got ${generalTracks.length}`,
+		);
+		return undefined;
+	}
+
+	const [generalTrack] = generalTracks;
+	if (generalTrack === undefined) {
+		return undefined;
+	}
+
+	const timestampFromMediaInfo =
+		generalTrack.File_Created_Date ??
+		generalTrack.Recorded_Date ??
+		generalTrack.Encoded_Date;
+	if (timestampFromMediaInfo === undefined) {
+		return undefined;
+	}
+
+	const isoFormattedTimestamp = getISOStringFromMediaInfoTimestamp(
+		timestampFromMediaInfo,
+	);
+
+	return {
+		creationTime:
+			isoFormattedTimestamp === undefined
+				? undefined
+				: new Date(isoFormattedTimestamp),
+		creationTimeInEdtf: isoFormattedTimestamp,
+	};
+};
+
+const getVideoMetadataFromQuickTimeMetadata = (
+	embeddedMetadata: EmbeddedMetadata,
+): {
+	creationTime: Date | undefined;
+	creationTimeInEdtf: string | undefined;
+} => {
+	const {
+		"rdf:RDF": {
+			"rdf:Description": { "QuickTime:CreationDate": quicktimeTimestamp },
+		},
+	} = embeddedMetadata;
+	const isoFormattedTimestamp =
+		quicktimeTimestamp === undefined
+			? undefined
+			: getISOStringFromQuicktimeTimestamp(quicktimeTimestamp);
+	return {
+		creationTime:
+			isoFormattedTimestamp === undefined
+				? undefined
+				: new Date(isoFormattedTimestamp),
+		creationTimeInEdtf: isoFormattedTimestamp,
+	};
+};
+
+const getVideoMetadata = (
+	embeddedMetadata: EmbeddedMetadata,
+): {
+	creationTime: Date | undefined;
+	creationTimeInEdtf: string | undefined;
+} =>
+	getVideoMetadataFromMediaInfo(embeddedMetadata) ??
+	getVideoMetadataFromQuickTimeMetadata(embeddedMetadata);
 
 export const handler: SQSHandler = Sentry.wrapHandler(
 	async (event: SQSEvent, _, __) => {
@@ -145,37 +255,37 @@ export const handler: SQSHandler = Sentry.wrapHandler(
 					return;
 				}
 
-				const timestamp =
-					embeddedMetadata["ExifIFD:DateTimeOriginal"] === undefined
-						? undefined
-						: getISOStringFromExifTimestamp(
-								embeddedMetadata["ExifIFD:DateTimeOriginal"],
-								embeddedMetadata["ExifIFD:OffsetTimeOriginal"],
-							);
-				const tags =
-					embeddedMetadata["IPTC:Keywords"] === undefined
-						? undefined
-						: embeddedMetadata["IPTC:Keywords"]["rdf:Bag"]["rdf:li"];
-
-				await db.sql("queries.update_metadata", {
-					fileId,
-					fileTags: tags,
-					nameFromEmbeddedMetadata:
-						embeddedMetadata["IPTC:ObjectName"] ??
-						embeddedMetadata["ExifIFD:Title"],
-					descriptionFromEmbeddedMetadata:
-						embeddedMetadata["IPTC:Caption-Abstract"] ??
-						embeddedMetadata["ExifIFD:UserComment"] ??
-						embeddedMetadata["ExifIFD:Comments"],
-					timestampFromEmbeddedMetadata:
-						embeddedMetadata["ExifIFD:OffsetTimeOriginal"] === undefined ||
-						timestamp === undefined
-							? null
-							: new Date(timestamp).toISOString(),
-					timeFromEmbeddedMetadata: timestamp,
-					altTextFromEmbeddedMetadata:
-						embeddedMetadata["XMP-iptcCore:AltTextAccessibility"],
-				});
+				const {
+					"rdf:RDF": {
+						"rdf:Description": { "File:MIMEType": mimeType },
+					},
+				} = embeddedMetadata;
+				const [mimeCategory] = mimeType.split("/");
+				if (mimeCategory === "image") {
+					const photoMetadata = getPhotoMetadata(embeddedMetadata);
+					await db.sql("queries.update_metadata", {
+						fileId,
+						fileTags: photoMetadata.tags,
+						nameFromEmbeddedMetadata: photoMetadata.title,
+						descriptionFromEmbeddedMetadata: photoMetadata.description,
+						timestampFromEmbeddedMetadata:
+							photoMetadata.creationTime?.toISOString(),
+						timeFromEmbeddedMetadata: photoMetadata.creationTimeInEdtf,
+						altTextFromEmbeddedMetadata: photoMetadata.altText,
+					});
+				} else if (mimeCategory === "video") {
+					const videoMetadata = getVideoMetadata(embeddedMetadata);
+					await db.sql("queries.update_metadata", {
+						fileId,
+						timestampFromEmbeddedMetadata:
+							videoMetadata.creationTime?.toISOString(),
+						timeFromEmbeddedMetadata: videoMetadata.creationTimeInEdtf,
+						fileTags: [],
+						nameFromEmbeddedMetadata: null,
+						descriptionFromEmbeddedMetadata: null,
+						altTextFromEmbeddedMetadata: null,
+					});
+				}
 			}),
 		);
 	},

--- a/packages/metadata_attacher/src/models.ts
+++ b/packages/metadata_attacher/src/models.ts
@@ -12,11 +12,7 @@ export interface MetsAdministrativeSection {
 					"premis:originalName": string;
 					"premis:objectCharacteristics": {
 						"premis:objectCharacteristicsExtension":
-							| {
-									"rdf:RDF": {
-										"rdf:Description": EmbeddedMetadata;
-									};
-							  }
+							| EmbeddedMetadata
 							| undefined;
 					};
 				};
@@ -25,7 +21,15 @@ export interface MetsAdministrativeSection {
 	};
 }
 
-export interface EmbeddedMetadata {
+export interface TrackMetadata {
+	StreamKind: string;
+	File_Created_Date: string | undefined;
+	Recorded_Date: string | undefined;
+	Encoded_Date: string | undefined;
+}
+
+export interface RdfMetadata {
+	"File:MIMEType": string;
 	"IPTC:ObjectName": string | undefined;
 	"IPTC:Caption-Abstract": string | undefined;
 	"IPTC:Keywords":
@@ -41,4 +45,18 @@ export interface EmbeddedMetadata {
 	"ExifIFD:DateTimeOriginal": string | undefined;
 	"ExifIFD:OffsetTimeOriginal": string | undefined;
 	"XMP-iptcCore:AltTextAccessibility": string | undefined;
+	"QuickTime:CreationDate": string | undefined;
+}
+
+export interface EmbeddedMetadata {
+	"rdf:RDF": {
+		"rdf:Description": RdfMetadata;
+	};
+	MediaInfo:
+		| {
+				media: {
+					track: TrackMetadata[];
+				};
+		  }
+		| undefined;
 }

--- a/packages/metadata_attacher/src/timestamps.ts
+++ b/packages/metadata_attacher/src/timestamps.ts
@@ -1,0 +1,89 @@
+import { logger } from "@stela/logger";
+
+type ExifTimestamp =
+	`${number}${number}${number}${number}:${number}${number}:${number}${number} ${number}${number}:${number}${number}:${number}${number}`;
+const isExifTimestamp = (value: string): value is ExifTimestamp =>
+	/^(\d{4}):(0[1-9]|1[0-2]):(0[1-9]|[12]\d|3[01]) ([01]\d|2[0-3]):[0-5]\d:[0-5]\d$/.test(
+		value,
+	);
+export const getISOStringFromExifTimestamp = (
+	exifTimestamp: string,
+	exifOffset: string | undefined,
+): string | undefined => {
+	// We expect exifTimestamp to be of the form YYYY:MM:DD HH:MM:SS
+	// We expect exifOffset to be of the form ±HH:MM
+	if (!isExifTimestamp(exifTimestamp)) {
+		logger.info(`Invalid timestamp: ${exifTimestamp}`);
+		return undefined;
+	}
+	const timestampPieces = exifTimestamp.split(" ");
+	if (timestampPieces[0] === undefined || timestampPieces[1] === undefined) {
+		logger.info(`Invalid timestamp: ${exifTimestamp}`);
+		return undefined;
+	}
+	const dateComponent = timestampPieces[0].replaceAll(":", "-");
+	const [, timeComponent] = timestampPieces;
+	return (
+		dateComponent +
+		"T" +
+		timeComponent +
+		(exifOffset === undefined ? "" : exifOffset === "+00:00" ? "Z" : exifOffset)
+	);
+};
+
+type MediaInfoTimestamp =
+	`${number}${number}${number}${number}-${number}${number}-${number}${number} ${number}${number}:${number}${number}:${number}${number} UTC`;
+const isMediaInfoTimestamp = (value: string): value is MediaInfoTimestamp =>
+	/^(\d{4})-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]) ([01]\d|2[0-3]):[0-5]\d:[0-5]\d UTC$/.test(
+		value,
+	);
+export const getISOStringFromMediaInfoTimestamp = (
+	timestamp: string,
+): string | undefined => {
+	// We expect timestamp to be of the form YYYY-MM-DD HH:MM:SS UTC
+	if (!isMediaInfoTimestamp(timestamp)) {
+		logger.info(`Invalid timestamp: ${timestamp}`);
+		return undefined;
+	}
+	const timestampPieces = timestamp.split(" ");
+	const [dateComponent, timeComponent, timezoneComponent] = timestampPieces;
+	if (
+		dateComponent === undefined ||
+		timeComponent === undefined ||
+		timezoneComponent === undefined
+	) {
+		logger.info(`Invalid timestamp: ${timestamp}`);
+		return undefined;
+	}
+	if (timezoneComponent !== "UTC") {
+		logger.info(
+			`MediaInfo timestamps should be in UTC, this one has timezone: ${timezoneComponent}`,
+		);
+		return undefined;
+	}
+	return dateComponent + "T" + timeComponent + "Z";
+};
+
+type QuicktimeTimestamp =
+	`${number}${number}${number}${number}:${number}${number}:${number}${number} ${number}${number}:${number}${number}:${number}${number}${"+" | "-"}${number}${number}:${number}${number}`;
+const isQuicktimeTimestamp = (value: string): value is QuicktimeTimestamp =>
+	/^(\d{4}):(0[1-9]|1[0-2]):(0[1-9]|[12]\d|3[01]) ([01]\d|2[0-3]):[0-5]\d:[0-5]\d(\+|-)([01]\d|2[0-3]):[0-5]\d$/.test(
+		value,
+	);
+export const getISOStringFromQuicktimeTimestamp = (
+	timestamp: string,
+): string | undefined => {
+	// We expect timestamp to be of the form YYYY:MM:DD HH:MM:SS±HH:MM
+	if (!isQuicktimeTimestamp(timestamp)) {
+		logger.info(`Invalid timestamp: ${timestamp}`);
+		return undefined;
+	}
+	const timestampPieces = timestamp.split(" ");
+	if (timestampPieces[0] === undefined || timestampPieces[1] === undefined) {
+		logger.info(`Invalid timestamp: ${timestamp}`);
+		return undefined;
+	}
+	const dateComponent = timestampPieces[0].replaceAll(":", "-");
+	const timeComponent = timestampPieces[1].replace("+00:00", "Z");
+	return dateComponent + "T" + timeComponent;
+};

--- a/packages/metadata_attacher/src/validators.ts
+++ b/packages/metadata_attacher/src/validators.ts
@@ -2,7 +2,8 @@ import Joi from "joi";
 import { logger } from "@stela/logger";
 import type { MetsMetadata } from "./models";
 
-const embeddedMetadataSchema = Joi.object({
+const rdfMetadataSchema = Joi.object({
+	"File:MIMEType": Joi.string().required(),
 	"IPTC:ObjectName": Joi.string().optional(),
 	"IPTC:Caption-Abstract": Joi.string().optional(),
 	"IPTC:Keywords": Joi.object({
@@ -10,9 +11,37 @@ const embeddedMetadataSchema = Joi.object({
 			"rdf:li": Joi.array().items(Joi.string()).required(),
 		}).required(),
 	}).optional(),
+	"ExifIFD:Title": Joi.string().optional(),
+	"ExifIFD:UserComment": Joi.string().optional(),
+	"ExifIFD:Comments": Joi.string().optional(),
 	"ExifIFD:DateTimeOriginal": Joi.string().optional(),
 	"ExifIFD:OffsetTimeOriginal": Joi.string().optional(),
 	"XMP-iptcCore:AltTextAccessibility": Joi.string().optional(),
+	"QuickTime:CreationDate": Joi.string().optional(),
+}).unknown(true);
+
+const trackMetadataSchema = Joi.object({
+	StreamKind: Joi.string().required(),
+	File_Created_Date: Joi.string().optional(),
+	Recorded_Date: Joi.string().optional(),
+	Encoded_Date: Joi.string().optional(),
+}).unknown(true);
+
+const embeddedMetadataSchema = Joi.object({
+	"rdf:RDF": Joi.object({
+		"rdf:Description": rdfMetadataSchema.required(),
+	})
+		.required()
+		.unknown(true),
+	MediaInfo: Joi.object({
+		media: Joi.object({
+			track: Joi.array().items(trackMetadataSchema).required(),
+		})
+			.required()
+			.unknown(true),
+	})
+		.optional()
+		.unknown(true),
 }).unknown(true);
 
 const metsAdministrativeSectionSchema = Joi.object({
@@ -22,15 +51,8 @@ const metsAdministrativeSectionSchema = Joi.object({
 				"premis:object": Joi.object({
 					"premis:originalName": Joi.string().required(),
 					"premis:objectCharacteristics": Joi.object({
-						"premis:objectCharacteristicsExtension": Joi.object({
-							"rdf:RDF": Joi.object({
-								"rdf:Description": embeddedMetadataSchema.required(),
-							})
-								.required()
-								.unknown(true),
-						})
-							.optional()
-							.unknown(true),
+						"premis:objectCharacteristicsExtension":
+							embeddedMetadataSchema.optional(),
 					})
 						.required()
 						.unknown(true),


### PR DESCRIPTION
We would like our to extract timestamp data from the Archivematica-generated metadata for videos uploaded to Permanent. Video metadata is shaped differently than image metadata, so this commit updates the metadata attacher lambda to handle both.