### PR TITLE
Add dev Dockerfile to event_send cron

### DIFF
--- a/packages/event_send/Dockerfile.dev
+++ b/packages/event_send/Dockerfile.dev
@@ -1,0 +1,17 @@
+# Monorepo Dockerfile - must be built from repository root:
+#   docker build -f packages/event_send/Dockerfile.dev .
+FROM node:24-alpine
+WORKDIR /usr/local/apps/stela
+
+COPY package.json ./
+COPY package-lock.json ./
+COPY tsconfig.json ./
+COPY tsconfig.build.json ./
+COPY packages ./packages
+
+RUN npm install \
+    && npm install --dev
+RUN npm run build -ws
+
+WORKDIR /usr/local/apps/stela/packages/event_send
+CMD sh -c 'while true; do npm run start; sleep 60; done'

--- a/packages/event_send/package.json
+++ b/packages/event_send/package.json
@@ -22,7 +22,7 @@
 		"eslint": "eslint --max-warnings 0 ./src --ext .ts",
 		"lint": "npm run check-format && npm run check-types && npm run eslint",
 		"build": "rm -rf dist/* && tsc -p tsconfig.build.json && tscp -p tsconfig.tscp.json",
-		"start": "node dist/index.js",
+		"start": "tsc -p tsconfig.build.json && tscp -p tsconfig.tscp.json && node dist/index.js",
 		"clear-database": "psql postgresql://postgres:permanent@localhost:5432 -c 'DROP DATABASE IF EXISTS test_permanent;'",
 		"create-database": "psql postgresql://postgres:permanent@localhost:5432 -c 'CREATE DATABASE test_permanent;'",
 		"set-up-database": "docker exec --env='PGPASSWORD=permanent' permanent-database-1 pg_dump -U postgres permanent --schema-only | psql postgresql://postgres:permanent@localhost:5432/test_permanent",


### PR DESCRIPTION
We want to be able to send events in our local environment, so this commit adds a Dockerfile for use in the local env to the event_send package.