### PR TITLE
Add STRIPE_SECRET_KEY to terraform

### DIFF
--- a/terraform/prod_cluster/secrets.tf
+++ b/terraform/prod_cluster/secrets.tf
@@ -20,5 +20,6 @@ resource "kubernetes_secret" "prod-secrets" {
     "NEW_RELIC_LICENSE_KEY"           = var.new_relic_license_key
     "CLOUDFRONT_KEY_PAIR_ID"          = var.cloudfront_key_pair_id
     "CLOUDFRONT_PRIVATE_KEY"          = var.cloudfront_private_key
+    "STRIPE_SECRET_KEY"               = var.stripe_secret_key
   }
 }

--- a/terraform/prod_cluster/stela_prod_deployment.tf
+++ b/terraform/prod_cluster/stela_prod_deployment.tf
@@ -208,6 +208,17 @@ resource "kubernetes_deployment" "stela_prod" {
           }
 
           env {
+            name = "STRIPE_SECRET_KEY"
+            value_from {
+              secret_key_ref {
+                name     = "prod-secrets"
+                key      = "STRIPE_SECRET_KEY"
+                optional = false
+              }
+            }
+          }
+
+          env {
             name  = "NEW_RELIC_APP_NAME"
             value = var.new_relic_app_name
           }

--- a/terraform/prod_cluster/variables.tf
+++ b/terraform/prod_cluster/variables.tf
@@ -250,3 +250,8 @@ variable "archivematica_processing_workflow" {
   type        = string
   default     = "default"
 }
+
+variable "stripe_secret_key" {
+  description = "A key used to connect to Stripe"
+  type        = string
+}

--- a/terraform/test_cluster/secrets.tf
+++ b/terraform/test_cluster/secrets.tf
@@ -20,6 +20,7 @@ resource "kubernetes_secret" "dev-secrets" {
     "NEW_RELIC_LICENSE_KEY"           = var.dev_new_relic_license_key
     "CLOUDFRONT_KEY_PAIR_ID"          = var.cloudfront_key_pair_id
     "CLOUDFRONT_PRIVATE_KEY"          = var.cloudfront_private_key
+    "STRIPE_SECRET_KEY"               = var.stripe_test_secret_key
   }
 }
 
@@ -45,5 +46,6 @@ resource "kubernetes_secret" "staging-secrets" {
     "NEW_RELIC_LICENSE_KEY"           = var.staging_new_relic_license_key
     "CLOUDFRONT_KEY_PAIR_ID"          = var.cloudfront_key_pair_id
     "CLOUDFRONT_PRIVATE_KEY"          = var.cloudfront_private_key
+    "STRIPE_SECRET_KEY"               = var.stripe_test_secret_key
   }
 }

--- a/terraform/test_cluster/stela_dev_deployment.tf
+++ b/terraform/test_cluster/stela_dev_deployment.tf
@@ -215,6 +215,17 @@ resource "kubernetes_deployment" "stela_dev" {
           }
 
           env {
+            name = "STRIPE_SECRET_KEY"
+            value_from {
+              secret_key_ref {
+                name     = "dev-secrets"
+                key      = "STRIPE_SECRET_KEY"
+                optional = false
+              }
+            }
+          }
+
+          env {
             name  = "NEW_RELIC_APP_NAME"
             value = var.dev_new_relic_app_name
           }

--- a/terraform/test_cluster/stela_staging_deployment.tf
+++ b/terraform/test_cluster/stela_staging_deployment.tf
@@ -215,6 +215,17 @@ resource "kubernetes_deployment" "stela_staging" {
           }
 
           env {
+            name = "STRIPE_SECRET_KEY"
+            value_from {
+              secret_key_ref {
+                name     = "staging-secrets"
+                key      = "STRIPE_SECRET_KEY"
+                optional = false
+              }
+            }
+          }
+
+          env {
             name  = "NEW_RELIC_APP_NAME"
             value = var.staging_new_relic_app_name
           }

--- a/terraform/test_cluster/variables.tf
+++ b/terraform/test_cluster/variables.tf
@@ -353,3 +353,8 @@ variable "staging_archivematica_processing_workflow" {
   type        = string
   default     = "default"
 }
+
+variable "stripe_test_secret_key" {
+  description = "A key used in dev and staging to connect to Stripe's test environment"
+  type        = string
+}


### PR DESCRIPTION
A recent commit added an endpoint for creating payment intents in Stripe. This endpoint relies on a STRIPE_SECRET_KEY env var for communicating with Stripe. We forgot to add that env var to the terraform for deploying stela in that commit, so we do so here.