### PR TITLE
Update kubernetes to 1.33

### DIFF
--- a/terraform/prod_cluster/eks-cluster.tf
+++ b/terraform/prod_cluster/eks-cluster.tf
@@ -3,7 +3,7 @@ module "eks" {
   version = "21.2.0"
 
   name               = local.cluster_name
-  kubernetes_version = "1.32"
+  kubernetes_version = "1.33"
 
   vpc_id                 = var.vpc_id
   subnet_ids             = var.subnet_ids

--- a/terraform/test_cluster/eks-cluster.tf
+++ b/terraform/test_cluster/eks-cluster.tf
@@ -3,7 +3,7 @@ module "eks" {
   version = "21.2.0"
 
   name               = local.cluster_name
-  kubernetes_version = "1.32"
+  kubernetes_version = "1.33"
 
   vpc_id                 = var.vpc_id
   subnet_ids             = var.subnet_ids


### PR DESCRIPTION
Currently we're on kubernetes 1.32; this will leave standard support in EKS before the end of the quarter