### PR TITLE
Add NewRelic Kubernetes integration

### DIFF
--- a/terraform/prod_cluster/newrelic.tf
+++ b/terraform/prod_cluster/newrelic.tf
@@ -1,0 +1,37 @@
+resource "helm_release" "newrelic" {
+  name             = "newrelic"
+  repository       = "https://helm-charts.newrelic.com"
+  chart            = "nri-bundle"
+  namespace        = "newrelic"
+  create_namespace = true
+
+  set_sensitive {
+    name  = "global.licenseKey"
+    value = var.new_relic_license_key
+  }
+
+  set {
+    name  = "global.cluster"
+    value = module.eks.cluster_name
+  }
+
+  set {
+    name  = "kube-state-metrics.enabled"
+    value = "true"
+  }
+
+  set {
+    name  = "nri-kube-events.enabled"
+    value = "true"
+  }
+
+  set {
+    name  = "newrelic-logging.enabled"
+    value = "true"
+  }
+
+  set {
+    name  = "newrelic-prometheus-agent.enabled"
+    value = "true"
+  }
+}

--- a/terraform/test_cluster/newrelic.tf
+++ b/terraform/test_cluster/newrelic.tf
@@ -1,0 +1,37 @@
+resource "helm_release" "newrelic" {
+  name             = "newrelic"
+  repository       = "https://helm-charts.newrelic.com"
+  chart            = "nri-bundle"
+  namespace        = "newrelic"
+  create_namespace = true
+
+  set_sensitive {
+    name  = "global.licenseKey"
+    value = var.dev_new_relic_license_key
+  }
+
+  set {
+    name  = "global.cluster"
+    value = module.eks.cluster_name
+  }
+
+  set {
+    name  = "kube-state-metrics.enabled"
+    value = "true"
+  }
+
+  set {
+    name  = "nri-kube-events.enabled"
+    value = "true"
+  }
+
+  set {
+    name  = "newrelic-logging.enabled"
+    value = "true"
+  }
+
+  set {
+    name  = "newrelic-prometheus-agent.enabled"
+    value = "true"
+  }
+}


### PR DESCRIPTION
This commit updates our terraform to add the NewRelic integration to our Kubernetes clusters, in the interest of centralizing our logs and metrics in NewRelic.