### PR TITLE
Per 10435 storage purchase webhook

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -12,6 +12,7 @@ FUSIONAUTH_SFTP_APPLICATION_ID="<sftp application ID here>"
 
 LEGACY_BACKEND_HOST_URL='http://load_balancer:80/api'
 LEGACY_BACKEND_SHARED_SECRET="<shared secret here>"
+LEGACY_BACKEND_CREDIT_STORAGE_SECRET="<secret here>"
 
 MAILCHIMP_API_KEY="<API key here>"
 MAILCHIMP_TRANSACTIONAL_API_KEY="<API key here>"
@@ -47,3 +48,4 @@ ARCHIVEMATICA_PROCESSING_WORKFLOW="local_<dev_name>"
 STRIPE_SECRET_KEY="<Stripe secret key here>"
 
 DELEGATED_CALL_SECRET=local-test-delegated-call-secret
+STRIPE_WEBHOOK_SECRET="<webhook secret here>"

--- a/README.md
+++ b/README.md
@@ -90,7 +90,9 @@ For these, simply fill in any fake value to prevent `require-env-variable` from 
 | ARCHIVEMATICA_ORIGINAL_LOCATION_ID | none                                                      | Only needed for the archivematica_triggerer lambda. Check the dev storage service to find the ID of the correct location for your local env.                                                                        |
 | ARCHIVEMATICA_PROCESSING_WORKFLOW  | none                                                      | Only needed for the archivematica_triggerer lambda. Check dev Archivematica to find the find the correct processing workflow for your local env. It should have been created in CLOUD_SETUP.md, in the devenv repo. |
 | STRIPE_SECRET_KEY                  | none                                                      | Can be found in the Stripe dashboard. Use the test key for all non-prod envs.                                                                                                                                       |
+| STRIPE_WEBHOOK_SECRET              | none                                                      | Can be found in the Stripe dashboard.                                                                                                                                                                               |
 | DELEGATED_CALL_SECRET              | local-test-delegated-call-secret                          | A secret other servers pass to the stela API to verify their identities. This can be left as the default in local environments.                                                                                     |
+| SLACK_WEBHOOK_URL                  | none                                                      | Don't set this in your local environment unless you're testing Slack notifications specifically; we don't want to spam the channel                                                                                  |
 
 ## Linting
 

--- a/packages/api/src/app.ts
+++ b/packages/api/src/app.ts
@@ -20,6 +20,11 @@ app.use(
 );
 
 app.use(expressWinston.logger({ level: "http", winstonInstance: logger }));
+// Must be before express.json() so the raw body is available for Stripe signature verification
+app.use(
+	"/api/v2/storage-purchases/stripe/webhook",
+	express.raw({ type: "application/json" }),
+);
 app.use(express.json());
 
 // This is a temporary measure; it should be removed when the rest of

--- a/packages/api/src/legacy_client.test.ts
+++ b/packages/api/src/legacy_client.test.ts
@@ -2,6 +2,29 @@ import { legacyClient } from "./legacy_client";
 
 global.fetch = jest.fn();
 
+describe("creditStorage", () => {
+	test("should submit the correct request", async () => {
+		await legacyClient.creditStorage({
+			accountId: 1,
+			donationAmountInCents: 5000,
+			paymentIntentId: "pi_test123",
+		});
+
+		expect(fetch).toHaveBeenCalledWith("/billing/claimpledgemobile", {
+			method: "POST",
+			headers: {
+				"Content-Type": "application/json",
+			},
+			body: JSON.stringify({
+				accountId: 1,
+				donationAmountUSX: 5000,
+				pledgeId: "pi_test123",
+				donationToken: "",
+			}),
+		});
+	});
+});
+
 describe("transferArchiveOwnership", () => {
 	test("should submit the correct request", async () => {
 		const testEmail = "test@permanent.org";

--- a/packages/api/src/legacy_client.ts
+++ b/packages/api/src/legacy_client.ts
@@ -1,5 +1,7 @@
 const hostUrl = process.env["LEGACY_BACKEND_HOST_URL"] ?? "";
 const authenticationSecret = process.env["LEGACY_BACKEND_SHARED_SECRET"] ?? "";
+const creditStorageAuthenticationSecret =
+	process.env["LEGACY_BACKEND_CREDIT_STORAGE_SECRET"] ?? "";
 
 const transferArchiveOwnership = async (request: {
 	recipientEmail: string;
@@ -27,4 +29,24 @@ const transferArchiveOwnership = async (request: {
 	return response;
 };
 
-export const legacyClient = { transferArchiveOwnership };
+const creditStorage = async (request: {
+	accountId: number;
+	donationAmountInCents: number;
+	paymentIntentId: string;
+}): Promise<Response> => {
+	const response = await fetch(`${hostUrl}/billing/claimpledgemobile`, {
+		method: "POST",
+		headers: {
+			"Content-Type": "application/json",
+		},
+		body: JSON.stringify({
+			accountId: request.accountId,
+			donationAmountUSX: request.donationAmountInCents,
+			pledgeId: request.paymentIntentId,
+			donationToken: creditStorageAuthenticationSecret,
+		}),
+	});
+	return response;
+};
+
+export const legacyClient = { transferArchiveOwnership, creditStorage };

--- a/packages/api/src/storage_purchase/controller.test.ts
+++ b/packages/api/src/storage_purchase/controller.test.ts
@@ -1,12 +1,16 @@
 import request from "supertest";
+import Stripe from "stripe";
+import { logger } from "@stela/logger";
 import { app } from "../app";
 import { db } from "../database";
 import { stripeClient } from "../stripe";
+import { legacyClient } from "../legacy_client";
 import { verifyUserAuthentication } from "../middleware";
 import { mockVerifyUserAuthentication } from "../../test/middleware_mocks";
 
 jest.mock("../database");
 jest.mock("../stripe");
+jest.mock("../legacy_client");
 jest.mock("../middleware");
 jest.mock("@stela/logger");
 
@@ -232,5 +236,252 @@ describe("POST /storage-purchases", () => {
 			.post("/api/v2/storage-purchases")
 			.send({ amountInUSD: 10 })
 			.expect(500);
+	});
+});
+
+describe("POST /storage-purchases/stripe/webhook", () => {
+	const agent = request(app);
+
+	const mockPaymentIntent = {
+		id: "pi_test123",
+		customer: "cus_existing123",
+		amount: 10000,
+	};
+
+	const mockSuccessEvent = {
+		type: "payment_intent.succeeded",
+		data: { object: mockPaymentIntent },
+	};
+
+	beforeEach(async () => {
+		process.env["STRIPE_WEBHOOK_SECRET"] = "test_webhook_secret";
+		jest
+			.spyOn(stripeClient.webhooks, "constructEvent")
+			.mockImplementation(jest.fn().mockReturnValue(mockSuccessEvent));
+		jest
+			.spyOn(legacyClient, "creditStorage")
+			.mockImplementation(jest.fn().mockResolvedValue({ ok: true }));
+		await clearDatabase();
+		await loadFixtures();
+	});
+
+	afterEach(async () => {
+		delete process.env["STRIPE_WEBHOOK_SECRET"];
+		delete process.env["SLACK_WEBHOOK_URL"];
+		await clearDatabase();
+		jest.restoreAllMocks();
+		jest.clearAllMocks();
+	});
+
+	test("should return 400 if no stripe-signature header", async () => {
+		await agent
+			.post("/api/v2/storage-purchases/stripe/webhook")
+			.set("Content-Type", "application/json")
+			.send("{}")
+			.expect(400);
+	});
+
+	test("should return 400 if the body is not a raw buffer", async () => {
+		await agent
+			.post("/api/v2/storage-purchases/stripe/webhook")
+			.set("stripe-signature", "test_sig")
+			.set("Content-Type", "text/plain")
+			.send("not a buffer")
+			.expect(400);
+	});
+
+	test("should return 400 if Stripe signature verification fails", async () => {
+		const signatureError = new Stripe.errors.StripeSignatureVerificationError({
+			type: "api_error",
+		});
+		jest.spyOn(stripeClient.webhooks, "constructEvent").mockImplementationOnce(
+			jest.fn().mockImplementation(() => {
+				throw signatureError;
+			}),
+		);
+		await agent
+			.post("/api/v2/storage-purchases/stripe/webhook")
+			.set("stripe-signature", "invalid_sig")
+			.set("Content-Type", "application/json")
+			.send("{}")
+			.expect(400);
+	});
+
+	test("should return 200 on payment_intent.succeeded", async () => {
+		await agent
+			.post("/api/v2/storage-purchases/stripe/webhook")
+			.set("stripe-signature", "test_sig")
+			.set("Content-Type", "application/json")
+			.send("{}")
+			.expect(200);
+	});
+
+	test("should call creditStorage with the correct params on payment_intent.succeeded", async () => {
+		await agent
+			.post("/api/v2/storage-purchases/stripe/webhook")
+			.set("stripe-signature", "test_sig")
+			.set("Content-Type", "application/json")
+			.send("{}");
+		expect(legacyClient.creditStorage).toHaveBeenCalledWith({
+			accountId: 3,
+			donationAmountInCents: 10000,
+			paymentIntentId: "pi_test123",
+		});
+	});
+
+	test("should return 200 on payment_intent.payment_failed and log the failure", async () => {
+		jest.spyOn(stripeClient.webhooks, "constructEvent").mockImplementation(
+			jest.fn().mockReturnValueOnce({
+				type: "payment_intent.payment_failed",
+				data: { object: mockPaymentIntent },
+			}),
+		);
+		await agent
+			.post("/api/v2/storage-purchases/stripe/webhook")
+			.set("stripe-signature", "test_sig")
+			.set("Content-Type", "application/json")
+			.send("{}")
+			.expect(200);
+		expect(logger.info).toHaveBeenCalledWith("Stripe payment failed", {
+			paymentIntentId: "pi_test123",
+		});
+	});
+
+	test("should return 200 on unhandled event types", async () => {
+		jest.spyOn(stripeClient.webhooks, "constructEvent").mockImplementation(
+			jest.fn().mockReturnValueOnce({
+				type: "customer.created",
+				data: { object: {} },
+			}),
+		);
+		await agent
+			.post("/api/v2/storage-purchases/stripe/webhook")
+			.set("stripe-signature", "test_sig")
+			.set("Content-Type", "application/json")
+			.send("{}")
+			.expect(200);
+	});
+
+	test("should return 500 if the webhook secret is not set", async () => {
+		delete process.env["STRIPE_WEBHOOK_SECRET"];
+		await agent
+			.post("/api/v2/storage-purchases/stripe/webhook")
+			.set("stripe-signature", "test_sig")
+			.set("Content-Type", "application/json")
+			.send("{}")
+			.expect(500);
+	});
+
+	test("should return 400 if the payment intent customer is not a string", async () => {
+		jest.spyOn(stripeClient.webhooks, "constructEvent").mockImplementation(
+			jest.fn().mockReturnValue({
+				...mockSuccessEvent,
+				data: { object: { ...mockPaymentIntent, customer: null } },
+			}),
+		);
+		await agent
+			.post("/api/v2/storage-purchases/stripe/webhook")
+			.set("stripe-signature", "test_sig")
+			.set("Content-Type", "application/json")
+			.send("{}")
+			.expect(400);
+	});
+
+	test("should return 500 if the account lookup fails", async () => {
+		jest
+			.spyOn(db, "sql")
+			.mockImplementationOnce(
+				jest.fn().mockRejectedValueOnce(new Error("DB error")),
+			);
+		await agent
+			.post("/api/v2/storage-purchases/stripe/webhook")
+			.set("stripe-signature", "test_sig")
+			.set("Content-Type", "application/json")
+			.send("{}")
+			.expect(500);
+	});
+
+	test("should return 500 if no account is found for the Stripe customer", async () => {
+		jest
+			.spyOn(db, "sql")
+			.mockImplementationOnce(jest.fn().mockResolvedValueOnce({ rows: [] }));
+		await agent
+			.post("/api/v2/storage-purchases/stripe/webhook")
+			.set("stripe-signature", "test_sig")
+			.set("Content-Type", "application/json")
+			.send("{}")
+			.expect(500);
+	});
+
+	test("should return 500 if creditStorage throws", async () => {
+		jest
+			.spyOn(legacyClient, "creditStorage")
+			.mockRejectedValueOnce(new Error("Network error"));
+		await agent
+			.post("/api/v2/storage-purchases/stripe/webhook")
+			.set("stripe-signature", "test_sig")
+			.set("Content-Type", "application/json")
+			.send("{}")
+			.expect(500);
+	});
+
+	test("should return 500 if the legacy API returns an error", async () => {
+		jest
+			.spyOn(legacyClient, "creditStorage")
+			.mockImplementation(
+				jest.fn().mockResolvedValueOnce({ ok: false, status: 500 }),
+			);
+		await agent
+			.post("/api/v2/storage-purchases/stripe/webhook")
+			.set("stripe-signature", "test_sig")
+			.set("Content-Type", "application/json")
+			.send("{}")
+			.expect(500);
+	});
+
+	test("should send a Slack notification on payment_intent.succeeded", async () => {
+		process.env["SLACK_WEBHOOK_URL"] = "https://hooks.slack.com/test";
+		jest
+			.spyOn(global, "fetch")
+			.mockImplementation(jest.fn().mockResolvedValue({ ok: true }));
+		await agent
+			.post("/api/v2/storage-purchases/stripe/webhook")
+			.set("stripe-signature", "test_sig")
+			.set("Content-Type", "application/json")
+			.send("{}");
+		expect(global.fetch).toHaveBeenCalledWith(
+			"https://hooks.slack.com/test",
+			expect.objectContaining({
+				method: "POST",
+				body: JSON.stringify({
+					text: "NEW PURCHASE - Test User 2 just spent $100 on storage!",
+					icon_url:
+						"https://www.permanent.org/app/assets/icon/android-chrome-192x192.png",
+				}),
+			}),
+		);
+	});
+
+	test("should not send a Slack notification if SLACK_WEBHOOK_URL is not set", async () => {
+		jest
+			.spyOn(global, "fetch")
+			.mockImplementation(jest.fn().mockResolvedValue({ ok: true }));
+		await agent
+			.post("/api/v2/storage-purchases/stripe/webhook")
+			.set("stripe-signature", "test_sig")
+			.set("Content-Type", "application/json")
+			.send("{}");
+		expect(global.fetch).not.toHaveBeenCalled();
+	});
+
+	test("should return 200 if the Slack notification fails", async () => {
+		process.env["SLACK_WEBHOOK_URL"] = "https://hooks.slack.com/test";
+		jest.spyOn(global, "fetch").mockRejectedValue(new Error("Slack error"));
+		await agent
+			.post("/api/v2/storage-purchases/stripe/webhook")
+			.set("stripe-signature", "test_sig")
+			.set("Content-Type", "application/json")
+			.send("{}")
+			.expect(200);
 	});
 });

--- a/packages/api/src/storage_purchase/controller.ts
+++ b/packages/api/src/storage_purchase/controller.ts
@@ -1,12 +1,41 @@
 import { Router } from "express";
 import type { Request, Response, NextFunction } from "express";
 import { verifyUserAuthentication } from "../middleware";
-import { validateStoragePurchaseRequest } from "./validators";
+import {
+	validateStoragePurchaseRequest,
+	validateStripeWebhookBody,
+} from "./validators";
 import { isValidationError } from "../validators/validator_util";
-import { initiateStoragePurchase } from "./service";
+import { initiateStoragePurchase, handleStripeWebhook } from "./service";
 import { HTTP_STATUS } from "@pdc/http-status-codes";
 
 export const storagePurchaseController = Router();
+
+storagePurchaseController.post(
+	"/stripe/webhook",
+	async (req: Request, res: Response, next: NextFunction) => {
+		try {
+			const {
+				headers: { "stripe-signature": signature },
+			} = req;
+			if (typeof signature !== "string") {
+				res.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST).end();
+				return;
+			}
+			validateStripeWebhookBody(req.body);
+			await handleStripeWebhook(req.body, signature);
+			res.status(HTTP_STATUS.SUCCESSFUL.OK).end();
+		} catch (err) {
+			if (isValidationError(err)) {
+				res
+					.status(HTTP_STATUS.CLIENT_ERROR.BAD_REQUEST)
+					.json({ error: err.message });
+				return;
+			}
+			next(err);
+		}
+	},
+);
 
 storagePurchaseController.post(
 	"/",

--- a/packages/api/src/storage_purchase/queries/get_account_by_stripe_customer_id.sql
+++ b/packages/api/src/storage_purchase/queries/get_account_by_stripe_customer_id.sql
@@ -1,0 +1,5 @@
+SELECT
+  accountid AS "accountId",
+  fullname AS name
+FROM account
+WHERE stripecustomerid = :stripeCustomerId;

--- a/packages/api/src/storage_purchase/service.ts
+++ b/packages/api/src/storage_purchase/service.ts
@@ -1,7 +1,9 @@
+import Stripe from "stripe";
 import createError from "http-errors";
 import { logger } from "@stela/logger";
 import { db } from "../database";
 import { stripeClient } from "../stripe";
+import { legacyClient } from "../legacy_client";
 import type { StoragePurchaseRequest, StoragePurchaseResponse } from "./models";
 
 const CENTS_PER_DOLLAR = 100;
@@ -115,4 +117,122 @@ export const initiateStoragePurchase = async (
 	return {
 		clientSecret: paymentIntent.client_secret,
 	};
+};
+
+export const handleStripeWebhook = async (
+	rawBody: Buffer,
+	signature: string | string[],
+): Promise<void> => {
+	const {
+		env: { STRIPE_WEBHOOK_SECRET: webhookSecret },
+	} = process;
+	if (webhookSecret === undefined) {
+		logger.error("STRIPE_WEBHOOK_SECRET is not configured");
+		throw new createError.InternalServerError(
+			"Stripe webhook secret is not configured",
+		);
+	}
+
+	try {
+		const event = stripeClient.webhooks.constructEvent(
+			rawBody,
+			signature,
+			webhookSecret,
+		);
+
+		switch (event.type) {
+			case "payment_intent.succeeded":
+				await creditAccountStorage(event.data.object);
+				break;
+			case "payment_intent.payment_failed":
+				logger.info("Stripe payment failed", {
+					paymentIntentId: event.data.object.id,
+				});
+				break;
+			default: // This is an event that we don't need to take action upon
+		}
+	} catch (err) {
+		if (err instanceof Stripe.errors.StripeSignatureVerificationError) {
+			throw new createError.BadRequest("Invalid Stripe webhook signature");
+		}
+		throw err;
+	}
+};
+
+const sendSlackNotification = async (
+	name: string,
+	amountInDollars: number,
+): Promise<void> => {
+	const {
+		env: { SLACK_WEBHOOK_URL: webhookUrl },
+	} = process;
+	if (webhookUrl === undefined) {
+		return;
+	}
+
+	try {
+		const response = await fetch(webhookUrl, {
+			method: "POST",
+			headers: { "Content-Type": "application/json" },
+			body: JSON.stringify({
+				text: `NEW PURCHASE - ${name} just spent $${amountInDollars.toString()} on storage!`,
+				icon_url:
+					"https://www.permanent.org/app/assets/icon/android-chrome-192x192.png",
+			}),
+		});
+		if (!response.ok) {
+			logger.error(response.body);
+		}
+	} catch (err: unknown) {
+		logger.error(err);
+	}
+};
+
+const creditAccountStorage = async (
+	paymentIntent: Stripe.PaymentIntent,
+): Promise<void> => {
+	if (typeof paymentIntent.customer !== "string") {
+		throw new createError.BadRequest("Payment intent missing customer ID");
+	}
+
+	const accountResult = await db
+		.sql<{
+			accountId: string;
+			name: string;
+		}>("storage_purchase.queries.get_account_by_stripe_customer_id", {
+			stripeCustomerId: paymentIntent.customer,
+		})
+		.catch((err: unknown) => {
+			logger.error(err);
+			throw new createError.InternalServerError("Failed to look up account");
+		});
+
+	if (accountResult.rows[0] === undefined) {
+		throw new createError.InternalServerError(
+			"No account found for Stripe customer",
+		);
+	}
+
+	const claimResponse = await legacyClient
+		.creditStorage({
+			accountId: +accountResult.rows[0].accountId,
+			donationAmountInCents: paymentIntent.amount,
+			paymentIntentId: paymentIntent.id,
+		})
+		.catch((err: unknown) => {
+			logger.error(err);
+			throw new createError.InternalServerError("Failed to claim storage");
+		});
+
+	if (!claimResponse.ok) {
+		logger.error("Legacy API returned error for claimPledge", {
+			status: claimResponse.status,
+		});
+		throw new createError.InternalServerError("Failed to claim storage");
+	}
+
+	await sendSlackNotification(
+		accountResult.rows[0].name,
+		paymentIntent.amount / CENTS_PER_DOLLAR,
+	);
 };

--- a/packages/api/src/storage_purchase/validators.ts
+++ b/packages/api/src/storage_purchase/validators.ts
@@ -22,3 +22,12 @@ export const validateStoragePurchaseRequest: (
 		throw validation.error;
 	}
 };
+
+export const validateStripeWebhookBody: (
+	data: unknown,
+) => asserts data is Buffer = (data: unknown): asserts data is Buffer => {
+	const validation = Joi.binary().validate(data);
+	if (validation.error !== undefined) {
+		throw validation.error;
+	}
+};

--- a/terraform/prod_cluster/secrets.tf
+++ b/terraform/prod_cluster/secrets.tf
@@ -21,6 +21,8 @@ resource "kubernetes_secret" "prod-secrets" {
     "CLOUDFRONT_KEY_PAIR_ID"          = var.cloudfront_key_pair_id
     "CLOUDFRONT_PRIVATE_KEY"          = var.cloudfront_private_key
     "STRIPE_SECRET_KEY"               = var.stripe_secret_key
+    "STRIPE_WEBHOOK_SECRET"           = var.stripe_webhook_secret
     "DELEGATED_CALL_SECRET"           = var.delegated_call_secret
+    "SLACK_WEBHOOK_URL"               = var.slack_webhook_url
   }
 }

--- a/terraform/prod_cluster/stela_prod_deployment.tf
+++ b/terraform/prod_cluster/stela_prod_deployment.tf
@@ -64,6 +64,17 @@ resource "kubernetes_deployment" "stela_prod" {
           }
 
           env {
+            name = "LEGACY_BACKEND_CREDIT_STORAGE_SECRET"
+            value_from {
+              secret_key_ref {
+                name     = "prod-secrets"
+                key      = "LEGACY_BACKEND_CREDIT_STORAGE_SECRET"
+                optional = false
+              }
+            }
+          }
+
+          env {
             name  = "FUSIONAUTH_HOST"
             value = var.fusionauth_host
           }
@@ -224,6 +235,28 @@ resource "kubernetes_deployment" "stela_prod" {
               secret_key_ref {
                 name     = "prod-secrets"
                 key      = "DELEGATED_CALL_SECRET"
+                optional = false
+              }
+            }
+          }
+
+          env {
+            name = "STRIPE_WEBHOOK_SECRET"
+            value_from {
+              secret_key_ref {
+                name     = "prod-secrets"
+                key      = "STRIPE_WEBHOOK_SECRET"
+                optional = false
+              }
+            }
+          }
+
+          env {
+            name = "SLACK_WEBHOOK_URL"
+            value_from {
+              secret_key_ref {
+                name     = "prod-secrets"
+                key      = "SLACK_WEBHOOK_URL"
                 optional = false
               }
             }

--- a/terraform/prod_cluster/variables.tf
+++ b/terraform/prod_cluster/variables.tf
@@ -124,6 +124,11 @@ variable "prod_legacy_backend_shared_secret" {
   type        = string
 }
 
+variable "legacy_backend_credit_storage_secret" {
+  description = "Shared secret for authenticating calls to the legacy backend's credit storage endpoint"
+  type        = string
+}
+
 variable "mailchimp_api_key" {
   description = "API key for Mailchimp Marketing"
   type        = string
@@ -258,5 +263,15 @@ variable "stripe_secret_key" {
 
 variable "delegated_call_secret" {
   description = "Secret used to authenticate delegated calls in the prod environment"
+  type        = string
+}
+
+variable "stripe_webhook_secret" {
+  description = "A key used to authenticate calls to the Stripe webhook"
+  type        = string
+}
+
+variable "slack_webhook_url" {
+  description = "The webhook URL for posting messages in Permanent's slack"
   type        = string
 }

--- a/terraform/test_cluster/secrets.tf
+++ b/terraform/test_cluster/secrets.tf
@@ -21,6 +21,7 @@ resource "kubernetes_secret" "dev-secrets" {
     "CLOUDFRONT_KEY_PAIR_ID"          = var.cloudfront_key_pair_id
     "CLOUDFRONT_PRIVATE_KEY"          = var.cloudfront_private_key
     "STRIPE_SECRET_KEY"               = var.stripe_test_secret_key
+    "STRIPE_WEBHOOK_SECRET"           = var.stripe_dev_webhook_secret
     "DELEGATED_CALL_SECRET"           = var.dev_delegated_call_secret
   }
 }
@@ -48,6 +49,7 @@ resource "kubernetes_secret" "staging-secrets" {
     "CLOUDFRONT_KEY_PAIR_ID"          = var.cloudfront_key_pair_id
     "CLOUDFRONT_PRIVATE_KEY"          = var.cloudfront_private_key
     "STRIPE_SECRET_KEY"               = var.stripe_test_secret_key
+    "STRIPE_WEBHOOK_SECRET"           = var.stripe_staging_webhook_secret
     "DELEGATED_CALL_SECRET"           = var.staging_delegated_call_secret
   }
 }

--- a/terraform/test_cluster/stela_dev_deployment.tf
+++ b/terraform/test_cluster/stela_dev_deployment.tf
@@ -71,6 +71,17 @@ resource "kubernetes_deployment" "stela_dev" {
           }
 
           env {
+            name = "LEGACY_BACKEND_CREDIT_STORAGE_SECRET"
+            value_from {
+              secret_key_ref {
+                name     = "dev-secrets"
+                key      = "LEGACY_BACKEND_CREDIT_STORAGE_SECRET"
+                optional = false
+              }
+            }
+          }
+
+          env {
             name  = "FUSIONAUTH_HOST"
             value = var.fusionauth_host
           }
@@ -231,6 +242,17 @@ resource "kubernetes_deployment" "stela_dev" {
               secret_key_ref {
                 name     = "dev-secrets"
                 key      = "DELEGATED_CALL_SECRET"
+                optional = false
+              }
+            }
+          }
+
+          env {
+            name = "STRIPE_WEBHOOK_SECRET"
+            value_from {
+              secret_key_ref {
+                name     = "dev-secrets"
+                key      = "STRIPE_WEBHOOK_SECRET"
                 optional = false
               }
             }

--- a/terraform/test_cluster/stela_staging_deployment.tf
+++ b/terraform/test_cluster/stela_staging_deployment.tf
@@ -71,6 +71,17 @@ resource "kubernetes_deployment" "stela_staging" {
           }
 
           env {
+            name = "LEGACY_BACKEND_CREDIT_STORAGE_SECRET"
+            value_from {
+              secret_key_ref {
+                name     = "staging-secrets"
+                key      = "LEGACY_BACKEND_CREDIT_STORAGE_SECRET"
+                optional = false
+              }
+            }
+          }
+
+          env {
             name  = "FUSIONAUTH_HOST"
             value = var.fusionauth_host
           }
@@ -231,6 +242,17 @@ resource "kubernetes_deployment" "stela_staging" {
               secret_key_ref {
                 name     = "staging-secrets"
                 key      = "DELEGATED_CALL_SECRET"
+                optional = false
+              }
+            }
+          }
+
+          env {
+            name = "STRIPE_WEBHOOK_SECRET"
+            value_from {
+              secret_key_ref {
+                name     = "staging-secrets"
+                key      = "STRIPE_WEBHOOK_SECRET"
                 optional = false
               }
             }

--- a/terraform/test_cluster/variables.tf
+++ b/terraform/test_cluster/variables.tf
@@ -142,6 +142,16 @@ variable "staging_legacy_backend_shared_secret" {
   type        = string
 }
 
+variable "dev_legacy_backend_credit_storage_secret" {
+  description = "Shared secret for authenticating calls to the legacy backend's credit storage endpoint in the dev environment"
+  type        = string
+}
+
+variable "staging_legacy_backend_credit_storage_secret" {
+  description = "Shared secret for authenticating calls to the legacy backend's credit storage endpoint in the staging environment"
+  type        = string
+}
+
 variable "mailchimp_api_key" {
   description = "API key for Mailchimp Marketing"
   type        = string
@@ -366,5 +376,15 @@ variable "dev_delegated_call_secret" {
 
 variable "staging_delegated_call_secret" {
   description = "Secret used to authenticate delegated calls in the staging environment"
+  type        = string
+}
+
+variable "stripe_dev_webhook_secret" {
+  description = "A key used in dev for verifying requests to the stripe webhook"
+  type        = string
+}
+
+variable "stripe_staging_webhook_secret" {
+  description = "A key used in staging for verifying requests to the stripe webhook"
   type        = string
 }


### PR DESCRIPTION
Testing Instructions:
1. Install the [Stripe CLI](https://docs.stripe.com/stripe-cli/install)
2. Run `stripe listen --forward-to local.permanent.org/api/v2/storage-purchases/stripe/webhook`
3. Set the `STRIPE_WEBHOOK_SECRET` in your `.env` to the secret output in step 2.
4. In your local database, set `stripecustomerid` to the ID of a customer in the stripe test environment for one of your test users
5. Run `stripe trigger payment_intent.succeeded --override payment_intent:customer=<CUSTOMER_ID_FROM_STEP_4>`
6. Check `ledger_financial` to confirm that storage was issued to your test account