### PR TITLE
PER-10577: Add name to pendingShare object

### DIFF
--- a/packages/api/docs/src/models/share.yaml
+++ b/packages/api/docs/src/models/share.yaml
@@ -20,6 +20,9 @@ pendingShare:
       type: string
     email:
       type: string
+    name:
+      type: string
+      nullable: true
     accessRole:
       type: string
 shareArchive:

--- a/packages/api/src/folder/controller/get_folder.test.ts
+++ b/packages/api/src/folder/controller/get_folder.test.ts
@@ -234,11 +234,13 @@ describe("GET /folder", () => {
 					expect.objectContaining({
 						id: "1",
 						email: "pending1@example.com",
+						name: "Carol Zhang",
 						accessRole: "access.role.viewer",
 					}),
 					expect.objectContaining({
 						id: "2",
 						email: "pending2@example.com",
+						name: "Juan Sotos",
 						accessRole: "access.role.editor",
 					}),
 				]) as unknown,

--- a/packages/api/src/folder/fixtures/create_test_invite_shares.sql
+++ b/packages/api/src/folder/fixtures/create_test_invite_shares.sql
@@ -1,6 +1,7 @@
 INSERT INTO invite (
   inviteid,
   email,
+  fullname,
   byarchiveid,
   byaccountid,
   token,
@@ -11,6 +12,7 @@ INSERT INTO invite (
 ) VALUES (
   1,
   'pending1@example.com',
+  'Carol Zhang',
   1,
   2,
   'token-1',
@@ -22,6 +24,7 @@ INSERT INTO invite (
 (
   2,
   'pending2@example.com',
+  'Juan Sotos',
   1,
   2,
   'token-2',
@@ -33,6 +36,7 @@ INSERT INTO invite (
 (
   3,
   'revoked@example.com',
+  'Mary Lee',
   1,
   2,
   'token-3',

--- a/packages/api/src/folder/queries/get_folders.sql
+++ b/packages/api/src/folder/queries/get_folders.sql
@@ -78,6 +78,7 @@ aggregated_pending_shares AS (
     ARRAY_AGG(JSONB_BUILD_OBJECT(
       'id', invite_share.invite_shareid::text,
       'email', invite.email,
+      'name', invite.fullname,
       'accessRole', invite_share.accessrole
     )) AS pending_shares_as_json
   FROM invite_share

--- a/packages/api/src/record/controller.test.ts
+++ b/packages/api/src/record/controller.test.ts
@@ -202,11 +202,13 @@ describe("GET /records/:recordId", () => {
 				expect.objectContaining({
 					id: "1",
 					email: "pending1@example.com",
+					name: "Carol Zhang",
 					accessRole: "access.role.viewer",
 				}),
 				expect.objectContaining({
 					id: "2",
 					email: "pending2@example.com",
+					name: "Juan Sotos",
 					accessRole: "access.role.editor",
 				}),
 			]) as unknown,

--- a/packages/api/src/record/fixtures/create_test_invite_shares.sql
+++ b/packages/api/src/record/fixtures/create_test_invite_shares.sql
@@ -1,6 +1,7 @@
 INSERT INTO invite (
   inviteid,
   email,
+  fullname,
   byarchiveid,
   byaccountid,
   token,
@@ -11,6 +12,7 @@ INSERT INTO invite (
 ) VALUES (
   1,
   'pending1@example.com',
+  'Carol Zhang',
   1,
   2,
   'token-1',
@@ -22,6 +24,7 @@ INSERT INTO invite (
 (
   2,
   'pending2@example.com',
+  'Juan Sotos',
   1,
   2,
   'token-2',
@@ -33,6 +36,7 @@ INSERT INTO invite (
 (
   3,
   'revoked@example.com',
+  'Mary Lee',
   1,
   2,
   'token-3',

--- a/packages/api/src/record/queries/get_records.sql
+++ b/packages/api/src/record/queries/get_records.sql
@@ -111,6 +111,7 @@ aggregated_pending_shares AS (
     ARRAY_AGG(JSONB_BUILD_OBJECT(
       'id', invite_share.invite_shareid::TEXT,
       'email', invite.email,
+      'name', invite.fullname,
       'accessRole', invite_share.accessrole
     )) AS pending_shares_as_json
   FROM invite_share

--- a/packages/api/src/share/models.ts
+++ b/packages/api/src/share/models.ts
@@ -16,6 +16,7 @@ export interface ShareArchive {
 export interface PendingShare {
 	id: string;
 	email: string;
+	name: string | null;
 	accessRole: AccessRole;
 }
 


### PR DESCRIPTION
We added this `pendingShare` attribute to records and folders in response to new designs/screens on the mobile apps. When I made the original ticket, I missed that those designs included the name of the invitee. Add that name to both folder and record responses. This is a followup to #688.