### PR TITLE
Add PATCH /archive endpoint

### DIFF
--- a/packages/api/docs/src/api.yaml
+++ b/packages/api/docs/src/api.yaml
@@ -55,6 +55,8 @@ paths:
     $ref: "./paths/folder.yaml#/folders-id-children"
   /folders/{id}/share-links:
     $ref: "./paths/folder.yaml#/folders-id-share-links"
+  /archive/{id}:
+    $ref: "./paths/archive.yaml#/archives~1{id}"
   /archive/{id}/folders/shared:
     $ref: "./paths/archive.yaml#/archive-id-folders-shared"
   /archives:

--- a/packages/api/docs/src/models/archive.yaml
+++ b/packages/api/docs/src/models/archive.yaml
@@ -65,3 +65,8 @@ archive:
     updatedAt:
       type: string
       format: date-time
+    milestoneSortOrder:
+      type: string
+      enum:
+        - chronological
+        - reverse_chronological

--- a/packages/api/docs/src/paths/archive.yaml
+++ b/packages/api/docs/src/paths/archive.yaml
@@ -33,6 +33,45 @@ archives:
         $ref: "../errors.yaml#/400"
       "500":
         $ref: "../errors.yaml#/500"
+archives/{id}:
+  patch:
+    summary: Update an archive
+    parameters:
+      - name: id
+        in: path
+        required: true
+        schema:
+          type: integer
+    security:
+      - bearerHttpAuthentication: []
+    tags:
+      - archives
+    operationId: patch-archives
+    requestBody:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              milestoneSortOrder:
+                type: string
+                enum:
+                  - chronological
+                  - reverse_chronological
+    responses:
+      "200":
+        description: The updated archive
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                data:
+                  $ref: "../models/archive.yaml#/archive"
+      "400":
+        $ref: "../errors.yaml#/400"
+      "500":
+        $ref: "../errors.yaml#/500"
 archive-id-folders-shared:
   parameters:
     - name: id

--- a/packages/api/src/archive/controller/controller.ts
+++ b/packages/api/src/archive/controller/controller.ts
@@ -10,6 +10,7 @@ import {
 	validateArchiveIdFromParams,
 	validateBodyFromAuthentication,
 	validateSearchQuery,
+	validatePatchArchiveBody,
 } from "../validators";
 import { isValidationError } from "../../validators/validator_util";
 import { archiveService } from "../service";
@@ -51,6 +52,30 @@ archiveController.get(
 		}
 	},
 );
+
+archiveController.patch(
+	"/:archiveId",
+	verifyUserAuthentication,
+	async (req: Request, res: Response, next: NextFunction) => {
+		try {
+			validateArchiveIdFromParams(req.params);
+			validatePatchArchiveBody(req.body);
+			const archive = await archiveService.updateArchive(
+				req.params.archiveId,
+				req.body.milestoneSortOrder,
+				req.body.emailFromAuthToken,
+			);
+			res.json({ data: archive });
+		} catch (err) {
+			if (isValidationError(err)) {
+				res.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST).json({ error: err });
+				return;
+			}
+			next(err);
+		}
+	},
+);
+
 archiveController.get(
 	"/:archiveId/tags/public",
 	async (req: Request, res: Response, next: NextFunction) => {

--- a/packages/api/src/archive/controller/update_archive.test.ts
+++ b/packages/api/src/archive/controller/update_archive.test.ts
@@ -1,0 +1,122 @@
+import request from "supertest";
+import { logger } from "@stela/logger";
+import { app } from "../../app";
+import { db } from "../../database";
+import { mockVerifyUserAuthentication } from "../../../test/middleware_mocks";
+import type { Archive } from "../models";
+
+jest.mock("../../database");
+jest.mock("../../middleware");
+jest.mock("@stela/logger");
+
+const loadFixtures = async (): Promise<void> => {
+	await db.sql("archive.fixtures.create_test_accounts");
+	await db.sql("archive.fixtures.create_test_archives");
+	await db.sql("archive.fixtures.create_test_account_archives");
+	await db.sql("archive.fixtures.create_test_profile_items");
+	await db.sql("archive.fixtures.create_test_text_data");
+	await db.sql("archive.fixtures.create_test_folders");
+};
+
+const clearDatabase = async (): Promise<void> => {
+	await db.query(
+		"TRUNCATE account, archive, account_archive, profile_item, text_data, folder CASCADE",
+	);
+};
+
+describe("PATCH /archive/:archiveId", () => {
+	const agent = request(app);
+	beforeEach(async () => {
+		mockVerifyUserAuthentication(
+			"test@permanent.org",
+			"82bd483e-914b-4bfe-abf9-92ffe86d7803",
+		);
+		await loadFixtures();
+	});
+
+	afterEach(async () => {
+		await clearDatabase();
+	});
+
+	test("should update archive with chronological milestone sort order", async () => {
+		const archiveId = "1";
+
+		const response = await agent
+			.patch(`/api/v2/archive/${archiveId}`)
+			.send({ milestoneSortOrder: "chronological" })
+			.expect(200);
+
+		const {
+			body: { data: archive },
+		} = response as { body: { data: Archive } };
+		expect(archive).toBeDefined();
+		expect(archive.archiveId).toBe(archiveId);
+		expect(archive.milestoneSortOrder).toBe("chronological");
+	});
+
+	test("should update archive with reverse_chronological milestone sort order", async () => {
+		const archiveId = "1";
+
+		const response = await agent
+			.patch(`/api/v2/archive/${archiveId}`)
+			.send({ milestoneSortOrder: "reverse_chronological" })
+			.expect(200);
+
+		const {
+			body: { data: archive },
+		} = response as { body: { data: Archive } };
+		expect(archive).toBeDefined();
+		expect(archive.archiveId).toBe(archiveId);
+		expect(archive.milestoneSortOrder).toBe("reverse_chronological");
+	});
+
+	test("should return 400 if milestoneSortOrder is missing", async () => {
+		const archiveId = "1";
+
+		await agent.patch(`/api/v2/archive/${archiveId}`).send({}).expect(400);
+	});
+
+	test("should return 400 if milestoneSortOrder has invalid value", async () => {
+		const archiveId = "1";
+
+		await agent
+			.patch(`/api/v2/archive/${archiveId}`)
+			.send({ milestoneSortOrder: "invalid_value" })
+			.expect(400);
+	});
+
+	test("should return 404 if archive doesn't exist", async () => {
+		const archiveId = "1000000";
+
+		await agent
+			.patch(`/api/v2/archive/${archiveId}`)
+			.send({ milestoneSortOrder: "chronological" })
+			.expect(404);
+	});
+
+	test("should return 404 if user does not have permission to update archive", async () => {
+		mockVerifyUserAuthentication(
+			"unauthorized@example.com",
+			"aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee",
+		);
+		const archiveId = "1";
+
+		await agent
+			.patch(`/api/v2/archive/${archiveId}`)
+			.send({ milestoneSortOrder: "chronological" })
+			.expect(404);
+	});
+
+	test("should throw an InternalServerError if database query fails", async () => {
+		const archiveId = "1";
+		const testError = new Error("error: out of cheese - redo from start");
+		jest.spyOn(db, "sql").mockRejectedValueOnce(testError);
+
+		await agent
+			.patch(`/api/v2/archive/${archiveId}`)
+			.send({ milestoneSortOrder: "chronological" })
+			.expect(500);
+
+		expect(logger.error).toHaveBeenCalledWith(testError);
+	});
+});

--- a/packages/api/src/archive/models.ts
+++ b/packages/api/src/archive/models.ts
@@ -43,6 +43,11 @@ export interface ArchiveOwner {
 	phoneNumber?: string | null;
 }
 
+export enum MilestoneSortOrder {
+	Chronological = "chronological",
+	ReverseChronological = "reverse_chronological",
+}
+
 export interface Archive {
 	archiveId: string;
 	rootFolderId: string;
@@ -54,6 +59,7 @@ export interface Archive {
 	allowPublicDownload: boolean;
 	thumbnailUrls: ThumbnailUrls;
 	owner?: ArchiveOwner | null;
+	milestoneSortOrder: MilestoneSortOrder;
 	status: string;
 	type: string;
 	createdAt: string;

--- a/packages/api/src/archive/queries/search_archives.sql
+++ b/packages/api/src/archive/queries/search_archives.sql
@@ -13,6 +13,7 @@ WITH all_archives AS (
       'width1000', archive.thumburl1000,
       'width2000', archive.thumburl2000
     ) AS "thumbnailUrls",
+    archive.milestonesortorder AS "milestoneSortOrder",
     archive.status,
     archive.type,
     archive.createddt AS "createdAt",
@@ -110,6 +111,7 @@ SELECT
   "publicAt",
   "allowPublicDownload",
   "thumbnailUrls",
+  "milestoneSortOrder",
   status,
   type,
   "createdAt",

--- a/packages/api/src/archive/queries/update_archive.sql
+++ b/packages/api/src/archive/queries/update_archive.sql
@@ -1,0 +1,81 @@
+WITH archive_access AS (
+  SELECT account_archive.archiveid
+  FROM account_archive
+  INNER JOIN account ON account_archive.accountid = account.accountid
+  WHERE
+    account.primaryemail = :email
+    AND account_archive.archiveid = :archiveId
+    AND account_archive.accessrole IN (
+      'access.role.owner',
+      'access.role.manager'
+    )
+    AND account_archive.status = 'status.generic.ok'
+),
+
+updated_archive AS (
+  UPDATE archive
+  SET
+    milestonesortorder = :milestoneSortOrder,
+    updateddt = NOW()
+  WHERE
+    archiveid = :archiveId
+    AND status != 'status.generic.deleted'
+    AND EXISTS (
+      SELECT 1
+      FROM archive_access
+      WHERE archiveid = :archiveId
+    )
+  RETURNING
+    archiveid,
+    milestonesortorder,
+    updateddt
+)
+
+SELECT
+  archive.archiveid AS "archiveId",
+  archive.archivenbr AS "archiveNbr",
+  basic_profile_item.string1 AS name,
+  text_data.valuetext AS description,
+  archive.public,
+  archive.publicdt AS "publicAt",
+  archive.allowpublicdownload AS "allowPublicDownload",
+  updated_archive.milestonesortorder AS "milestoneSortOrder",
+  archive.status,
+  archive.type,
+  archive.createddt AS "createdAt",
+  updated_archive.updateddt AS "updatedAt",
+  root_folder.folderid AS "rootFolderId",
+  archive.payeraccountid AS "payerAccountId",
+  JSONB_BUILD_OBJECT(
+    'width200', archive.thumburl200,
+    'width500', archive.thumburl500,
+    'width1000', archive.thumburl1000,
+    'width2000', archive.thumburl2000
+  ) AS "thumbnailUrls"
+FROM
+  archive
+INNER JOIN
+  updated_archive
+  ON
+    archive.archiveid = updated_archive.archiveid
+INNER JOIN
+  profile_item AS basic_profile_item
+  ON
+    archive.archiveid = basic_profile_item.archiveid
+    AND basic_profile_item.fieldnameui = 'profile.basic'
+    AND basic_profile_item.status != 'status.generic.deleted'
+LEFT JOIN
+  profile_item AS description_profile_item
+  ON
+    archive.archiveid = description_profile_item.archiveid
+    AND description_profile_item.fieldnameui = 'profile.description'
+    AND basic_profile_item.status != 'status.generic.deleted'
+LEFT JOIN
+  text_data
+  ON
+    description_profile_item.text_dataid1 = text_data.text_dataid
+INNER JOIN
+  folder AS root_folder
+  ON
+    archive.archiveid = root_folder.archiveid
+    AND root_folder.type = 'type.folder.root.root';

--- a/packages/api/src/archive/service/index.ts
+++ b/packages/api/src/archive/service/index.ts
@@ -6,6 +6,7 @@ import { getFeatured } from "./get_featured";
 import { getSharedFolders } from "./get_shared_folders";
 import { backfillLedger } from "./backfill_ledger";
 import { searchArchives } from "./search_archives";
+import { updateArchive } from "./update_archive";
 
 export const archiveService = {
 	getPublicTags,
@@ -16,4 +17,5 @@ export const archiveService = {
 	getSharedFolders,
 	backfillLedger,
 	searchArchives,
+	updateArchive,
 };

--- a/packages/api/src/archive/service/update_archive.ts
+++ b/packages/api/src/archive/service/update_archive.ts
@@ -1,0 +1,27 @@
+import createError from "http-errors";
+import { logger } from "@stela/logger";
+import { db } from "../../database";
+import type { Archive } from "../models";
+
+export const updateArchive = async (
+	archiveId: string,
+	milestoneSortOrder: string,
+	email: string,
+): Promise<Archive> => {
+	const updateArchiveResult = await db
+		.sql<Archive>("archive.queries.update_archive", {
+			archiveId,
+			milestoneSortOrder,
+			email,
+		})
+		.catch((err: unknown) => {
+			logger.error(err);
+			throw new createError.InternalServerError("failed to update archive");
+		});
+	if (updateArchiveResult.rows[0] === undefined) {
+		throw new createError.NotFound(
+			"archive not found or you do not have permission to update it",
+		);
+	}
+	return updateArchiveResult.rows[0];
+};

--- a/packages/api/src/archive/validators.ts
+++ b/packages/api/src/archive/validators.ts
@@ -1,5 +1,9 @@
 import Joi from "joi";
-import { validateBodyFromAuthentication } from "../validators";
+import {
+	validateBodyFromAuthentication,
+	fieldsFromUserAuthentication,
+} from "../validators";
+import type { MilestoneSortOrder } from "./models";
 
 export { validateBodyFromAuthentication };
 
@@ -32,6 +36,28 @@ export const validateSearchQuery: (data: unknown) => asserts data is {
 			searchQuery: Joi.string().required(),
 			pageSize: Joi.number().integer().min(1).required(),
 			cursor: Joi.string().optional(),
+		})
+		.validate(data);
+	if (validation.error !== undefined) {
+		throw validation.error;
+	}
+};
+
+export const validatePatchArchiveBody: (data: unknown) => asserts data is {
+	emailFromAuthToken: string;
+	milestoneSortOrder: MilestoneSortOrder;
+} = (
+	data: unknown,
+): asserts data is {
+	emailFromAuthToken: string;
+	milestoneSortOrder: string;
+} => {
+	const validation = Joi.object()
+		.keys({
+			...fieldsFromUserAuthentication,
+			milestoneSortOrder: Joi.string()
+				.valid("chronological", "reverse_chronological")
+				.required(),
 		})
 		.validate(data);
 	if (validation.error !== undefined) {


### PR DESCRIPTION
Certain fields of archives should be updateable, so this commit adds a PATCH endpoint for archives. Currently it supports only the milestoneSortOrder field, because this is the field we most pressingly need an update endoint for.