### PR TITLE
Treat empty user agents as undefined on POST /events

### DIFF
--- a/packages/api/src/event/controller.test.ts
+++ b/packages/api/src/event/controller.test.ts
@@ -213,6 +213,20 @@ describe("POST /event", () => {
 			.expect(400);
 	});
 
+	test("should not error if userAgent is an empty string", async () => {
+		await agent
+			.post("/api/v2/event")
+			.send({
+				entity: "account",
+				action: "create",
+				version: 1,
+				entityId: "123",
+				userAgent: "",
+				body: {},
+			})
+			.expect(200);
+	});
+
 	test("should return 400 if userAgent is not a string", async () => {
 		await agent
 			.post("/api/v2/event")

--- a/packages/api/src/event/validators.ts
+++ b/packages/api/src/event/validators.ts
@@ -14,7 +14,7 @@ export const validateCreateEventRequest: (
 			version: Joi.number().required(),
 			entityId: Joi.string().required(),
 			ip: Joi.string().ip().required(),
-			userAgent: Joi.string(),
+			userAgent: Joi.string().empty(""),
 			body: Joi.object()
 				.keys({
 					analytics: Joi.object().keys({


### PR DESCRIPTION
Currently the POST /events endpoint returns a 400 error if passed an "" in the user agent field. This field is optional, so it is unintuitive for an empty value to break it. This commit updates the input validation logic to treat "" the same way as undefined.