### PR TITLE
Fix required fields in storage adjustment response

### DIFF
--- a/packages/api/docs/src/paths/account.yaml
+++ b/packages/api/docs/src/paths/account.yaml
@@ -77,7 +77,7 @@ storage-adjustment:
               properties:
                 data:
                   type: object
-                  required: [storageTotal, storageUsed]
+                  required: [newStorageTotal, adjustmentSize, createdAt]
                   properties:
                     newStorageTotal:
                       description: The total amount of storage now available to the account expressed in GBs


### PR DESCRIPTION
Currently the required fields of the response from the storage adjustment endpoint are incorrect in the docs; this commit fixes that.