### PR TITLE
Sort by displayTimeInEDTF when available

### DIFF
--- a/packages/api/src/folder/fixtures/create_test_folder_links.sql
+++ b/packages/api/src/folder/fixtures/create_test_folder_links.sql
@@ -142,4 +142,28 @@ VALUES
   'access.role.owner',
   'status.generic.ok',
   'type.folder_link.private'
+),
+(
+  12,
+  NULL,
+  101,
+  13,
+  13,
+  1,
+  1,
+  'access.role.owner',
+  'status.generic.ok',
+  'type.folder_link.private'
+),
+(
+  13,
+  NULL,
+  102,
+  13,
+  13,
+  1,
+  1,
+  'access.role.owner',
+  'status.generic.ok',
+  'type.folder_link.private'
 );

--- a/packages/api/src/folder/fixtures/create_test_folders.sql
+++ b/packages/api/src/folder/fixtures/create_test_folders.sql
@@ -20,6 +20,7 @@ folder (
   displaydt,
   displayenddt,
   displaytime,
+  displaytimelowerbound,
   imageratio,
   sort,
   view
@@ -35,6 +36,7 @@ VALUES
   'status.generic.ok',
   CURRENT_TIMESTAMP - '2 days'::interval,
   'type.folder.public',
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -71,6 +73,7 @@ VALUES
   '2025-01-01',
   '2025-01-01',
   '2025-01-01',
+  '2025-01-01',
   1.00,
   'sort.alphabetical_asc',
   'folder.view.grid'
@@ -98,6 +101,7 @@ VALUES
   NULL,
   NULL,
   NULL,
+  NULL,
   NULL
 ),
 (
@@ -110,6 +114,7 @@ VALUES
   'status.generic.deleted',
   CURRENT_TIMESTAMP,
   'type.folder.private',
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -148,6 +153,7 @@ VALUES
   NULL,
   NULL,
   NULL,
+  NULL,
   NULL
 ),
 (
@@ -160,6 +166,7 @@ VALUES
   'status.generic.ok',
   CURRENT_TIMESTAMP + '1 day'::interval,
   'type.folder.private',
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -198,6 +205,7 @@ VALUES
   NULL,
   NULL,
   NULL,
+  NULL,
   NULL
 ),
 (
@@ -210,6 +218,7 @@ VALUES
   'status.generic.deleted',
   '2020-01-01 00:00:00',
   'type.folder.private',
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -248,6 +257,7 @@ VALUES
   NULL,
   NULL,
   NULL,
+  NULL,
   NULL
 ),
 (
@@ -262,6 +272,7 @@ VALUES
   'type.folder.root.private',
   NULL,
   'https://test-folder-thumbnail',
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -298,6 +309,7 @@ VALUES
   NULL,
   NULL,
   NULL,
+  NULL,
   NULL
 ),
 (
@@ -310,6 +322,7 @@ VALUES
   'status.generic.ok',
   CURRENT_TIMESTAMP,
   'type.folder.private',
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -348,6 +361,7 @@ VALUES
   NULL,
   NULL,
   NULL,
+  NULL,
   NULL
 ),
 (
@@ -371,6 +385,59 @@ VALUES
   NULL,
   NULL,
   NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL
+),
+(
+  101,
+  1,
+  NULL,
+  'Test Folder 101',
+  'Test Folder 101',
+  NULL,
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  'type.folder.private',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  '2020-01-01',
+  NULL,
+  NULL,
+  '2025-01-01',
+  NULL,
+  NULL,
+  NULL
+),
+(
+  102,
+  1,
+  NULL,
+  'Test Folder 102',
+  'Test Folder 102',
+  NULL,
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  'type.folder.private',
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  '2025-01-01',
+  NULL,
+  NULL,
+  '2020-01-01',
   NULL,
   NULL,
   NULL

--- a/packages/api/src/folder/queries/get_folder_children.sql
+++ b/packages/api/src/folder/queries/get_folder_children.sql
@@ -27,7 +27,7 @@ WITH all_children AS (
             FROM folder
             WHERE folder.folderid = :parentFolderId
           ) = 'sort.display_date_asc'
-            THEN displaydt
+            THEN COALESCE(displaytimelowerbound, displaydt)
         END) ASC,
         (CASE
           WHEN (
@@ -35,7 +35,7 @@ WITH all_children AS (
             FROM folder
             WHERE folder.folderid = :parentFolderId
           ) = 'sort.display_date_desc'
-            THEN displaydt
+            THEN COALESCE(displaytimelowerbound, displaydt)
         END) DESC,
         (CASE
           WHEN (
@@ -60,6 +60,7 @@ WITH all_children AS (
       'folder' AS item_type,
       folder_link.folder_linkid,
       folder.displayname,
+      folder.displaytimelowerbound,
       folder.displaydt,
       folder.type
     FROM
@@ -77,6 +78,7 @@ WITH all_children AS (
       'record' AS item_type,
       folder_link.folder_linkid,
       record.displayname,
+      record.displaytimelowerbound,
       record.displaydt,
       record.type
     FROM


### PR DESCRIPTION
We plan to replace the displayDt field with the displayTimeInEDTF field. This means the sort by date setting of a folder should use displayTimeInEDTF. Since we haven't made the switch yet, this commit updates sort to use COALESCE(displayTimeInEDTF, displayDt). Once the clients are writing only to displayTimeInEDTF and we've migrated older data from displayDt to displayTimeInEDTF, we'll be able to remove displayDt from the sorting logic.