### PR TITLE
Consistently name EDTF metadata as displayTime

### DIFF
--- a/packages/api/docs/src/models/folder.yaml
+++ b/packages/api/docs/src/models/folder.yaml
@@ -63,7 +63,7 @@ folder:
     displayEndTimestamp:
       type: string
       format: date-time
-    displayTimeInEDTF:
+    displayTime:
       type: string
       format: edtf
     displayName:

--- a/packages/api/docs/src/models/record.yaml
+++ b/packages/api/docs/src/models/record.yaml
@@ -75,7 +75,7 @@ record:
     displayDate:
       type: string
       format: date-time
-    displayTimeInEDTF:
+    displayTime:
       type: string
       format: edtf
     fileCreatedAt:

--- a/packages/api/docs/src/paths/record.yaml
+++ b/packages/api/docs/src/paths/record.yaml
@@ -106,7 +106,7 @@ records/{id}:
                 type: integer
               description:
                 type: string
-              displayTimeInEDTF:
+              displayTime:
                 type: string
                 format: edtf
     responses:

--- a/packages/api/src/folder/controller/get_folder.test.ts
+++ b/packages/api/src/folder/controller/get_folder.test.ts
@@ -247,7 +247,7 @@ describe("GET /folder", () => {
 			expect(folders[0].displayEndTimestamp).toEqual(
 				"2025-01-01T00:00:00.000Z",
 			);
-			expect(folders[0].displayTimeInEDTF).toEqual("2025-01-01");
+			expect(folders[0].displayTime).toEqual("2025-01-01");
 			expect(folders[0].displayName).toEqual("Private Folder");
 			expect(folders[0].downloadName).toEqual("Private Folder");
 			expect(folders[0].imageRatio).toEqual(1);

--- a/packages/api/src/folder/controller/patch_folder.test.ts
+++ b/packages/api/src/folder/controller/patch_folder.test.ts
@@ -77,10 +77,10 @@ describe("patch folder", () => {
 		expect(result.rows[0]).toStrictEqual({ displaydt: null });
 	});
 
-	test("expect displayTimeInEDTF is updated", async () => {
+	test("expect displayTime is updated", async () => {
 		await agent
 			.patch("/api/v2/folders/1")
-			.send({ displayTimeInEDTF: "2024-1X" })
+			.send({ displayTime: "2024-1X" })
 			.expect(200);
 
 		const result = await db.query(
@@ -93,10 +93,10 @@ describe("patch folder", () => {
 		expect(result.rows[0]).toEqual({ displaytime: "2024-1X" });
 	});
 
-	test("expect displayTimeInEDTF is updated when set to null", async () => {
+	test("expect displayTime is updated when set to null", async () => {
 		await agent
 			.patch("/api/v2/folders/2")
-			.send({ displayTimeInEDTF: null })
+			.send({ displayTime: null })
 			.expect(200);
 
 		const result = await db.query(
@@ -109,10 +109,10 @@ describe("patch folder", () => {
 		expect(result.rows[0]).toEqual({ displaytime: null });
 	});
 
-	test("expect 400 error when displayTimeInEDTF is not valid Level 1 EDTF", async () => {
+	test("expect 400 error when displayTime is not valid Level 1 EDTF", async () => {
 		await agent
 			.patch("/api/v2/folders/2")
-			.send({ displayTimeInEDTF: "2024-33" })
+			.send({ displayTime: "2024-33" })
 			.expect(400);
 	});
 
@@ -234,7 +234,7 @@ describe("patch folder", () => {
 		test("expect displaytimelowerbound is set for year only (YYYY)", async () => {
 			await agent
 				.patch("/api/v2/folder/1")
-				.send({ displayTimeInEDTF: "2024" })
+				.send({ displayTime: "2024" })
 				.expect(200);
 
 			const result = await db.query(
@@ -250,7 +250,7 @@ describe("patch folder", () => {
 		test("expect displaytimelowerbound is set for year-month (YYYY-MM)", async () => {
 			await agent
 				.patch("/api/v2/folder/1")
-				.send({ displayTimeInEDTF: "2024-06" })
+				.send({ displayTime: "2024-06" })
 				.expect(200);
 
 			const result = await db.query(
@@ -266,7 +266,7 @@ describe("patch folder", () => {
 		test("expect displaytimelowerbound is set for full date (YYYY-MM-DD)", async () => {
 			await agent
 				.patch("/api/v2/folder/1")
-				.send({ displayTimeInEDTF: "2024-06-15" })
+				.send({ displayTime: "2024-06-15" })
 				.expect(200);
 
 			const result = await db.query(
@@ -282,7 +282,7 @@ describe("patch folder", () => {
 		test("expect displaytimelowerbound is set for date with time (YYYY-MM-DDTHH:MM:SS)", async () => {
 			await agent
 				.patch("/api/v2/folder/1")
-				.send({ displayTimeInEDTF: "2024-06-15T14:30:45" })
+				.send({ displayTime: "2024-06-15T14:30:45" })
 				.expect(200);
 
 			const result = await db.query(
@@ -298,7 +298,7 @@ describe("patch folder", () => {
 		test("expect displaytimelowerbound is set for date with UTC timezone (YYYY-MM-DDTHH:MM:SSZ)", async () => {
 			await agent
 				.patch("/api/v2/folder/1")
-				.send({ displayTimeInEDTF: "2024-06-15T14:30:45Z" })
+				.send({ displayTime: "2024-06-15T14:30:45Z" })
 				.expect(200);
 
 			const result = await db.query(
@@ -314,7 +314,7 @@ describe("patch folder", () => {
 		test("expect displaytimelowerbound is set for date with timezone offset (YYYY-MM-DDTHH:MM:SS+HH:MM)", async () => {
 			await agent
 				.patch("/api/v2/folder/1")
-				.send({ displayTimeInEDTF: "2024-06-15T14:30:45-07:00" })
+				.send({ displayTime: "2024-06-15T14:30:45-07:00" })
 				.expect(200);
 
 			const result = await db.query(
@@ -330,7 +330,7 @@ describe("patch folder", () => {
 		test("expect displaytimelowerbound is set for uncertain date (YYYY-MM-DD?)", async () => {
 			await agent
 				.patch("/api/v2/folder/1")
-				.send({ displayTimeInEDTF: "2024-06-15?" })
+				.send({ displayTime: "2024-06-15?" })
 				.expect(200);
 
 			const result = await db.query(
@@ -346,7 +346,7 @@ describe("patch folder", () => {
 		test("expect displaytimelowerbound is set for uncertain year (YYYY?)", async () => {
 			await agent
 				.patch("/api/v2/folder/1")
-				.send({ displayTimeInEDTF: "2024?" })
+				.send({ displayTime: "2024?" })
 				.expect(200);
 
 			const result = await db.query(
@@ -362,7 +362,7 @@ describe("patch folder", () => {
 		test("expect displaytimelowerbound is set for uncertain year-month (YYYY-MM?)", async () => {
 			await agent
 				.patch("/api/v2/folder/1")
-				.send({ displayTimeInEDTF: "2024-06?" })
+				.send({ displayTime: "2024-06?" })
 				.expect(200);
 
 			const result = await db.query(
@@ -378,7 +378,7 @@ describe("patch folder", () => {
 		test("expect displaytimelowerbound is set for approximate date (YYYY-MM-DD~)", async () => {
 			await agent
 				.patch("/api/v2/folder/1")
-				.send({ displayTimeInEDTF: "2024-06-15~" })
+				.send({ displayTime: "2024-06-15~" })
 				.expect(200);
 
 			const result = await db.query(
@@ -394,7 +394,7 @@ describe("patch folder", () => {
 		test("expect displaytimelowerbound is set for uncertain and approximate date (YYYY-MM-DD%)", async () => {
 			await agent
 				.patch("/api/v2/folder/1")
-				.send({ displayTimeInEDTF: "2024-06-15%" })
+				.send({ displayTime: "2024-06-15%" })
 				.expect(200);
 
 			const result = await db.query(
@@ -410,7 +410,7 @@ describe("patch folder", () => {
 		test("expect displaytimelowerbound is set for uncertain and approximate year (YYYY%)", async () => {
 			await agent
 				.patch("/api/v2/folder/1")
-				.send({ displayTimeInEDTF: "2024%" })
+				.send({ displayTime: "2024%" })
 				.expect(200);
 
 			const result = await db.query(
@@ -426,7 +426,7 @@ describe("patch folder", () => {
 		test("expect displaytimelowerbound is set for unspecified day (YYYY-MM-XX)", async () => {
 			await agent
 				.patch("/api/v2/folder/1")
-				.send({ displayTimeInEDTF: "2024-06-XX" })
+				.send({ displayTime: "2024-06-XX" })
 				.expect(200);
 
 			const result = await db.query(
@@ -442,7 +442,7 @@ describe("patch folder", () => {
 		test("expect displaytimelowerbound is set for unspecified month (YYYY-XX)", async () => {
 			await agent
 				.patch("/api/v2/folder/1")
-				.send({ displayTimeInEDTF: "2024-XX" })
+				.send({ displayTime: "2024-XX" })
 				.expect(200);
 
 			const result = await db.query(
@@ -458,7 +458,7 @@ describe("patch folder", () => {
 		test("expect displaytimelowerbound is set for unspecified year digits (19XX)", async () => {
 			await agent
 				.patch("/api/v2/folder/1")
-				.send({ displayTimeInEDTF: "19XX" })
+				.send({ displayTime: "19XX" })
 				.expect(200);
 
 			const result = await db.query(
@@ -474,7 +474,7 @@ describe("patch folder", () => {
 		test("expect displaytimelowerbound is set for multiple unspecified digits (1XXX)", async () => {
 			await agent
 				.patch("/api/v2/folder/1")
-				.send({ displayTimeInEDTF: "1XXX" })
+				.send({ displayTime: "1XXX" })
 				.expect(200);
 
 			const result = await db.query(
@@ -490,7 +490,7 @@ describe("patch folder", () => {
 		test("expect displaytimelowerbound is -infinity for completely unspecified year (XXXX)", async () => {
 			await agent
 				.patch("/api/v2/folder/1")
-				.send({ displayTimeInEDTF: "XXXX" })
+				.send({ displayTime: "XXXX" })
 				.expect(200);
 
 			const result = await db.query(
@@ -504,7 +504,7 @@ describe("patch folder", () => {
 		test("expect displaytimelowerbound is set for full interval (YYYY-MM-DD/YYYY-MM-DD)", async () => {
 			await agent
 				.patch("/api/v2/folder/1")
-				.send({ displayTimeInEDTF: "2024-01-15/2024-06-15" })
+				.send({ displayTime: "2024-01-15/2024-06-15" })
 				.expect(200);
 
 			const result = await db.query(
@@ -520,7 +520,7 @@ describe("patch folder", () => {
 		test("expect displaytimelowerbound is set for interval with open end (YYYY-MM-DD/..)", async () => {
 			await agent
 				.patch("/api/v2/folder/1")
-				.send({ displayTimeInEDTF: "2024-01-15/.." })
+				.send({ displayTime: "2024-01-15/.." })
 				.expect(200);
 
 			const result = await db.query(
@@ -536,7 +536,7 @@ describe("patch folder", () => {
 		test("expect displaytimelowerbound is -infinity for interval with open start (../YYYY-MM-DD)", async () => {
 			await agent
 				.patch("/api/v2/folder/1")
-				.send({ displayTimeInEDTF: "../2024-06-15" })
+				.send({ displayTime: "../2024-06-15" })
 				.expect(200);
 
 			const result = await db.query(
@@ -550,7 +550,7 @@ describe("patch folder", () => {
 		test("expect displaytimelowerbound is -infinity for interval with unknown start (/YYYY-MM-DD)", async () => {
 			await agent
 				.patch("/api/v2/folder/1")
-				.send({ displayTimeInEDTF: "/2024-06-15" })
+				.send({ displayTime: "/2024-06-15" })
 				.expect(200);
 
 			const result = await db.query(
@@ -564,7 +564,7 @@ describe("patch folder", () => {
 		test("expect displaytimelowerbound is set for year interval (YYYY/YYYY)", async () => {
 			await agent
 				.patch("/api/v2/folder/1")
-				.send({ displayTimeInEDTF: "2020/2024" })
+				.send({ displayTime: "2020/2024" })
 				.expect(200);
 
 			const result = await db.query(
@@ -580,7 +580,7 @@ describe("patch folder", () => {
 		test("expect displaytimelowerbound is set for spring (YYYY-21)", async () => {
 			await agent
 				.patch("/api/v2/folder/1")
-				.send({ displayTimeInEDTF: "2024-21" })
+				.send({ displayTime: "2024-21" })
 				.expect(200);
 
 			const result = await db.query(
@@ -596,7 +596,7 @@ describe("patch folder", () => {
 		test("expect displaytimelowerbound is set for summer (YYYY-22)", async () => {
 			await agent
 				.patch("/api/v2/folder/1")
-				.send({ displayTimeInEDTF: "2024-22" })
+				.send({ displayTime: "2024-22" })
 				.expect(200);
 
 			const result = await db.query(
@@ -612,7 +612,7 @@ describe("patch folder", () => {
 		test("expect displaytimelowerbound is set for autumn (YYYY-23)", async () => {
 			await agent
 				.patch("/api/v2/folder/1")
-				.send({ displayTimeInEDTF: "2024-23" })
+				.send({ displayTime: "2024-23" })
 				.expect(200);
 
 			const result = await db.query(
@@ -628,7 +628,7 @@ describe("patch folder", () => {
 		test("expect displaytimelowerbound is set for winter (YYYY-24)", async () => {
 			await agent
 				.patch("/api/v2/folder/1")
-				.send({ displayTimeInEDTF: "2024-24" })
+				.send({ displayTime: "2024-24" })
 				.expect(200);
 
 			const result = await db.query(
@@ -644,7 +644,7 @@ describe("patch folder", () => {
 		test("expect displaytimelowerbound is set for uncertain season (YYYY-21?)", async () => {
 			await agent
 				.patch("/api/v2/folder/1")
-				.send({ displayTimeInEDTF: "2024-21?" })
+				.send({ displayTime: "2024-21?" })
 				.expect(200);
 
 			const result = await db.query(
@@ -660,7 +660,7 @@ describe("patch folder", () => {
 		test("expect displaytimelowerbound is set for five-digit year (Y17000)", async () => {
 			await agent
 				.patch("/api/v2/folder/1")
-				.send({ displayTimeInEDTF: "Y17000" })
+				.send({ displayTime: "Y17000" })
 				.expect(200);
 
 			const result = await db.query(
@@ -676,7 +676,7 @@ describe("patch folder", () => {
 		test("expect displaytimelowerbound is set for negative year after 4000 BC (-3000)", async () => {
 			await agent
 				.patch("/api/v2/folder/1")
-				.send({ displayTimeInEDTF: "-3000" })
+				.send({ displayTime: "-3000" })
 				.expect(200);
 
 			const result = await db.query(
@@ -692,7 +692,7 @@ describe("patch folder", () => {
 		test("expect displaytimelowerbound is -infinity for year before PostgreSQL timestamp range (Y-10000)", async () => {
 			await agent
 				.patch("/api/v2/folder/1")
-				.send({ displayTimeInEDTF: "Y-10000" })
+				.send({ displayTime: "Y-10000" })
 				.expect(200);
 
 			const result = await db.query(
@@ -706,7 +706,7 @@ describe("patch folder", () => {
 		test("expect displaytimelowerbound is infinity for year after PostgreSQL timestamp range (Y300000)", async () => {
 			await agent
 				.patch("/api/v2/folder/1")
-				.send({ displayTimeInEDTF: "Y300000" })
+				.send({ displayTime: "Y300000" })
 				.expect(200);
 
 			const result = await db.query(
@@ -720,7 +720,7 @@ describe("patch folder", () => {
 		test("expect displaytimelowerbound is set for unspecified day with uncertainty (YYYY-MM-XX?)", async () => {
 			await agent
 				.patch("/api/v2/folder/1")
-				.send({ displayTimeInEDTF: "2024-06-XX?" })
+				.send({ displayTime: "2024-06-XX?" })
 				.expect(200);
 
 			const result = await db.query(
@@ -736,7 +736,7 @@ describe("patch folder", () => {
 		test("expect displaytimelowerbound is set for interval with uncertain dates (YYYY-MM-DD?/YYYY-MM-DD?)", async () => {
 			await agent
 				.patch("/api/v2/folder/1")
-				.send({ displayTimeInEDTF: "2024-01-15?/2024-06-15?" })
+				.send({ displayTime: "2024-01-15?/2024-06-15?" })
 				.expect(200);
 
 			const result = await db.query(
@@ -749,17 +749,17 @@ describe("patch folder", () => {
 			});
 		});
 
-		test("expect displaytimelowerbound is set to null when displayTimeInEDTF is set to null", async () => {
-			// First set a displayTimeInEDTF
+		test("expect displaytimelowerbound is set to null when displayTime is set to null", async () => {
+			// First set a displayTime
 			await agent
 				.patch("/api/v2/folder/1")
-				.send({ displayTimeInEDTF: "2024-06-15" })
+				.send({ displayTime: "2024-06-15" })
 				.expect(200);
 
 			// Then set it to null
 			await agent
 				.patch("/api/v2/folder/1")
-				.send({ displayTimeInEDTF: null })
+				.send({ displayTime: null })
 				.expect(200);
 
 			const result = await db.query(

--- a/packages/api/src/folder/models.ts
+++ b/packages/api/src/folder/models.ts
@@ -32,7 +32,7 @@ export interface FolderRow {
 	description?: string;
 	displayTimestamp?: string;
 	displayEndTimestamp?: string;
-	displayTimeInEDTF?: string;
+	displayTime?: string;
 	displayName: string;
 	downloadName?: string;
 	imageRatio?: string;
@@ -80,7 +80,7 @@ export interface Folder {
 	description?: string;
 	displayTimestamp?: string;
 	displayEndTimestamp?: string;
-	displayTimeInEDTF?: string;
+	displayTime?: string;
 	displayName: string;
 	downloadName?: string;
 	imageRatio?: number;
@@ -123,7 +123,7 @@ export interface PatchFolderRequest {
 	emailFromAuthToken: string;
 	displayDate?: string | null;
 	displayEndDate?: string | null;
-	displayTimeInEDTF?: string | null;
+	displayTime?: string | null;
 }
 
 export enum FolderStatus {

--- a/packages/api/src/folder/queries/get_folders.sql
+++ b/packages/api/src/folder/queries/get_folders.sql
@@ -194,7 +194,7 @@ SELECT
   folder.description,
   folder.displaydt AS "displayTimestamp",
   folder.displayenddt AS "displayEndTimestamp",
-  folder.displaytime AS "displayTimeInEDTF",
+  folder.displaytime AS "displayTime",
   folder.displayname AS "displayName",
   folder.downloadname AS "downloadName",
   folder.imageratio AS "imageRatio",

--- a/packages/api/src/folder/service.ts
+++ b/packages/api/src/folder/service.ts
@@ -223,8 +223,8 @@ export const patchFolder = async (
 			setDisplayDateToNull: folderData.displayDate === null,
 			displayEndDate: folderData.displayEndDate,
 			setDisplayEndDateToNull: folderData.displayEndDate === null,
-			displayTime: folderData.displayTimeInEDTF,
-			setDisplayTimeToNull: folderData.displayTimeInEDTF === null,
+			displayTime: folderData.displayTime,
+			setDisplayTimeToNull: folderData.displayTime === null,
 		})
 		.catch((err: unknown) => {
 			logger.error(err);

--- a/packages/api/src/folder/validators.ts
+++ b/packages/api/src/folder/validators.ts
@@ -28,7 +28,7 @@ export const validatePatchFolderRequest: (
 			...fieldsFromUserAuthentication,
 			displayDate: Joi.string().optional().allow(null),
 			displayEndDate: Joi.string().optional().allow(null),
-			displayTimeInEDTF: Joi.string()
+			displayTime: Joi.string()
 				.custom((value: string) => {
 					if (isValidEDTF(value, 1)) {
 						return value;
@@ -39,7 +39,7 @@ export const validatePatchFolderRequest: (
 				.optional()
 				.allow(null),
 		})
-		.or("displayDate", "displayEndDate", "displayTimeInEDTF")
+		.or("displayDate", "displayEndDate", "displayTime")
 		.validate(data);
 
 	if (validation.error !== undefined) {

--- a/packages/api/src/record/controller.test.ts
+++ b/packages/api/src/record/controller.test.ts
@@ -715,7 +715,7 @@ describe("PATCH /records", () => {
 		await agent
 			.patch("/api/v2/records/1")
 			.send({
-				displayTimeInEDTF: "2001-34", // This is Level 2 EDTF for "Q2 of 2001"
+				displayTime: "2001-34", // This is Level 2 EDTF for "Q2 of 2001"
 			})
 			.expect(400);
 	});
@@ -723,7 +723,7 @@ describe("PATCH /records", () => {
 	test("expect display time is updated", async () => {
 		await agent
 			.patch("/api/v2/records/1")
-			.send({ displayTimeInEDTF: "2001-21~" })
+			.send({ displayTime: "2001-21~" })
 			.expect(200);
 
 		const result = await db.query(
@@ -739,7 +739,7 @@ describe("PATCH /records", () => {
 	test("expect display time is updated when set to null", async () => {
 		await agent
 			.patch("/api/v2/records/8")
-			.send({ displayTimeInEDTF: null })
+			.send({ displayTime: null })
 			.expect(200);
 
 		const result = await db.query(
@@ -791,8 +791,8 @@ describe("PATCH /records", () => {
 				setLocationIdToNull: false,
 				description: undefined,
 				setDescriptionToNull: false,
-				displayTimeInEDTF: undefined,
-				setDisplayTimeInEDTFToNull: false,
+				displayTime: undefined,
+				setDisplayTimeToNull: false,
 			})
 			.mockRejectedValueOnce(testError);
 
@@ -850,8 +850,8 @@ describe("PATCH /records", () => {
 				setLocationIdToNull: false,
 				description: undefined,
 				setDescriptionToNull: false,
-				displayTimeInEDTF: undefined,
-				setDisplayTimeInEDTFToNull: false,
+				displayTime: undefined,
+				setDisplayTimeToNull: false,
 			})
 			.mockImplementationOnce(
 				jest.fn().mockResolvedValueOnce({

--- a/packages/api/src/record/models.ts
+++ b/packages/api/src/record/models.ts
@@ -16,7 +16,7 @@ export interface ArchiveRecord {
 	uploadPayerAccountId?: string;
 	size?: number;
 	displayDate?: string;
-	displayTimeInEDTF?: string;
+	displayTime?: string;
 	fileCreatedAt?: string;
 	imageRatio?: number;
 	thumbUrl200?: string;
@@ -114,7 +114,7 @@ export interface PatchRecordRequest {
 	locationId?: bigint | null;
 	description?: string | null;
 	displayName?: string;
-	displayTimeInEDTF?: string | null;
+	displayTime?: string | null;
 }
 
 export enum RecordStatus {

--- a/packages/api/src/record/queries/get_records.sql
+++ b/packages/api/src/record/queries/get_records.sql
@@ -168,7 +168,7 @@ SELECT DISTINCT ON (record.recordid)
   record.uploadpayeraccountid AS "uploadPayerAccountId",
   record.size,
   record.displaydt AS "displayDate",
-  record.originalfilecreationtime AS "displayTimeInEDTF",
+  record.originalfilecreationtime AS "displayTime",
   record.derivedcreateddt AS "fileCreatedAt",
   record.imageratio AS "imageRatio",
   record.thumburl200 AS "thumbUrl200",

--- a/packages/api/src/record/queries/update_record.sql
+++ b/packages/api/src/record/queries/update_record.sql
@@ -11,8 +11,8 @@ SET
     ELSE COALESCE(:description, description)
   END,
   originalfilecreationtime = CASE
-    WHEN :setDisplayTimeInEDTFToNull THEN NULL
-    ELSE COALESCE(:displayTimeInEDTF, originalfilecreationtime)
+    WHEN :setDisplayTimeToNull THEN NULL
+    ELSE COALESCE(:displayTime, originalfilecreationtime)
   END,
   updateddt = CURRENT_TIMESTAMP
 WHERE

--- a/packages/api/src/record/service.ts
+++ b/packages/api/src/record/service.ts
@@ -80,8 +80,8 @@ export const patchRecord = async (
 			setLocationIdToNull: recordData.locationId === null,
 			description: recordData.description,
 			setDescriptionToNull: recordData.description === null,
-			displayTimeInEDTF: recordData.displayTimeInEDTF,
-			setDisplayTimeInEDTFToNull: recordData.displayTimeInEDTF === null,
+			displayTime: recordData.displayTime,
+			setDisplayTimeToNull: recordData.displayTime === null,
 		})
 		.catch((err: unknown) => {
 			logger.error(err);

--- a/packages/api/src/record/validators.ts
+++ b/packages/api/src/record/validators.ts
@@ -45,7 +45,7 @@ export const validatePatchRecordRequest: (
 			locationId: Joi.number().integer().optional().allow(null),
 			description: Joi.string().optional().allow(null),
 			displayName: Joi.string().min(1).optional(),
-			displayTimeInEDTF: Joi.string()
+			displayTime: Joi.string()
 				.custom((value: string) => {
 					if (isValidEDTF(value, 1)) {
 						return value;
@@ -58,7 +58,7 @@ export const validatePatchRecordRequest: (
 		})
 		// We can't use .min(1) here due to the auth fields being in the body
 		// See: https://github.com/PermanentOrg/stela/issues/407
-		.or("locationId", "description", "displayName", "displayTimeInEDTF")
+		.or("locationId", "description", "displayName", "displayTime")
 		.unknown(false)
 		.validate(data);
 


### PR DESCRIPTION
Currently, in some places the EDTF metadata field of records and folders is referred to as `displayTime`, and in others it's refered to as `displayTimeInEDTF`. This commit standardizes the API on `displayTime`.