### PR TITLE
PER-10584: Make recipient emails for gifts case insensitive

### DIFF
--- a/packages/api/src/storage/controller.test.ts
+++ b/packages/api/src/storage/controller.test.ts
@@ -272,7 +272,7 @@ describe("/storage/gift", () => {
 		const initialRecipientSpace = await getAccountSpace(recipientOneAccountId);
 		await agent
 			.post("/api/v2/storage/gift")
-			.send({ storageAmount: 1, recipientEmails: ["test+1@permanent.org"] })
+			.send({ storageAmount: 1, recipientEmails: ["Test+1@permanent.org"] })
 			.expect(200);
 		await checkLedgerEntries({
 			gifterAccountId: senderAccountId,
@@ -431,7 +431,7 @@ describe("/storage/gift", () => {
 		await db.sql("storage.fixtures.create_test_emails");
 		await db.sql("storage.fixtures.create_test_invites");
 
-		const newUserEmails = ["test+already_invited@permanent.org"];
+		const newUserEmails = ["Test+Already_Invited@permanent.org"];
 
 		await agent
 			.post("/api/v2/storage/gift")

--- a/packages/api/src/storage/queries/get_existing_account_emails.sql
+++ b/packages/api/src/storage/queries/get_existing_account_emails.sql
@@ -1,5 +1,5 @@
-SELECT email
+SELECT LOWER(email) AS email
 FROM
   email
 WHERE
-  email = ANY(:emails);
+  LOWER(email) = ANY(:emails);

--- a/packages/api/src/storage/queries/get_invited_emails.sql
+++ b/packages/api/src/storage/queries/get_invited_emails.sql
@@ -1,5 +1,5 @@
-SELECT email
+SELECT LOWER(email) AS email
 FROM
   invite
 WHERE
-  email = ANY(:emails);
+  LOWER(email) = ANY(:emails);

--- a/packages/api/src/storage/queries/record_gift.sql
+++ b/packages/api/src/storage/queries/record_gift.sql
@@ -11,7 +11,7 @@ to_account AS (
   FROM
     account
   WHERE
-    primaryemail = ANY(:toEmails)
+    LOWER(primaryemail) = ANY(:toEmails)
 ),
 
 from_account_space AS (

--- a/packages/api/src/storage/service.ts
+++ b/packages/api/src/storage/service.ts
@@ -19,9 +19,12 @@ const getRandomAlphanumericString = (length: number): string => {
 export const issueGift = async (
 	requestBody: GiftStorageRequest,
 ): Promise<GiftStorageResponse> => {
+	const recipientEmails = requestBody.recipientEmails.map((email: string) =>
+		email.toLowerCase(),
+	);
 	const existingAccountEmailResult = await db
 		.sql<{ email: string }>("storage.queries.get_existing_account_emails", {
-			emails: requestBody.recipientEmails,
+			emails: recipientEmails,
 		})
 		.catch((err: unknown) => {
 			logger.error(err);
@@ -32,7 +35,7 @@ export const issueGift = async (
 	const existingAccountEmails = existingAccountEmailResult.rows.map(
 		(row) => row.email,
 	);
-	const newEmails = requestBody.recipientEmails.filter(
+	const newEmails = recipientEmails.filter(
 		(email) => !existingAccountEmails.includes(email),
 	);
 


### PR DESCRIPTION
Currently, storage gifts will fail to find recipient accounts if the given email uses different casing than that used to store that email in the database. This commit corrects that, making recipient emails for storage gifts case insensitive.