### PR TITLE
Treat empty strings in optional metadata fields as undefined

### DIFF
--- a/packages/metadata_attacher/src/fixtures/sample_mets.xml
+++ b/packages/metadata_attacher/src/fixtures/sample_mets.xml
@@ -163,6 +163,7 @@
 <ExifIFD:ComponentsConfiguration>Y, Cb, Cr, -</ExifIFD:ComponentsConfiguration>
 <ExifIFD:FlashpixVersion>0100</ExifIFD:FlashpixVersion>
 <ExifIFD:ColorSpace>Uncalibrated</ExifIFD:ColorSpace>
+<ExifIFD:UserComment></ExifIFD:UserComment>
 <IPTC:ObjectAttributeReference>000:Actuality</IPTC:ObjectAttributeReference>
 <IPTC:ObjectName>Test Image Title</IPTC:ObjectName>
 <IPTC:SubjectReference>

--- a/packages/metadata_attacher/src/validators.ts
+++ b/packages/metadata_attacher/src/validators.ts
@@ -4,20 +4,20 @@ import type { MetsMetadata } from "./models";
 
 const rdfMetadataSchema = Joi.object({
 	"File:MIMEType": Joi.string().required(),
-	"IPTC:ObjectName": Joi.string().optional(),
-	"IPTC:Caption-Abstract": Joi.string().optional(),
+	"IPTC:ObjectName": Joi.string().optional().empty(""),
+	"IPTC:Caption-Abstract": Joi.string().optional().empty(""),
 	"IPTC:Keywords": Joi.object({
 		"rdf:Bag": Joi.object({
 			"rdf:li": Joi.array().items(Joi.string()).required(),
 		}).required(),
 	}).optional(),
-	"ExifIFD:Title": Joi.string().optional(),
-	"ExifIFD:UserComment": Joi.string().optional(),
-	"ExifIFD:Comments": Joi.string().optional(),
-	"ExifIFD:DateTimeOriginal": Joi.string().optional(),
-	"ExifIFD:OffsetTimeOriginal": Joi.string().optional(),
-	"XMP-iptcCore:AltTextAccessibility": Joi.string().optional(),
-	"QuickTime:CreationDate": Joi.string().optional(),
+	"ExifIFD:Title": Joi.string().optional().empty(""),
+	"ExifIFD:UserComment": Joi.string().optional().empty(""),
+	"ExifIFD:Comments": Joi.string().optional().empty(""),
+	"ExifIFD:DateTimeOriginal": Joi.string().optional().empty(""),
+	"ExifIFD:OffsetTimeOriginal": Joi.string().optional().empty(""),
+	"XMP-iptcCore:AltTextAccessibility": Joi.string().optional().empty(""),
+	"QuickTime:CreationDate": Joi.string().optional().empty(""),
 }).unknown(true);
 
 const trackMetadataSchema = Joi.object({


### PR DESCRIPTION
Currently, if an optional string field in the METS file from which we extract metadata in the metadata attacher lambda is an empty string, validation fails, causing the lambda execution to fail. This commit updates the validator to instead set the field to undefined if it is an empty string, allowing the lambda to handle it like any other missing field.