### PR TITLE
Remove redundant dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,8 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "ts-md5"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "uuid"
+        update-types: ["version-update:semver-major"]
     groups:
       eslint:
         patterns:


### PR DESCRIPTION
This PR updates our Dependabot config to remove redundancy.

If we ever need to configure a specific package differently we can always do so, but for now a single root config will still result in bumps within workspace packages.

Resolves #587

See: https://github.com/dependabot/dependabot-core/issues/4993#issuecomment-1289133027