### PR TITLE
Harden IP extraction middleware

### DIFF
--- a/packages/api/src/middleware/extract_ip.test.ts
+++ b/packages/api/src/middleware/extract_ip.test.ts
@@ -26,6 +26,21 @@ describe("extractIp", () => {
 		} = request as { body: { ip: string } };
 		expect(ip).toBe(testIp);
 	});
+	test("should extract IP from the remoteAddress if forwarded value is not an IP", () => {
+		const testIp = "192.168.0.1";
+		const request = createRequest({
+			headers: { "X-Forwarded-For": "unknown" },
+			socket: {
+				remoteAddress: testIp,
+			},
+		});
+		extractIp(request, createResponse(), jest.fn());
+
+		const {
+			body: { ip },
+		} = request as { body: { ip: string } };
+		expect(ip).toBe(testIp);
+	});
 	test("should extract the client IP from X-Forwarded-For header with multiple proxies", () => {
 		const testIp = "192.168.0.1";
 		const request = createRequest({ headers: { "X-Forwarded-For": testIp } });

--- a/packages/api/src/middleware/extract_ip.ts
+++ b/packages/api/src/middleware/extract_ip.ts
@@ -1,4 +1,5 @@
 import type { Request, Response, NextFunction } from "express";
+import Joi from "joi";
 
 const extractClientIpFromProxyList = (
 	list: string | undefined,
@@ -16,8 +17,12 @@ export const extractIp = (
 	_: Response,
 	next: NextFunction,
 ): void => {
+	const ipFromHeaders = extractClientIpFromProxyList(
+		req.get("X-Forwarded-For"),
+	);
 	req.body["ip"] =
-		extractClientIpFromProxyList(req.get("X-Forwarded-For")) ??
-		req.socket.remoteAddress;
+		Joi.string().ip().required().validate(ipFromHeaders).error === undefined
+			? ipFromHeaders
+			: req.socket.remoteAddress;
 	next();
 };


### PR DESCRIPTION
Currently, if the X-Forwarded-For header contains a value that is not an IP address, our IP extraction middleware will still attach that value to the request. This causes problems, because our PHP API will sometimes report an IP as "unknown". This commit updates the middleware to fall back to the requests socket address if the X-Forwarded-For header is not an IP.