### PR TITLE
Add GET /record/{id} endpoint

### DIFF
--- a/packages/api/docs/src/paths/record.yaml
+++ b/packages/api/docs/src/paths/record.yaml
@@ -37,6 +37,39 @@ records:
       "500":
         $ref: "../errors.yaml#/500"
 records/{id}:
+  get:
+    summary: Get a single record by ID
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: string
+    security:
+      - {}
+      - bearerHttpAuthentication: []
+      - permanentShareToken: []
+    tags:
+      - records
+    operationId: get-one-record
+    responses:
+      "200":
+        description: The requested record
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                data:
+                  $ref: "../models/record.yaml#/record"
+      "400":
+        $ref: "../errors.yaml#/400"
+      "401":
+        $ref: "../errors.yaml#/401"
+      "404":
+        $ref: "../errors.yaml#/404"
+      "500":
+        $ref: "../errors.yaml#/500"
   patch:
     parameters:
       - name: id

--- a/packages/api/src/record/validators.ts
+++ b/packages/api/src/record/validators.ts
@@ -17,7 +17,7 @@ export const validateGetRecordQuery: (
 		throw validation.error;
 	}
 };
-export const validateRecordRequest: (
+export const validateSingleRecordParams: (
 	data: unknown,
 ) => asserts data is { recordId: string } = (
 	data: unknown,


### PR DESCRIPTION
In cases where a client only wants one record, it's more convenient to not have to deal with an array in the response. Thus this commit adds a GET /record/{id} endpoint that retrieves a single record.