### PR TITLE
PER-10552: Fix PATCH /records response

### DIFF
--- a/packages/api/src/record/controller.test.ts
+++ b/packages/api/src/record/controller.test.ts
@@ -767,6 +767,19 @@ describe("PATCH /records", () => {
 		expect(result.rows[0]).toStrictEqual({ description: null });
 	});
 
+	test("expect a success response to include the updated record", async () => {
+		const response = await agent
+			.patch("/api/v2/records/8")
+			.send({ description: "new description" })
+			.expect(200);
+
+		const {
+			body: { data: record },
+		} = response as { body: { data: ArchiveRecord } };
+		expect(record.recordId).toStrictEqual("8");
+		expect(record.description).toStrictEqual("new description");
+	});
+
 	test("expect 400 error if location id is wrong type", async () => {
 		await agent
 			.patch("/api/v2/records/1")

--- a/packages/api/src/record/controller.ts
+++ b/packages/api/src/record/controller.ts
@@ -79,7 +79,7 @@ recordController.patch(
 				accountEmail: req.body.emailFromAuthToken,
 			});
 
-			res.status(HTTP_STATUS.SUCCESSFUL.OK).send({ data: record });
+			res.status(HTTP_STATUS.SUCCESSFUL.OK).send({ data: record[0] });
 		} catch (err) {
 			next(err);
 		}

--- a/packages/api/src/record/queries/update_record.sql
+++ b/packages/api/src/record/queries/update_record.sql
@@ -18,4 +18,4 @@ SET
 WHERE
   recordid = :recordId
 RETURNING
-  recordid;
+  recordid AS "recordId";

--- a/packages/api/src/record/service.ts
+++ b/packages/api/src/record/service.ts
@@ -73,7 +73,7 @@ export const patchRecord = async (
 	await validateCanPatchRecord(recordId, recordData.emailFromAuthToken);
 
 	const result = await db
-		.sql<ArchiveRecordRow>("record.queries.update_record", {
+		.sql<{ recordId: string }>("record.queries.update_record", {
 			recordId,
 			displayName: recordData.displayName,
 			locationId: recordData.locationId,


### PR DESCRIPTION
Currently, PATH /records isn't returning the updated record in its response. This commit fixes that.