### PR TITLE
Make SQL function casing consistent

### DIFF
--- a/.sqlfluff
+++ b/.sqlfluff
@@ -14,3 +14,6 @@ spacing_within = touch:inline
 
 [sqlfluff:rules:references.keywords]
 ignore_words = name, owner, type, trigger, shares, location
+
+[sqlfluff:rules:capitalisation.functions]
+extended_capitalisation_policy = upper

--- a/packages/api/src/admin/queries/get_orphaned_folders.sql
+++ b/packages/api/src/admin/queries/get_orphaned_folders.sql
@@ -22,8 +22,8 @@ WHERE
       orphaned_folder.status != 'status.generic.deleted'
     GROUP BY orphaned_folder.folderid
     HAVING
-      ARRAY['status.generic.deleted'] = array_agg(orphaned_folder_link.status)
-      AND ARRAY[1]::int[] != array_agg(orphaned_folder_link.linkcount)::int[]
+      ARRAY['status.generic.deleted'] = ARRAY_AGG(orphaned_folder_link.status)
+      AND ARRAY[1]::int[] != ARRAY_AGG(orphaned_folder_link.linkcount)::int[]
   )
 ORDER BY
   folder.folderid ASC;

--- a/packages/api/src/archive/queries/search_archives.sql
+++ b/packages/api/src/archive/queries/search_archives.sql
@@ -7,7 +7,7 @@ WITH all_archives AS (
     archive.public,
     archive.publicdt AS "publicAt",
     archive.allowpublicdownload AS "allowPublicDownload",
-    jsonb_build_object(
+    JSONB_BUILD_OBJECT(
       'width200', archive.thumburl200,
       'width500', archive.thumburl500,
       'width1000', archive.thumburl1000,
@@ -21,7 +21,7 @@ WITH all_archives AS (
     CASE
       WHEN :isAdmin
         THEN
-          jsonb_build_object(
+          JSONB_BUILD_OBJECT(
             'name', owner_account.fullname,
             'email', owner_account.primaryemail,
             'phoneNumber', owner_account.primaryphone
@@ -29,11 +29,11 @@ WITH all_archives AS (
       ELSE NULL
     END AS owner,
     archive.payeraccountid AS "payerAccountId",
-    row_number() OVER (
+    ROW_NUMBER() OVER (
       ORDER BY
-        ts_rank(
-          to_tsvector('english', basic_profile_item.string1),
-          plainto_tsquery('english', :searchQuery)
+        TS_RANK(
+          TO_TSVECTOR('english', basic_profile_item.string1),
+          PLAINTO_TSQUERY('english', :searchQuery)
         ) DESC,
         basic_profile_item.string1
     ) AS rank
@@ -70,8 +70,8 @@ WITH all_archives AS (
     account AS owner_account
     ON owner_account_archive.accountid = owner_account.accountid
   WHERE
-    plainto_tsquery('english', :searchQuery)
-    @@ to_tsvector('english', basic_profile_item.string1)
+    PLAINTO_TSQUERY('english', :searchQuery)
+    @@ TO_TSVECTOR('english', basic_profile_item.string1)
     AND archive.status != 'status.generic.deleted'
     AND (
       (archive.public IS NOT NULL AND archive.public)
@@ -97,7 +97,7 @@ cursor AS (
 ),
 
 total_pages AS (
-  SELECT ceiling(count(*) / :pageSize::numeric)::int AS total_pages
+  SELECT CEILING(COUNT(*) / :pageSize::numeric)::int AS total_pages
   FROM all_archives
 )
 
@@ -120,6 +120,6 @@ SELECT
   (SELECT total_pages.total_pages FROM total_pages) AS "totalPages"
 FROM all_archives
 WHERE
-  rank > coalesce((SELECT cursor.rank FROM cursor), 0)
+  rank > COALESCE((SELECT cursor.rank FROM cursor), 0)
 ORDER BY rank ASC
 LIMIT :pageSize;

--- a/packages/api/src/directive/queries/create_directive.sql
+++ b/packages/api/src/directive/queries/create_directive.sql
@@ -20,7 +20,7 @@ RETURNING
   updated_dt AS "updatedDt",
   (
     SELECT
-      jsonb_build_object(
+      JSONB_BUILD_OBJECT(
         'email',
         primaryemail,
         'name',

--- a/packages/api/src/directive/queries/get_directives_by_archive.sql
+++ b/packages/api/src/directive/queries/get_directives_by_archive.sql
@@ -6,13 +6,13 @@ SELECT
   directive.updated_dt AS "updatedDt",
   directive.note,
   directive.execution_dt AS "executionDt",
-  jsonb_build_object(
+  JSONB_BUILD_OBJECT(
     'email',
     account.primaryemail,
     'name',
     account.fullname
   ) AS steward,
-  jsonb_build_object(
+  JSONB_BUILD_OBJECT(
     'directiveTriggerId',
     directive_trigger.directive_trigger_id,
     'directiveId',

--- a/packages/api/src/folder/queries/get_folder_children.sql
+++ b/packages/api/src/folder/queries/get_folder_children.sql
@@ -3,7 +3,7 @@ WITH all_children AS (
     id,
     item_type,
     folder_linkid,
-    row_number() OVER (
+    ROW_NUMBER() OVER (
       ORDER BY
         (CASE
           WHEN (
@@ -100,7 +100,7 @@ cursor AS (
 ),
 
 total_pages AS (
-  SELECT ceiling(count(*) / :pageSize) AS total_pages
+  SELECT CEILING(COUNT(*) / :pageSize) AS total_pages
   FROM all_children
 )
 
@@ -110,6 +110,6 @@ SELECT
   (SELECT total_pages.total_pages FROM total_pages) AS "totalPages"
 FROM all_children
 WHERE
-  rank > coalesce((SELECT cursor.rank FROM cursor), 0)
+  rank > COALESCE((SELECT cursor.rank FROM cursor), 0)
 ORDER BY rank ASC
 LIMIT :pageSize;

--- a/packages/api/src/share_link/queries/get_share_links.sql
+++ b/packages/api/src/share_link/queries/get_share_links.sql
@@ -5,14 +5,14 @@ SELECT
   shareby_url.expiresdt AS "expirationTimestamp",
   shareby_url.createddt AS "createdAt",
   shareby_url.updateddt AS "updatedAt",
-  substring(
-    shareby_url.defaultaccessrole FROM (length('access.role.') + 1)
+  SUBSTRING(
+    shareby_url.defaultaccessrole FROM (LENGTH('access.role.') + 1)
   ) AS "permissionsLevel",
   CASE
     WHEN shareby_url.maxuses = 0 THEN NULL
     ELSE shareby_url.maxuses
   END AS "maxUses",
-  coalesce(folder_link.recordid, folder_link.folderid) AS "itemId",
+  COALESCE(folder_link.recordid, folder_link.folderid) AS "itemId",
   CASE
     WHEN folder_link.recordid IS NOT NULL THEN 'record'
     ELSE 'folder'
@@ -22,7 +22,7 @@ SELECT
     WHEN shareby_url.autoapprovetoggle = 1 THEN 'account'
     ELSE 'approval'
   END AS "accessRestrictions",
-  json_build_object(
+  JSON_BUILD_OBJECT(
     'id',
     shareby_url.byaccountid::text,
     'name',
@@ -38,8 +38,8 @@ INNER JOIN
   ON shareby_url.folder_linkid = folder_link.folder_linkid
 WHERE
   (
-    shareby_url.shareby_urlid::text = any(:shareLinkIds)
-    OR shareby_url.urltoken = any(:shareTokens)
+    shareby_url.shareby_urlid::text = ANY(:shareLinkIds)
+    OR shareby_url.urltoken = ANY(:shareTokens)
   )
   AND (
     account.primaryemail = :email

--- a/packages/metadata_attacher/src/queries/update_metadata.sql
+++ b/packages/metadata_attacher/src/queries/update_metadata.sql
@@ -17,7 +17,7 @@ new_tag_names AS (
 	SELECT
 		name
 	FROM
-		unnest(:fileTags) AS file_tags(name)
+		UNNEST(:fileTags) AS file_tags(name)
 	WHERE
 		name NOT IN (SELECT name FROM existing_tags)
 ),


### PR DESCRIPTION
By default, SQLFluff doesn't specify whether SQL functions should be uppercase or lowercase, but it does require that they all use the same casing within each SQL file. As a result, we presently have some SQL files with uppercase function names and some with lowercase function names. This commit configures SQLFluff to requre uppercase function names, and updates all the SQL files to use uppercase function names.