### PR TITLE
Fix NewRelic APM

### DIFF
--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -41,4 +41,4 @@ RUN npm install --workspace @stela/api
 ENV PORT=80
 EXPOSE 80
 
-CMD node packages/api/dist/index.js
+CMD node -r newrelic packages/api/dist/index.js

--- a/packages/api/src/index.ts
+++ b/packages/api/src/index.ts
@@ -1,4 +1,3 @@
-import _ from "newrelic";
 import { logger } from "@stela/logger";
 import "./env";
 import { app } from "./app";


### PR DESCRIPTION
The stela API server no longer appears in NewRelic. This commit updates how we install the New Relic Node.js agent to fix that.