### PR TITLE
PER-10551: Show specific EDTF errors

### DIFF
--- a/packages/api/src/folder/controller/patch_folder.test.ts
+++ b/packages/api/src/folder/controller/patch_folder.test.ts
@@ -116,6 +116,16 @@ describe("patch folder", () => {
 			.expect(400);
 	});
 
+	test("expect 400 error with detail if displayTime interval end is before start", async () => {
+		const response = await agent
+			.patch("/api/v2/folders/2")
+			.send({ displayTime: "2020/2019" })
+			.expect(400);
+		expect(response.text).toContain(
+			"Interval start must be before or equal to end",
+		);
+	});
+
 	test("expect 400 error if display date is wrong type", async () => {
 		await agent
 			.patch("/api/v2/folders/1")

--- a/packages/api/src/folder/validators.ts
+++ b/packages/api/src/folder/validators.ts
@@ -1,5 +1,5 @@
 import Joi from "joi";
-import { isValid as isValidEDTF } from "@edtf-ts/core";
+import { parse as parseEDTF } from "@edtf-ts/core";
 import type { PatchFolderRequest } from "./models";
 import { fieldsFromUserAuthentication } from "../validators";
 
@@ -30,11 +30,12 @@ export const validatePatchFolderRequest: (
 			displayEndDate: Joi.string().optional().allow(null),
 			displayTime: Joi.string()
 				.custom((value: string) => {
-					if (isValidEDTF(value, 1)) {
+					const result = parseEDTF(value, 1);
+					if (result.success) {
 						return value;
-					} else {
-						throw new Error(`$${value} is not valid Level 1 EDTF`);
 					}
+					const detail = result.errors.map((e) => e.message).join("; ");
+					throw new Error(`${value} is not valid Level 1 EDTF: ${detail}`);
 				})
 				.optional()
 				.allow(null),

--- a/packages/api/src/record/controller.test.ts
+++ b/packages/api/src/record/controller.test.ts
@@ -771,6 +771,16 @@ describe("PATCH /records", () => {
 			.expect(400);
 	});
 
+	test("expect 400 error with detail if display time interval end is before start", async () => {
+		const response = await agent
+			.patch("/api/v2/records/1")
+			.send({ displayTime: "2020/2019" })
+			.expect(400);
+		expect(response.text).toContain(
+			"Interval start must be before or equal to end",
+		);
+	});
+
 	test("expect display time is updated", async () => {
 		await agent
 			.patch("/api/v2/records/1")

--- a/packages/api/src/record/validators.ts
+++ b/packages/api/src/record/validators.ts
@@ -1,5 +1,5 @@
 import Joi from "joi";
-import { isValid as isValidEDTF } from "@edtf-ts/core";
+import { parse as parseEDTF } from "@edtf-ts/core";
 import type { PatchRecordRequest } from "./models";
 import { fieldsFromUserAuthentication } from "../validators";
 
@@ -47,11 +47,12 @@ export const validatePatchRecordRequest: (
 			displayName: Joi.string().min(1).optional(),
 			displayTime: Joi.string()
 				.custom((value: string) => {
-					if (isValidEDTF(value, 1)) {
+					const result = parseEDTF(value, 1);
+					if (result.success) {
 						return value;
-					} else {
-						throw new Error(`${value} is not valid Level 1 EDTF`);
 					}
+					const detail = result.errors.map((e) => e.message).join("; ");
+					throw new Error(`${value} is not valid Level 1 EDTF: ${detail}`);
 				})
 				.optional()
 				.allow(null),


### PR DESCRIPTION
In order to show users more useful errors, surface those errors from our EDTF package's parser instead of the basic validator.