### PR TITLE
Update dependabot cadence

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,7 +3,11 @@ updates:
   - package-ecosystem: "npm"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: 'monthly'
+      time: '00:00'
+      timezone: 'Etc/UTC'
+    cooldown:
+      default-days: 7
     ignore:
       - dependency-name: "@types/node"
         update-types: ["version-update:semver-major"]
@@ -29,54 +33,98 @@ updates:
   - package-ecosystem: "npm"
     directory: "/packages/access_copy_attacher"
     schedule:
-      interval: "daily"
+      interval: 'monthly'
+      time: '00:00'
+      timezone: 'Etc/UTC'
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "npm"
     directory: "/packages/account_space_updater"
     schedule:
-      interval: "daily"
+      interval: 'monthly'
+      time: '00:00'
+      timezone: 'Etc/UTC'
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "npm"
     directory: "/packages/api"
     schedule:
-      interval: "daily"
+      interval: 'monthly'
+      time: '00:00'
+      timezone: 'Etc/UTC'
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "npm"
     directory: "/packages/archivematica_cleanup"
     schedule:
-      interval: "daily"
+      interval: 'monthly'
+      time: '00:00'
+      timezone: 'Etc/UTC'
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "npm"
     directory: "/packages/archivematica-utils"
     schedule:
-      interval: "daily"
+      interval: 'monthly'
+      time: '00:00'
+      timezone: 'Etc/UTC'
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "npm"
     directory: "/packages/file-utils"
     schedule:
-      interval: "daily"
+      interval: 'monthly'
+      time: '00:00'
+      timezone: 'Etc/UTC'
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "npm"
     directory: "/packages/logger"
     schedule:
-      interval: "daily"
+      interval: 'monthly'
+      time: '00:00'
+      timezone: 'Etc/UTC'
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "npm"
     directory: "/packages/record_thumbnail_attacher"
     schedule:
-      interval: "daily"
+      interval: 'monthly'
+      time: '00:00'
+      timezone: 'Etc/UTC'
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "npm"
     directory: "/packages/s3-utils"
     schedule:
-      interval: "daily"
+      interval: 'monthly'
+      time: '00:00'
+      timezone: 'Etc/UTC'
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "npm"
     directory: "/packages/thumbnail_refresh"
     schedule:
-      interval: "daily"
+      interval: 'monthly'
+      time: '00:00'
+      timezone: 'Etc/UTC'
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: "github-actions"
     directory: ".github/workflows"
     schedule:
-      interval: "weekly"
+      interval: 'monthly'
+      time: '00:00'
+      timezone: 'Etc/UTC'
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
This PR shifts to monthly dependabot updates + a 7-day cooldown.

There's no issue since we're doing this everywhere.