### PR TITLE
Use Jest lifecycles for database setup / teardown

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -35,7 +35,7 @@ jobs:
       - run: touch devenv/.env
       - run: (cd devenv; docker compose up database_setup -d; docker logs permanent-database_setup-1)
       - run: (cd stela/packages/api; npm run start-containers)
-      - run: (cd stela/packages/api; docker compose run stela npm run test-ci)
+      - run: (cd stela/packages/api; docker compose run stela npm run test:ci)
       - run: (cd stela; npm run test -w @stela/account_space_updater)
       - uses: codecov/codecov-action@v5
         env:

--- a/packages/api/jest.config.js
+++ b/packages/api/jest.config.js
@@ -5,5 +5,6 @@ module.exports = {
 		"^@stela/(.*)$": "<rootDir>/../$1/src",
 	},
 	setupFiles: ["<rootDir>/jest.env.setup.js"],
+	globalSetup: "<rootDir>/jest.db.setup.ts",
 	modulePathIgnorePatterns: ["<rootDir>/dist/"],
 };

--- a/packages/api/jest.db.setup.ts
+++ b/packages/api/jest.db.setup.ts
@@ -1,0 +1,24 @@
+import { exec } from "node:child_process";
+import { promisify } from "node:util";
+import pg from "pg";
+
+const execAsync = promisify(exec);
+const { Client } = pg;
+
+const TEST_DATABASE_NAME = "test_permanent";
+const GOLDEN_DATABASE_NAME = "permanent";
+
+export default async function globalSetup(): Promise<void> {
+	const client = new Client({
+		connectionString: "postgres://postgres:permanent@database/postgres",
+	});
+	await client.connect();
+
+	await client.query(`DROP DATABASE IF EXISTS ${TEST_DATABASE_NAME}`);
+	await client.query(`CREATE DATABASE ${TEST_DATABASE_NAME}`);
+	await client.end();
+
+	await execAsync(
+		`pg_dump postgresql://postgres:permanent@database/${GOLDEN_DATABASE_NAME} --schema-only | psql postgresql://postgres:permanent@database/${TEST_DATABASE_NAME}`
+	);
+}

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -27,14 +27,8 @@
 		"start:watch": "tsc-watch --onSuccess \"npm run start\"",
 		"start": "tscp -p tsconfig.tscp.json && node dist/index.js",
 		"start-containers": "(cd ../..; docker compose up -d --build stela)",
-		"clear-database": "psql postgresql://postgres:permanent@localhost:5432 -c 'DROP DATABASE IF EXISTS test_permanent;'",
-		"create-database": "psql postgresql://postgres:permanent@localhost:5432 -c 'CREATE DATABASE test_permanent;'",
-		"set-up-database": "docker exec --env='PGPASSWORD=permanent' permanent-database-1 pg_dump -U postgres permanent --schema-only | psql postgresql://postgres:permanent@localhost:5432/test_permanent",
-		"clear-database-ci": "psql postgresql://postgres:permanent@database:5432 -c 'DROP DATABASE IF EXISTS test_permanent;'",
-		"create-database-ci": "psql postgresql://postgres:permanent@database:5432 -c 'CREATE DATABASE test_permanent;'",
-		"set-up-database-ci": "pg_dump postgresql://postgres:permanent@database:5432/permanent --schema-only | psql postgresql://postgres:permanent@database:5432/test_permanent",
-		"test": "npm run start-containers && npm run clear-database && npm run create-database && npm run set-up-database && (cd ../..; docker compose run stela node --experimental-vm-modules ../../node_modules/jest/bin/jest.js -i --silent=false)",
-		"test-ci": "npm run clear-database-ci && npm run create-database-ci && npm run set-up-database-ci && node --experimental-vm-modules ../../node_modules/jest/bin/jest.js -i --coverage"
+		"test": "npm run start-containers && (cd ../..; docker compose run stela node --experimental-vm-modules ../../node_modules/jest/bin/jest.js -i --silent=false)",
+		"test:ci": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js -i --coverage"
 	},
 	"dependencies": {
 		"@aws-sdk/client-sns": "^3.975.0",


### PR DESCRIPTION
This PR moves the logic for test database setup / cleanup into jest, instead of npm script.

This simplifies our responsibilities and shrinks the "host" footprint of our developer environment since host no longer needs to be able to connect to the docker database to run tests.

Resolves #264 