### PR TITLE
Add nodes to test cluster

### DIFF
--- a/terraform/test_cluster/eks-cluster.tf
+++ b/terraform/test_cluster/eks-cluster.tf
@@ -49,9 +49,9 @@ module "eks" {
 
       instance_types = ["t3.small"]
 
-      min_size     = 2
-      max_size     = 3
-      desired_size = 2
+      min_size     = 4
+      max_size     = 5
+      desired_size = 4
     }
   }
 }


### PR DESCRIPTION
The addition of NewRelic monitoring pods, as well as more cronjobs, has put our test cluster at risk of running out of space to run all the pods it needs to. This commit addresses that problem by adding two more nodes to the cluster.