### PR TITLE
Use Node 24 on lambdas

### DIFF
--- a/Dockerfile.access_copy_attacher
+++ b/Dockerfile.access_copy_attacher
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/nodejs:22 as builder
+FROM public.ecr.aws/lambda/nodejs:24 as builder
 WORKDIR /usr/local/apps/stela/
 
 COPY package.json ./
@@ -13,7 +13,7 @@ RUN npm install -ws
 RUN npm run build -ws
 
 
-FROM public.ecr.aws/lambda/nodejs:22 as final
+FROM public.ecr.aws/lambda/nodejs:24 as final
 
 ARG AWS_RDS_CERT_BUNDLE
 

--- a/Dockerfile.account_space_updater
+++ b/Dockerfile.account_space_updater
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/nodejs:22 as builder
+FROM public.ecr.aws/lambda/nodejs:24 as builder
 WORKDIR /usr/local/apps/stela/
 
 COPY package.json ./
@@ -13,7 +13,7 @@ RUN npm install -ws
 RUN npm run build -ws
 
 
-FROM public.ecr.aws/lambda/nodejs:22 as final
+FROM public.ecr.aws/lambda/nodejs:24 as final
 
 ARG AWS_RDS_CERT_BUNDLE
 

--- a/Dockerfile.metadata_attacher
+++ b/Dockerfile.metadata_attacher
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/nodejs:22 as builder
+FROM public.ecr.aws/lambda/nodejs:24 as builder
 WORKDIR /usr/local/apps/stela/
 
 COPY package.json ./
@@ -13,7 +13,7 @@ RUN npm install -ws
 RUN npm run build -ws
 
 
-FROM public.ecr.aws/lambda/nodejs:22 as final
+FROM public.ecr.aws/lambda/nodejs:24 as final
 
 ARG AWS_RDS_CERT_BUNDLE
 

--- a/Dockerfile.record_thumbnail_attacher
+++ b/Dockerfile.record_thumbnail_attacher
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/nodejs:22 as builder
+FROM public.ecr.aws/lambda/nodejs:24 as builder
 WORKDIR /usr/local/apps/stela/
 
 COPY package.json ./
@@ -13,7 +13,7 @@ RUN npm install -ws
 RUN npm run build -ws
 
 
-FROM public.ecr.aws/lambda/nodejs:22 as final
+FROM public.ecr.aws/lambda/nodejs:24 as final
 
 ARG AWS_RDS_CERT_BUNDLE
 

--- a/Dockerfile.trigger_archivematica
+++ b/Dockerfile.trigger_archivematica
@@ -1,4 +1,4 @@
-FROM public.ecr.aws/lambda/nodejs:22 as builder
+FROM public.ecr.aws/lambda/nodejs:24 as builder
 WORKDIR /usr/local/apps/stela/
 
 COPY package.json ./
@@ -13,7 +13,7 @@ RUN npm install -ws
 RUN npm run build -ws
 
 
-FROM public.ecr.aws/lambda/nodejs:22 as final
+FROM public.ecr.aws/lambda/nodejs:24 as final
 
 ARG AWS_RDS_CERT_BUNDLE
 

--- a/packages/access_copy_attacher/package.json
+++ b/packages/access_copy_attacher/package.json
@@ -13,7 +13,7 @@
 	},
 	"homepage": "https://permanent.org",
 	"engines": {
-		"node": ">=22.0"
+		"node": ">=24.0"
 	},
 	"main": "dist/index.js",
 	"scripts": {

--- a/packages/access_copy_attacher/src/index.ts
+++ b/packages/access_copy_attacher/src/index.ts
@@ -25,7 +25,7 @@ const removeFirstCharacter = (str: string): string => {
 };
 
 export const handler: SQSHandler = Sentry.wrapHandler(
-	async (event: SQSEvent, _, __) => {
+	async (event: SQSEvent) => {
 		await Promise.all(
 			event.Records.map(async (message) => {
 				const s3Object = getS3ObjectFromS3Message(message);

--- a/packages/account_space_updater/package.json
+++ b/packages/account_space_updater/package.json
@@ -13,7 +13,7 @@
 	},
 	"homepage": "https://permanent.org",
 	"engines": {
-		"node": ">=22.0"
+		"node": ">=24.0"
 	},
 	"main": "dist/index.js",
 	"scripts": {

--- a/packages/account_space_updater/src/index.ts
+++ b/packages/account_space_updater/src/index.ts
@@ -57,7 +57,7 @@ export const extractFileAttributesFromS3Message = (
 	};
 };
 
-export const handler: SQSHandler = async (event: SQSEvent, _, __) => {
+export const handler: SQSHandler = async (event: SQSEvent) => {
 	await Promise.all(
 		event.Records.map(async (message) => {
 			const { recordId, operation } =

--- a/packages/metadata_attacher/package.json
+++ b/packages/metadata_attacher/package.json
@@ -13,7 +13,7 @@
 	},
 	"homepage": "https://permanent.org",
 	"engines": {
-		"node": ">=22.0"
+		"node": ">=24.0"
 	},
 	"main": "dist/index.js",
 	"scripts": {

--- a/packages/metadata_attacher/src/index.ts
+++ b/packages/metadata_attacher/src/index.ts
@@ -232,7 +232,7 @@ const getVideoMetadata = (
 	getVideoMetadataFromQuickTimeMetadata(embeddedMetadata);
 
 export const handler: SQSHandler = Sentry.wrapHandler(
-	async (event: SQSEvent, _, __) => {
+	async (event: SQSEvent) => {
 		await Promise.all(
 			event.Records.map(async (message) => {
 				const s3Bucket = getS3BucketFromS3Message(message);

--- a/packages/record_thumbnail_attacher/package.json
+++ b/packages/record_thumbnail_attacher/package.json
@@ -13,7 +13,7 @@
 	},
 	"homepage": "https://permanent.org",
 	"engines": {
-		"node": ">=22.0"
+		"node": ">=24.0"
 	},
 	"main": "dist/index.js",
 	"scripts": {

--- a/packages/record_thumbnail_attacher/src/index.ts
+++ b/packages/record_thumbnail_attacher/src/index.ts
@@ -9,7 +9,7 @@ import { logger } from "@stela/logger";
 import { db } from "./database";
 
 export const handler: SQSHandler = Sentry.wrapHandler(
-	async (event: SQSEvent, _, __) => {
+	async (event: SQSEvent) => {
 		await Promise.all(
 			event.Records.map(async (message) => {
 				const { key } = getS3ObjectFromS3Message(message);

--- a/packages/trigger_archivematica/package.json
+++ b/packages/trigger_archivematica/package.json
@@ -13,7 +13,7 @@
 	},
 	"homepage": "https://permanent.org",
 	"engines": {
-		"node": ">=22.0"
+		"node": ">=24.0"
 	},
 	"main": "dist/index.js",
 	"scripts": {

--- a/packages/trigger_archivematica/src/index.ts
+++ b/packages/trigger_archivematica/src/index.ts
@@ -40,7 +40,7 @@ export const extractRecordIdFromRecordCreateMessage = (
 	throw new Error("Unsupported action type");
 };
 
-export const handler: SQSHandler = async (event: SQSEvent, _, __) => {
+export const handler: SQSHandler = async (event: SQSEvent) => {
 	await Promise.all(
 		event.Records.map(async (message) => {
 			try {


### PR DESCRIPTION
When we initially adopted Node 24 in this repo AWS hadn't yet released a Node 24 docker image, so we had to leave our lambdas on Node 22. Now they have released such an image, so this commit updates the lambdas to use Node 24.