### PR TITLE
Add description to record PATCH

### DIFF
--- a/packages/api/docs/src/paths/record.yaml
+++ b/packages/api/docs/src/paths/record.yaml
@@ -56,6 +56,8 @@ record/{id}:
           schema:
             type: object
             properties:
+              displayName:
+                type: string
               locationId:
                 type: integer
               description:
@@ -72,6 +74,10 @@ record/{id}:
                   $ref: "../models/record.yaml#/record"
       "400":
         $ref: "../errors.yaml#/400"
+      "403":
+        $ref: "../errors.yaml#/403"
+      "404":
+        $ref: "../errors.yaml#/404"
       "500":
         $ref: "../errors.yaml#/500"
 records-id-share-links:

--- a/packages/api/src/record/controller.test.ts
+++ b/packages/api/src/record/controller.test.ts
@@ -546,6 +546,92 @@ describe("PATCH /record", () => {
 		);
 		await agent.patch("/api/v2/record/1").send({ locationId: 123 }).expect(404);
 	});
+
+	test("expect display name is updated", async () => {
+		await agent
+			.patch("/api/v2/record/1")
+			.send({ displayName: "New Name" })
+			.expect(200);
+
+		const result = await db.query(
+			"SELECT displayname FROM record WHERE recordId = :recordId",
+			{
+				recordId: 1,
+			},
+		);
+
+		expect(result.rows[0]).toEqual({ displayname: "New Name" });
+	});
+
+	test("expect display name and description are updated together", async () => {
+		await agent
+			.patch("/api/v2/record/1")
+			.send({ displayName: "Updated Name", description: "Updated description" })
+			.expect(200);
+
+		const result = await db.query(
+			"SELECT displayname, description FROM record WHERE recordId = :recordId",
+			{
+				recordId: 1,
+			},
+		);
+
+		expect(result.rows[0]).toEqual({
+			displayname: "Updated Name",
+			description: "Updated description",
+		});
+	});
+
+	test("expect all fields are updated together", async () => {
+		await agent
+			.patch("/api/v2/record/1")
+			.send({
+				displayName: "All Fields Name",
+				description: "All fields description",
+				locationId: 456,
+			})
+			.expect(200);
+
+		const result = await db.query(
+			"SELECT displayname, description, locnid FROM record WHERE recordId = :recordId",
+			{
+				recordId: 1,
+			},
+		);
+
+		expect(result.rows[0]).toEqual({
+			displayname: "All Fields Name",
+			description: "All fields description",
+			locnid: "456",
+		});
+	});
+
+	test("expect 400 error if display name is empty string", async () => {
+		await agent
+			.patch("/api/v2/record/1")
+			.send({
+				displayName: "",
+			})
+			.expect(400);
+	});
+
+	test("expect 400 error if display name is null", async () => {
+		await agent
+			.patch("/api/v2/record/1")
+			.send({
+				displayName: null,
+			})
+			.expect(400);
+	});
+
+	test("expect 400 error if display name is wrong type", async () => {
+		await agent
+			.patch("/api/v2/record/1")
+			.send({
+				displayName: false,
+			})
+			.expect(400);
+	});
 });
 
 describe("GET /record/{id}/share-links", () => {

--- a/packages/api/src/record/helper.ts
+++ b/packages/api/src/record/helper.ts
@@ -6,5 +6,6 @@ export const requestFieldsToDatabaseFields = (
 ): RecordColumnsForUpdate => ({
 	locnid: request.locationId,
 	description: request.description,
+	displayname: request.displayName,
 	recordId,
 });

--- a/packages/api/src/record/models.ts
+++ b/packages/api/src/record/models.ts
@@ -110,14 +110,16 @@ export interface ArchiveFile {
 
 export interface RecordColumnsForUpdate {
 	recordId: string;
-	locnid: bigint;
-	description: string;
+	locnid: bigint | undefined;
+	description: string | undefined;
+	displayname: string | undefined;
 }
 
 export interface PatchRecordRequest {
 	emailFromAuthToken: string;
-	locationId: bigint;
-	description: string;
+	locationId?: bigint;
+	description?: string;
+	displayName?: string;
 }
 
 export enum RecordStatus {

--- a/packages/api/src/record/service.test.ts
+++ b/packages/api/src/record/service.test.ts
@@ -1,0 +1,18 @@
+import createError from "http-errors";
+import { buildPatchQuery } from "./service";
+import type { RecordColumnsForUpdate } from "./models";
+
+describe("buildPatchQuery", () => {
+	test("should throw BadRequest error when no updates are provided", () => {
+		const columnsForUpdate: RecordColumnsForUpdate = {
+			recordId: "1",
+			locnid: undefined,
+			description: undefined,
+			displayname: undefined,
+		};
+
+		expect(() => buildPatchQuery(columnsForUpdate)).toThrow(
+			createError.BadRequest("Request cannot be empty"),
+		);
+	});
+});

--- a/packages/api/src/record/service.ts
+++ b/packages/api/src/record/service.ts
@@ -60,7 +60,9 @@ const validateCanPatchRecord = async (
 	}
 };
 
-const buildPatchQuery = (columnsForUpdate: RecordColumnsForUpdate): string => {
+export const buildPatchQuery = (
+	columnsForUpdate: RecordColumnsForUpdate,
+): string => {
 	const updates = Object.entries(columnsForUpdate)
 		.filter(([key, value]) => value !== undefined && key !== "recordId")
 		.map(([key, _]) => `${key} = :${key}`);

--- a/packages/api/src/record/validators.ts
+++ b/packages/api/src/record/validators.ts
@@ -41,7 +41,12 @@ export const validatePatchRecordRequest: (
 			...fieldsFromUserAuthentication,
 			locationId: Joi.number().integer().optional().allow(null),
 			description: Joi.string().optional().allow(null),
+			displayName: Joi.string().min(1).optional(),
 		})
+		// We can't use .min(1) here due to the auth fields being in the body
+		// See: https://github.com/PermanentOrg/stela/issues/407
+		.or("locationId", "description", "displayName")
+		.unknown(false)
 		.validate(data);
 
 	if (validation.error !== undefined) {


### PR DESCRIPTION
This PR adds support for editing the description to records via PATCH.

It also updates the PATCH endpoint so that each individual attribute is optional, which is more true to the intent of that HTTP verb.

Resolves #580 