### PR TITLE
Update GET /share-links docs to reflect all auth pathways

### DIFF
--- a/packages/api/docs/src/paths/share_link.yaml
+++ b/packages/api/docs/src/paths/share_link.yaml
@@ -78,13 +78,14 @@ share-link:
       - name: shareLinkIds
         in: query
         required: false
-        description: An array of share links' ids. Required if shareTokens is not set.
+        description: An array of share links' ids. Required if shareTokens is not set. Requires bearer token authentication.
         schema:
           type: array
           items:
             type: string
     summary: Retrieve a share link by ID or token
     security:
+      - {}
       - bearerHttpAuthentication: []
     operationId: getShareLink
     tags:


### PR DESCRIPTION
Currently, the API documentation for GET /share-links doesn't reflect that an auth token is not required for requests that use the shareToken parameter rather than a shareLinkId. This commit updates the docs to reflect that reality.