### PR TITLE
Process the correct record upon record.copy events

### DIFF
--- a/packages/trigger_archivematica/src/fixtures/create_test_files.sql
+++ b/packages/trigger_archivematica/src/fixtures/create_test_files.sql
@@ -29,4 +29,14 @@ VALUES
   'originals/2/2',
   CURRENT_TIMESTAMP,
   CURRENT_TIMESTAMP
+),
+(
+  3,
+  1,
+  'status.generic.original',
+  1024,
+  'file.format.original',
+  'originals/3/3',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 );

--- a/packages/trigger_archivematica/src/fixtures/create_test_record_files.sql
+++ b/packages/trigger_archivematica/src/fixtures/create_test_record_files.sql
@@ -17,8 +17,16 @@ VALUES
   CURRENT_TIMESTAMP
 ),
 (
-  1,
+  3,
   2,
+  'status.generic.ok',
+  'type.generic.placeholder',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
+),
+(
+  2,
+  3,
   'status.generic.ok',
   'type.generic.placeholder',
   CURRENT_TIMESTAMP,

--- a/packages/trigger_archivematica/src/fixtures/create_test_records.sql
+++ b/packages/trigger_archivematica/src/fixtures/create_test_records.sql
@@ -25,4 +25,30 @@ VALUES
   'test_file.jpg',
   'status.generic.ok',
   'type.record.image'
+),
+(
+  2,
+  1,
+  '2023-06-21',
+  'Test File',
+  2,
+  1024,
+  2,
+  'test_file.jpg',
+  'test_file.jpg',
+  'status.generic.ok',
+  'type.record.image'
+),
+(
+  3,
+  1,
+  '2023-06-21',
+  'Test File',
+  2,
+  1024,
+  2,
+  'test_file.jpg',
+  'test_file.jpg',
+  'status.generic.ok',
+  'type.record.image'
 );

--- a/packages/trigger_archivematica/src/index.test.ts
+++ b/packages/trigger_archivematica/src/index.test.ts
@@ -3,7 +3,7 @@ import { mock } from "jest-mock-extended";
 import { logger } from "@stela/logger";
 import { triggerArchivematicaProcessing } from "@stela/archivematica-utils";
 import { db } from "./database";
-import { handler, extractRecordIdFromRecordCreateMessage } from "./index";
+import { handler, extractRecordIdFromNewRecordMessage } from "./index";
 
 jest.mock("./database");
 jest.mock("@stela/archivematica-utils", () => ({
@@ -64,7 +64,7 @@ describe("extractRecordIdFromRecordCreateMessage", () => {
 			awsRegion: "1",
 		};
 
-		const recordId = extractRecordIdFromRecordCreateMessage(message);
+		const recordId = extractRecordIdFromNewRecordMessage(message);
 		expect(recordId).toBe("123");
 	});
 
@@ -86,7 +86,7 @@ describe("extractRecordIdFromRecordCreateMessage", () => {
 			awsRegion: "1",
 		};
 
-		expect(() => extractRecordIdFromRecordCreateMessage(message)).toThrow(
+		expect(() => extractRecordIdFromNewRecordMessage(message)).toThrow(
 			"Invalid message body",
 		);
 	});
@@ -111,7 +111,7 @@ describe("extractRecordIdFromRecordCreateMessage", () => {
 			awsRegion: "1",
 		};
 
-		expect(() => extractRecordIdFromRecordCreateMessage(message)).toThrow(
+		expect(() => extractRecordIdFromNewRecordMessage(message)).toThrow(
 			"Invalid message",
 		);
 	});
@@ -140,8 +140,37 @@ describe("extractRecordIdFromRecordCreateMessage", () => {
 			awsRegion: "1",
 		};
 
-		expect(() => extractRecordIdFromRecordCreateMessage(message)).toThrow(
+		expect(() => extractRecordIdFromNewRecordMessage(message)).toThrow(
 			"record field missing in body of record.create",
+		);
+	});
+
+	test("should throw error when newRecord field is missing", () => {
+		const message = {
+			messageId: "1",
+			receiptHandle: "1",
+			body: JSON.stringify({
+				Message: JSON.stringify({
+					entity: "record",
+					action: "copy",
+					body: {},
+				}),
+			}),
+			attributes: {
+				ApproximateReceiveCount: "1",
+				SentTimestamp: "1",
+				SenderId: "1",
+				ApproximateFirstReceiveTimestamp: "1",
+			},
+			messageAttributes: {},
+			md5OfBody: "1",
+			eventSource: "1",
+			eventSourceARN: "1",
+			awsRegion: "1",
+		};
+
+		expect(() => extractRecordIdFromNewRecordMessage(message)).toThrow(
+			"newRecord field missing in body of record.copy",
 		);
 	});
 });
@@ -211,7 +240,7 @@ describe("handler", () => {
 							Message: JSON.stringify({
 								entity: "record",
 								action: "create",
-								body: { record: { recordId: "2" } },
+								body: { record: { recordId: "3" } },
 							}),
 						}),
 						attributes: {
@@ -268,7 +297,7 @@ describe("handler", () => {
 							Message: JSON.stringify({
 								entity: "record",
 								action: "copy",
-								body: { record: { recordId: "2" } },
+								body: { newRecord: { recordId: "2" } },
 							}),
 						}),
 						attributes: {
@@ -289,10 +318,20 @@ describe("handler", () => {
 			jest.fn(),
 		);
 
-		expect(triggerArchivematicaProcessing).toHaveBeenCalledTimes(1);
+		expect(triggerArchivematicaProcessing).toHaveBeenCalledTimes(2);
 		expect(triggerArchivematicaProcessing).toHaveBeenCalledWith(
 			"1",
 			"originals/1/1",
+			{
+				archivematicaHostUrl: "https://example.com",
+				archivematicaApiKey: "test-api-key",
+				archivematicaOriginalLocationId: "a6962a82-5462-4d9c-9ea1-5b9982ed625a",
+				processingWorkflow: "default",
+			},
+		);
+		expect(triggerArchivematicaProcessing).toHaveBeenCalledWith(
+			"3",
+			"originals/3/3",
 			{
 				archivematicaHostUrl: "https://example.com",
 				archivematicaApiKey: "test-api-key",

--- a/packages/trigger_archivematica/src/index.ts
+++ b/packages/trigger_archivematica/src/index.ts
@@ -11,7 +11,7 @@ import {
 	ARCHIVEMATICA_PROCESSING_WORKFLOW,
 } from "./env";
 
-export const extractRecordIdFromRecordCreateMessage = (
+export const extractRecordIdFromNewRecordMessage = (
 	message: SQSRecord,
 ): string => {
 	const { body } = message;
@@ -27,7 +27,7 @@ export const extractRecordIdFromRecordCreateMessage = (
 	}
 	const { action } = parsedMessage;
 
-	if (action === "create" || action === "copy") {
+	if (action === "create") {
 		if (parsedMessage.body.record === undefined) {
 			logger.error(
 				`record.create event missing record: ${JSON.stringify(
@@ -37,6 +37,16 @@ export const extractRecordIdFromRecordCreateMessage = (
 			throw new Error("record field missing in body of record.create");
 		}
 		return parsedMessage.body.record.recordId;
+	} else if (action === "copy") {
+		if (parsedMessage.body.newRecord === undefined) {
+			logger.error(
+				`record.copy event missing newRecord: ${JSON.stringify(
+					parsedMessage.body,
+				)}`,
+			);
+			throw new Error("newRecord field missing in body of record.copy");
+		}
+		return parsedMessage.body.newRecord.recordId;
 	}
 	throw new Error("Unsupported action type");
 };
@@ -45,7 +55,7 @@ export const handler: SQSHandler = async (event: SQSEvent) => {
 	await Promise.all(
 		event.Records.map(async (message) => {
 			try {
-				const recordId = extractRecordIdFromRecordCreateMessage(message);
+				const recordId = extractRecordIdFromNewRecordMessage(message);
 				const fileResult = await db.sql<{ fileId: string; filePath: string }>(
 					"queries.get_file",
 					{ recordId },


### PR DESCRIPTION
Currently when a record is copied we trigger archivematica for the original record (which has already been processed by archivematica) rather than the copy. This commit fixes that.