### PR TITLE
Make API tests run in parallel

### DIFF
--- a/packages/api/jest.config.js
+++ b/packages/api/jest.config.js
@@ -6,5 +6,7 @@ module.exports = {
 	},
 	setupFiles: ["<rootDir>/jest.env.setup.js"],
 	globalSetup: "<rootDir>/jest.db.setup.ts",
+	globalTeardown: "<rootDir>/jest.db.teardown.ts",
 	modulePathIgnorePatterns: ["<rootDir>/dist/"],
+	maxWorkers: "50%",
 };

--- a/packages/api/jest.db.setup.ts
+++ b/packages/api/jest.db.setup.ts
@@ -1,11 +1,12 @@
 import { exec } from "node:child_process";
 import { promisify } from "node:util";
 import pg from "pg";
+import os from "node:os";
 
 const execAsync = promisify(exec);
 const { Client } = pg;
 
-const TEST_DATABASE_NAME = "test_permanent";
+const TEMPLATE_DATABASE_NAME = "test_permanent_template";
 const GOLDEN_DATABASE_NAME = "permanent";
 
 export default async function globalSetup(): Promise<void> {
@@ -14,11 +15,37 @@ export default async function globalSetup(): Promise<void> {
 	});
 	await client.connect();
 
-	await client.query(`DROP DATABASE IF EXISTS ${TEST_DATABASE_NAME}`);
-	await client.query(`CREATE DATABASE ${TEST_DATABASE_NAME}`);
-	await client.end();
+	try {
+		await client.query(`DROP DATABASE IF EXISTS ${TEMPLATE_DATABASE_NAME}`);
+		await client.query(`CREATE DATABASE ${TEMPLATE_DATABASE_NAME}`);
+		await client.end();
 
-	await execAsync(
-		`pg_dump postgresql://postgres:permanent@database/${GOLDEN_DATABASE_NAME} --schema-only | psql postgresql://postgres:permanent@database/${TEST_DATABASE_NAME}`
-	);
+		await execAsync(
+			`pg_dump postgresql://postgres:permanent@database/${GOLDEN_DATABASE_NAME} --schema-only | psql postgresql://postgres:permanent@database/${TEMPLATE_DATABASE_NAME}`,
+		);
+
+		// Create worker-specific databases from the template
+		// We've configured jest to use a number of workers equal to half the number of CPUs
+		const numWorkers = os.cpus().length / 2;
+
+		const adminClient = new Client({
+			connectionString: "postgres://postgres:permanent@database/postgres",
+		});
+		await adminClient.connect();
+
+		try {
+			for (let i = 1; i <= numWorkers; i++) {
+				const workerDbName = `test_permanent_worker_${i}`;
+				await adminClient.query(`DROP DATABASE IF EXISTS ${workerDbName}`);
+				await adminClient.query(
+					`CREATE DATABASE ${workerDbName} TEMPLATE ${TEMPLATE_DATABASE_NAME}`,
+				);
+			}
+		} finally {
+			await adminClient.end();
+		}
+	} catch (error) {
+		await client.end();
+		throw error;
+	}
 }

--- a/packages/api/jest.db.teardown.ts
+++ b/packages/api/jest.db.teardown.ts
@@ -1,0 +1,43 @@
+import pg from "pg";
+import os from "node:os";
+
+const { Client } = pg;
+
+const TEMPLATE_DATABASE_NAME = "test_permanent_template";
+
+export default async function globalTeardown(): Promise<void> {
+	const client = new Client({
+		connectionString: "postgres://postgres:permanent@database/postgres",
+	});
+	await client.connect();
+
+	try {
+		const numWorkers = os.cpus().length / 2;
+
+		// Terminate connections and drop worker databases
+		for (let i = 1; i <= numWorkers; i++) {
+			const workerDbName = `test_permanent_worker_${i}`;
+
+			// Terminate any remaining connections
+			await client.query(`
+				SELECT pg_terminate_backend(pg_stat_activity.pid)
+				FROM pg_stat_activity
+				WHERE pg_stat_activity.datname = '${workerDbName}'
+				AND pid <> pg_backend_pid()
+			`);
+
+			await client.query(`DROP DATABASE IF EXISTS ${workerDbName}`);
+		}
+
+		// Drop the template database
+		await client.query(`
+			SELECT pg_terminate_backend(pg_stat_activity.pid)
+			FROM pg_stat_activity
+			WHERE pg_stat_activity.datname = '${TEMPLATE_DATABASE_NAME}'
+			AND pid <> pg_backend_pid()
+		`);
+		await client.query(`DROP DATABASE IF EXISTS ${TEMPLATE_DATABASE_NAME}`);
+	} finally {
+		await client.end();
+	}
+}

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -27,8 +27,8 @@
 		"start:watch": "tsc-watch --onSuccess \"npm run start\"",
 		"start": "tscp -p tsconfig.tscp.json && node dist/index.js",
 		"start-containers": "(cd ../..; docker compose up -d --build stela)",
-		"test": "npm run start-containers && (cd ../..; docker compose run stela node --experimental-vm-modules ../../node_modules/jest/bin/jest.js -i --silent=false)",
-		"test:ci": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js -i --coverage"
+		"test": "npm run start-containers && (cd ../..; docker compose run stela node --experimental-vm-modules ../../node_modules/jest/bin/jest.js --silent=false)",
+		"test:ci": "node --experimental-vm-modules ../../node_modules/jest/bin/jest.js --coverage"
 	},
 	"dependencies": {
 		"@aws-sdk/client-sns": "^3.975.0",

--- a/packages/api/src/__mocks__/database.ts
+++ b/packages/api/src/__mocks__/database.ts
@@ -1,9 +1,13 @@
 import * as path from "node:path";
 import { TinyPg } from "tinypg";
 
+// Use worker-specific databases to enable parallel test execution
+// Each Jest worker gets its own isolated database
+const workerId = process.env["JEST_WORKER_ID"] ?? "1";
+const dbName = `test_permanent_worker_${workerId}`;
+
 const db = new TinyPg({
-	connection_string:
-		"postgres://postgres:permanent@database:5432/test_permanent",
+	connection_string: `postgres://postgres:permanent@database:5432/${dbName}`,
 	root_dir: [path.resolve(__dirname, "..")],
 	capture_stack_trace: true,
 });


### PR DESCRIPTION
The API package has a lot of tests, and currently they run sequentially because they all use the same database. This takes ~21 minutes on my machine. This commit updates the database setup so that each Jest worker gets its own database, allowing us to use Jest's parallelism. This cuts the time it takes to run the API tests down to ~7 minutes on my machine.