### PR TITLE
Set provenance flag to false on docker builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,7 +66,7 @@ jobs:
     steps:
       - uses: actions/checkout@v6
       - name: Build Image
-        run: docker build -t $IMAGE_TAG --build-arg="AWS_RDS_CERT_BUNDLE=$AWS_RDS_CERT_BUNDLE" -f packages/${{ matrix.package }}/Dockerfile .
+        run: docker build --provenance=false -t $IMAGE_TAG --build-arg="AWS_RDS_CERT_BUNDLE=$AWS_RDS_CERT_BUNDLE" -f packages/${{ matrix.package }}/Dockerfile .
         env:
           IMAGE_TAG: ${{ fromJSON(toJSON(inputs))[matrix.image_tag_var] || needs.generate_image_tags.outputs[matrix.image_tag_var] }}
           AWS_RDS_CERT_BUNDLE: ${{ secrets.AWS_RDS_CERT_BUNDLE }}


### PR DESCRIPTION
When the provenance flag is set to true (as it is by default), the
BuildKit version used on the latest Ubuntu release will use features in
constructing the image that aren't supported by the lambda runner. Since
we're the only consumer of our images, it is safe for us to turn
provenance off to avoid this issue.