### PR TITLE
Revert dry run builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,13 +1,6 @@
 name: Build
 on:
-  pull_request:
   workflow_call:
-    inputs:
-      publish:
-        description: 'Whether to publish images to ECR'
-        required: false
-        type: boolean
-        default: true
 jobs:
   generate_image_tags:
     uses: ./.github/workflows/generate_image_tags.yml
@@ -48,14 +41,12 @@ jobs:
           IMAGE_TAG: ${{ needs.generate_image_tags.outputs[matrix.image_tag_var] }}
           AWS_RDS_CERT_BUNDLE: ${{ secrets.AWS_RDS_CERT_BUNDLE }}
       - name: AWS Login
-        if: github.event_name == 'workflow_call' && inputs.publish
         run: aws ecr get-login-password --region $AWS_REGION | docker login --username AWS --password-stdin 364159549467.dkr.ecr.$AWS_REGION.amazonaws.com
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_REGION: ${{ secrets.AWS_DEFAULT_REGION }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
       - name: Publish Image to ECR
-        if: github.event_name == 'workflow_call' && inputs.publish
         run: docker push $IMAGE_TAG
         env:
           IMAGE_TAG: ${{ needs.generate_image_tags.outputs[matrix.image_tag_var] }}


### PR DESCRIPTION
The changes we made to allow dry run builds on PRs seem to have broken deploys, so this commit reverts them for now.