### PR TITLE
Trigger workflows on automerges

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -1,17 +1,19 @@
 name: Auto-merge
 on: pull_request
 
-permissions:
-  pull-requests: write
-  contents: write
-
 jobs:
   dependabot:
     runs-on: ubuntu-latest
     if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
+      - name: Generate GitHub App Token
+        uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ secrets.AUTOMERGER_APP_ID }}
+          private-key: ${{ secrets.AUTOMERGER_APP_PRIVATE_KEY }}
       - name: Enable auto-merge for Dependabot PRs
         run: gh pr merge --auto --merge "$PR_URL"
         env:
           PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
Currently, when our dependabot PRs automerge our workflows that should trigger on merge don't trigger. This is because the Github token used to authenticate the automerge isn't allowed to trigger other workflows. This commit updates the automerge workflow to use a different token that is allowed to trigger other workflows.