### PR TITLE
Use AWS EKS addons to handle DNS setup for the prod cluster

### DIFF
--- a/terraform/prod_cluster/eks-cluster.tf
+++ b/terraform/prod_cluster/eks-cluster.tf
@@ -22,6 +22,24 @@ module "eks" {
     }
   }
 
+  addons = {
+    coredns = {
+      most_recent                 = true
+      resolve_conflicts_on_create = "OVERWRITE"
+      resolve_conflicts           = "OVERWRITE"
+    }
+    kube-proxy = {
+      most_recent                 = true
+      resolve_conflicts_on_create = "OVERWRITE"
+      resolve_conflicts           = "OVERWRITE"
+    }
+    vpc-cni = {
+      most_recent                 = true
+      resolve_conflicts_on_create = "OVERWRITE"
+      resolve_conflicts           = "OVERWRITE"
+    }
+  }
+
   eks_managed_node_groups = {
     one = {
       ami_type = "AL2023_x86_64_STANDARD"


### PR DESCRIPTION
Somehow these add-ons got removed, probably through some kind of git mistake. This adds them back in order to fix our DNS on the prod cluster.