### PR TITLE
Ignore major UUID

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -20,6 +20,8 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "ts-md5"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "uuid"
+        update-types: ["version-update:semver-major"]
     groups:
       eslint:
         patterns:


### PR DESCRIPTION
This PR ignores major new UUID versions -- if / when we move stela to ESM we can remove this rule.