### PR TITLE
Per 10543 add file copy lambda

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -86,6 +86,8 @@ LOW_PRIORITY_TOPIC_ARN=test
 # Replace <DevName> with your first name (capitalized)
 EVENT_TOPIC_ARN=arn:aws:sns:us-west-2:000000000000:Local_Events_<DevName>
 
+S3_BUCKET="permanent-local"
+
 # ------ Archivematica (API server) ------
 
 # The base URL of the Archivematica instance.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,9 @@ on:
       EVENT_SEND_IMAGE_TAG:
         type: string
         required: false
+      FILE_COPIER_LAMBDA_IMAGE_TAG:
+        type: string
+        required: false
 jobs:
   generate_image_tags:
     if: inputs.API_IMAGE_TAG == ''
@@ -68,6 +71,8 @@ jobs:
             image_tag_var: METADATA_ATTACHER_LAMBDA_IMAGE_TAG
           - package: event_send
             image_tag_var: EVENT_SEND_IMAGE_TAG
+          - package: file_copier
+            image_tag_var: FILE_COPIER_LAMBDA_IMAGE_TAG
     steps:
       - uses: actions/checkout@v6
       - name: Build Image

--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -34,6 +34,7 @@ jobs:
       TRIGGER_ARCHIVEMATICA_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.TRIGGER_ARCHIVEMATICA_IMAGE_TAG }}
       METADATA_ATTACHER_LAMBDA_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.METADATA_ATTACHER_LAMBDA_IMAGE_TAG }}
       EVENT_SEND_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.EVENT_SEND_IMAGE_TAG }}
+      FILE_COPIER_LAMBDA_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.FILE_COPIER_LAMBDA_IMAGE_TAG }}
     defaults:
       run:
         working-directory: ./terraform/test_cluster
@@ -58,6 +59,7 @@ jobs:
             \"account-space-update-dev-lambda\"  = \"$ACCOUNT_SPACE_UPDATE_IMAGE_TAG\",
             \"archivematica-cleanup-dev\"        = \"$AM_CLEANUP_IMAGE_TAG\",
             \"event-send-dev\"                   = \"$EVENT_SEND_IMAGE_TAG\",
+            \"file-copier-dev-lambda\"           = \"$FILE_COPIER_LAMBDA_IMAGE_TAG\",
             \"file-url-refresh-dev\"             = \"$FILE_URL_REFRESH_IMAGE_TAG\",
             \"metadata-attacher-dev-lambda\"     = \"$METADATA_ATTACHER_LAMBDA_IMAGE_TAG\",
             \"record-thumbnail-dev-lambda\"      = \"$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG\",
@@ -73,6 +75,7 @@ jobs:
             \"account-space-update-dev-lambda\"  = \"$ACCOUNT_SPACE_UPDATE_IMAGE_TAG\",
             \"archivematica-cleanup-dev\"        = \"$AM_CLEANUP_IMAGE_TAG\",
             \"event-send-dev\"                   = \"$EVENT_SEND_IMAGE_TAG\",
+            \"file-copier-dev-lambda\"           = \"$FILE_COPIER_LAMBDA_IMAGE_TAG\",
             \"file-url-refresh-dev\"             = \"$FILE_URL_REFRESH_IMAGE_TAG\",
             \"metadata-attacher-dev-lambda\"     = \"$METADATA_ATTACHER_LAMBDA_IMAGE_TAG\",
             \"record-thumbnail-dev-lambda\"      = \"$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG\",

--- a/.github/workflows/generate_image_tags.yml
+++ b/.github/workflows/generate_image_tags.yml
@@ -28,6 +28,8 @@ on:
         value: ${{ jobs.generate_image_tags.outputs.METADATA_ATTACHER_LAMBDA_IMAGE_TAG }}
       EVENT_SEND_IMAGE_TAG:
         value: ${{ jobs.generate_image_tags.outputs.EVENT_SEND_IMAGE_TAG }}
+      FILE_COPIER_LAMBDA_IMAGE_TAG:
+        value: ${{ jobs.generate_image_tags.outputs.FILE_COPIER_LAMBDA_IMAGE_TAG }}
 jobs:
   generate_image_tags:
     runs-on: ubuntu-24.04
@@ -42,6 +44,7 @@ jobs:
       TRIGGER_ARCHIVEMATICA_IMAGE_TAG: ${{ steps.generate_trigger_archivematica_image_tag.outputs.TRIGGER_ARCHIVEMATICA_IMAGE_TAG }}
       METADATA_ATTACHER_LAMBDA_IMAGE_TAG: ${{ steps.generate_metadata_attacher_lambda_image_tag.outputs.METADATA_ATTACHER_LAMBDA_IMAGE_TAG }}
       EVENT_SEND_IMAGE_TAG: ${{ steps.generate_event_send_image_tag.outputs.EVENT_SEND_IMAGE_TAG }}
+      FILE_COPIER_LAMBDA_IMAGE_TAG: ${{ steps.generate_file_copier_lambda_image_tag.outputs.FILE_COPIER_LAMBDA_IMAGE_TAG }}
     steps:
       - uses: actions/checkout@v6
       - name: Set ECR domain env var
@@ -99,3 +102,6 @@ jobs:
       - name: Generate Event Send Image Tag
         id: generate_event_send_image_tag
         run: echo "EVENT_SEND_IMAGE_TAG=$ECR_DOMAIN/stela:event_send-$TAG_SUFFIX-$ABBREVIATED_COMMIT_HASH" >> "$GITHUB_OUTPUT"
+      - name: Generate File Copier Lambda Image Tag
+        id: generate_file_copier_lambda_image_tag
+        run: echo "FILE_COPIER_LAMBDA_IMAGE_TAG=$ECR_DOMAIN/stela:file_copier_lambda-$TAG_SUFFIX-$ABBREVIATED_COMMIT_HASH" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -43,6 +43,7 @@ jobs:
           - package: s3-utils
           - package: thumbnail_refresh
           - package: trigger_archivematica
+          - package: file_copier
     steps:
       - uses: actions/checkout@v6
 

--- a/.github/workflows/prod_deploy.yml
+++ b/.github/workflows/prod_deploy.yml
@@ -24,6 +24,7 @@ jobs:
       TRIGGER_ARCHIVEMATICA_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.TRIGGER_ARCHIVEMATICA_IMAGE_TAG }}
       METADATA_ATTACHER_LAMBDA_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.METADATA_ATTACHER_LAMBDA_IMAGE_TAG }}
       EVENT_SEND_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.EVENT_SEND_IMAGE_TAG }}
+      FILE_COPIER_LAMBDA_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.FILE_COPIER_LAMBDA_IMAGE_TAG }}
     secrets: inherit
 
   deploy_prod:
@@ -43,6 +44,7 @@ jobs:
       TRIGGER_ARCHIVEMATICA_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.TRIGGER_ARCHIVEMATICA_IMAGE_TAG }}
       METADATA_ATTACHER_LAMBDA_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.METADATA_ATTACHER_LAMBDA_IMAGE_TAG }}
       EVENT_SEND_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.EVENT_SEND_IMAGE_TAG }}
+      FILE_COPIER_LAMBDA_IMAGE_TAG: ${{ needs.generate_image_tags.outputs.FILE_COPIER_LAMBDA_IMAGE_TAG }}
     defaults:
       run:
         working-directory: ./terraform/prod_cluster
@@ -71,7 +73,8 @@ jobs:
           -var="account_space_updater_lambda_image=$ACCOUNT_SPACE_UPDATE_IMAGE_TAG" \
           -var="trigger_archivematica_lambda_image=$TRIGGER_ARCHIVEMATICA_IMAGE_TAG" \
           -var="metadata_attacher_lambda_image=$METADATA_ATTACHER_LAMBDA_IMAGE_TAG" \
-          -var="event_send_image=$EVENT_SEND_IMAGE_TAG"
+          -var="event_send_image=$EVENT_SEND_IMAGE_TAG" \
+          -var="file_copier_lambda_image=$FILE_COPIER_LAMBDA_IMAGE_TAG"
       - name: Terraform Apply
         run: |
           terraform apply -auto-approve -input=false \
@@ -84,4 +87,5 @@ jobs:
           -var="account_space_updater_lambda_image=$ACCOUNT_SPACE_UPDATE_IMAGE_TAG" \
           -var="trigger_archivematica_lambda_image=$TRIGGER_ARCHIVEMATICA_IMAGE_TAG" \
           -var="metadata_attacher_lambda_image=$METADATA_ATTACHER_LAMBDA_IMAGE_TAG" \
-          -var="event_send_image=$EVENT_SEND_IMAGE_TAG"
+          -var="event_send_image=$EVENT_SEND_IMAGE_TAG" \
+          -var="file_copier_lambda_image=$FILE_COPIER_LAMBDA_IMAGE_TAG"

--- a/.github/workflows/staging_deploy.yml
+++ b/.github/workflows/staging_deploy.yml
@@ -33,6 +33,9 @@ on:
       EVENT_SEND_IMAGE_TAG:
         type: string
         required: false
+      FILE_COPIER_LAMBDA_IMAGE_TAG:
+        type: string
+        required: false
 jobs:
   run_tests:
     uses: ./.github/workflows/test.yml
@@ -57,6 +60,7 @@ jobs:
       TRIGGER_ARCHIVEMATICA_IMAGE_TAG: ${{ inputs.TRIGGER_ARCHIVEMATICA_IMAGE_TAG }}
       METADATA_ATTACHER_LAMBDA_IMAGE_TAG: ${{ inputs.METADATA_ATTACHER_LAMBDA_IMAGE_TAG }}
       EVENT_SEND_IMAGE_TAG: ${{ inputs.EVENT_SEND_IMAGE_TAG }}
+      FILE_COPIER_LAMBDA_IMAGE_TAG: ${{ inputs.FILE_COPIER_LAMBDA_IMAGE_TAG }}
 
   deploy:
     needs:
@@ -76,6 +80,7 @@ jobs:
       TRIGGER_ARCHIVEMATICA_IMAGE_TAG: ${{ inputs.TRIGGER_ARCHIVEMATICA_IMAGE_TAG || needs.generate_image_tags.outputs.TRIGGER_ARCHIVEMATICA_IMAGE_TAG }}
       METADATA_ATTACHER_LAMBDA_IMAGE_TAG: ${{ inputs.METADATA_ATTACHER_LAMBDA_IMAGE_TAG || needs.generate_image_tags.outputs.METADATA_ATTACHER_LAMBDA_IMAGE_TAG }}
       EVENT_SEND_IMAGE_TAG: ${{ inputs.EVENT_SEND_IMAGE_TAG || needs.generate_image_tags.outputs.EVENT_SEND_IMAGE_TAG }}
+      FILE_COPIER_LAMBDA_IMAGE_TAG: ${{ inputs.FILE_COPIER_LAMBDA_IMAGE_TAG || needs.generate_image_tags.outputs.FILE_COPIER_LAMBDA_IMAGE_TAG }}
     defaults:
       run:
         working-directory: ./terraform/test_cluster
@@ -100,6 +105,7 @@ jobs:
             \"account-space-update-staging-lambda\"  = \"$ACCOUNT_SPACE_UPDATE_IMAGE_TAG\",
             \"archivematica-cleanup-staging\"        = \"$AM_CLEANUP_IMAGE_TAG\",
             \"event-send-staging\"                   = \"$EVENT_SEND_IMAGE_TAG\",
+            \"file-copier-staging-lambda\"           = \"$FILE_COPIER_LAMBDA_IMAGE_TAG\",
             \"file-url-refresh-staging\"             = \"$FILE_URL_REFRESH_IMAGE_TAG\",
             \"metadata-attacher-staging-lambda\"     = \"$METADATA_ATTACHER_LAMBDA_IMAGE_TAG\",
             \"record-thumbnail-staging-lambda\"      = \"$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG\",
@@ -115,6 +121,7 @@ jobs:
             \"account-space-update-staging-lambda\"  = \"$ACCOUNT_SPACE_UPDATE_IMAGE_TAG\",
             \"archivematica-cleanup-staging\"        = \"$AM_CLEANUP_IMAGE_TAG\",
             \"event-send-staging\"                   = \"$EVENT_SEND_IMAGE_TAG\",
+            \"file-copier-staging-lambda\"           = \"$FILE_COPIER_LAMBDA_IMAGE_TAG\",
             \"file-url-refresh-staging\"             = \"$FILE_URL_REFRESH_IMAGE_TAG\",
             \"metadata-attacher-staging-lambda\"     = \"$METADATA_ATTACHER_LAMBDA_IMAGE_TAG\",
             \"record-thumbnail-staging-lambda\"      = \"$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG\",

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,8 @@ jobs:
             needs_devenv: true
           - package: metadata_attacher
             needs_devenv: true
+          - package: file_copier
+            needs_devenv: true
           - package: thumbnail_refresh
             needs_devenv: true
           - package: file_url_refresh

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
 		"./packages/file_url_refresh",
 		"./packages/access_copy_attacher",
 		"./packages/trigger_archivematica",
-		"./packages/metadata_attacher"
+		"./packages/metadata_attacher",
+		"./packages/file_copier"
 	],
 	"repository": {
 		"type": "git",

--- a/packages/event_send/src/service.ts
+++ b/packages/event_send/src/service.ts
@@ -66,6 +66,7 @@ export const sendEvents = async (): Promise<void> => {
 	const messages = events.rows.map((event) => ({
 		id: event.id,
 		body: JSON.stringify({
+			id: event.id,
 			entity: event.entity,
 			action: event.action,
 			version: event.version,

--- a/packages/file_copier/Dockerfile
+++ b/packages/file_copier/Dockerfile
@@ -1,0 +1,39 @@
+# Monorepo Dockerfile - must be built from repository root:
+#   docker build -f packages/file_copier/Dockerfile .
+FROM public.ecr.aws/lambda/nodejs:24 as builder
+WORKDIR /usr/local/apps/stela/
+
+COPY package.json ./
+COPY package-lock.json ./
+COPY tsconfig.build.json ./
+COPY tsconfig.json ./
+COPY jest.config.js ./
+COPY packages ./packages
+
+RUN npm install
+RUN npm install -ws
+RUN npm run build -ws
+
+
+FROM public.ecr.aws/lambda/nodejs:24 as final
+
+ARG AWS_RDS_CERT_BUNDLE
+
+WORKDIR ${LAMBDA_TASK_ROOT}
+
+RUN mkdir /etc/ca-certificates
+RUN echo -e $AWS_RDS_CERT_BUNDLE > /etc/ca-certificates/rds-us-west-2-ca-bundle.pem
+
+COPY --from=builder /usr/local/apps/stela/packages/file_copier/dist ./packages/file_copier/dist
+COPY --from=builder /usr/local/apps/stela/packages/file_copier/package.json ./packages/file_copier/package.json
+COPY --from=builder /usr/local/apps/stela/packages/logger/dist ./packages/logger/dist
+COPY --from=builder /usr/local/apps/stela/packages/logger/package.json ./packages/logger/package.json
+COPY --from=builder /usr/local/apps/stela/packages/s3-utils/dist ./packages/s3-utils/dist
+COPY --from=builder /usr/local/apps/stela/packages/s3-utils/package.json ./packages/s3-utils/package.json
+COPY --from=builder /usr/local/apps/stela/package.json ./package.json
+COPY --from=builder /usr/local/apps/stela/package-lock.json ./package-lock.json
+
+RUN npm cache clean --force
+RUN npm install --workspace @stela/file_copier
+
+CMD ["packages/file_copier/dist/index.handler"]

--- a/packages/file_copier/jest.config.js
+++ b/packages/file_copier/jest.config.js
@@ -1,0 +1,7 @@
+const sharedConfig = require("../../jest.config");
+module.exports = {
+	...sharedConfig,
+	moduleNameMapper: {
+		"^@stela/(.*)$": "<rootDir>/../$1/src",
+	},
+};

--- a/packages/file_copier/package.json
+++ b/packages/file_copier/package.json
@@ -1,0 +1,47 @@
+{
+	"name": "@stela/file_copier",
+	"version": "1.0.0",
+	"description": "A lambda to copy files",
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/PermanentOrg/stela.git"
+	},
+	"author": "Permanent.org",
+	"license": "AGPL-3.0",
+	"bugs": {
+		"url": "https://github.com/PermanentOrg/stela/issues"
+	},
+	"homepage": "https://permanent.org",
+	"engines": {
+		"node": ">=24.0"
+	},
+	"main": "dist/index.js",
+	"scripts": {
+		"check-types": "tsc --noEmit",
+		"check-format": "prettier --check src",
+		"eslint": "eslint --max-warnings 0 ./src --ext .ts",
+		"lint-sql": "(cd ../..; docker run -i --rm -v $PWD:/sql sqlfluff/sqlfluff:3.4.2 lint --dialect postgres --nocolor packages/file_copier/src/queries/ packages/file_copier/src/fixtures/)",
+		"lint": "npm run check-format && npm run check-types && npm run eslint && npm run lint-sql",
+		"build": "rm -rf dist/* && tsc -p tsconfig.build.json && tscp -p tsconfig.tscp.json",
+		"start": "node dist/index.js",
+		"clear-database": "psql postgresql://postgres:permanent@localhost:5432 -c 'DROP DATABASE IF EXISTS test_permanent;'",
+		"create-database": "psql postgresql://postgres:permanent@localhost:5432 -c 'CREATE DATABASE test_permanent;'",
+		"set-up-database": "docker exec --env='PGPASSWORD=permanent' permanent-database-1 pg_dump -U postgres permanent --schema-only | psql postgresql://postgres:permanent@localhost:5432/test_permanent",
+		"test": "npm run clear-database && npm run create-database && npm run set-up-database && node --experimental-vm-modules ../../node_modules/jest/bin/jest.js -i --silent=false"
+	},
+	"dependencies": {
+		"@aws-sdk/client-s3": "^3.1037.0",
+		"@sentry/aws-serverless": "^10.50.0",
+		"@sentry/node": "^10.50.0",
+		"@sentry/profiling-node": "^10.50.0",
+		"@stela/logger": "^1.0.0",
+		"@stela/s3-utils": "^1.0.0",
+		"dotenv": "^17.4.2",
+		"joi": "^18.0.0",
+		"require-env-variable": "^4.0.2",
+		"tinypg": "^7.0.1"
+	},
+	"devDependencies": {
+		"@types/aws-lambda": "^8.10.159"
+	}
+}

--- a/packages/file_copier/src/__mocks__/database.ts
+++ b/packages/file_copier/src/__mocks__/database.ts
@@ -1,0 +1,11 @@
+import * as path from "node:path";
+import { TinyPg } from "tinypg";
+
+const db = new TinyPg({
+	connection_string:
+		"postgres://postgres:permanent@localhost:5432/test_permanent",
+	root_dir: [path.resolve(__dirname, "..")],
+	capture_stack_trace: true,
+});
+
+export { db };

--- a/packages/file_copier/src/database.ts
+++ b/packages/file_copier/src/database.ts
@@ -1,0 +1,7 @@
+import * as path from "node:path";
+import { TinyPg } from "tinypg";
+
+export const db = new TinyPg({
+	connection_string: process.env["DATABASE_URL"] ?? "",
+	root_dir: [path.resolve(__dirname, ".")],
+});

--- a/packages/file_copier/src/env.ts
+++ b/packages/file_copier/src/env.ts
@@ -1,0 +1,12 @@
+import { config } from "dotenv";
+import { requireEnv } from "require-env-variable";
+
+config({ path: "../../.env" });
+
+requireEnv("DATABASE_URL");
+requireEnv("SENTRY_DSN");
+requireEnv("S3_BUCKET");
+requireEnv("CLOUDFRONT_URL");
+requireEnv("CLOUDFRONT_KEY_PAIR_ID");
+requireEnv("CLOUDFRONT_PRIVATE_KEY");
+requireEnv("ENV");

--- a/packages/file_copier/src/fixtures/create_test_accounts.sql
+++ b/packages/file_copier/src/fixtures/create_test_accounts.sql
@@ -1,0 +1,20 @@
+INSERT INTO
+account (
+  accountid,
+  primaryemail,
+  status,
+  notificationpreferences,
+  type,
+  fullname,
+  subject
+)
+VALUES
+(
+  2,
+  'test@permanent.org',
+  'status.auth.ok',
+  '{}',
+  'type.account.standard',
+  'Jack Rando',
+  null
+);

--- a/packages/file_copier/src/fixtures/create_test_archives.sql
+++ b/packages/file_copier/src/fixtures/create_test_archives.sql
@@ -1,0 +1,4 @@
+INSERT INTO
+archive (archiveid, archivenbr, payeraccountid, public, type, thumburl200)
+VALUES
+(1, '0001-0001', 2, false, 'type.archive.person', null);

--- a/packages/file_copier/src/fixtures/create_test_events.sql
+++ b/packages/file_copier/src/fixtures/create_test_events.sql
@@ -1,0 +1,28 @@
+INSERT INTO
+event (
+  id,
+  entity,
+  action,
+  version,
+  actor_type,
+  actor_id,
+  entity_id,
+  ip,
+  user_agent,
+  body,
+  is_sent
+)
+VALUES
+(
+  '63b9b137-d049-4697-9b91-24c1caf9f1db',
+  'file',
+  'copy',
+  1,
+  'user',
+  '553f3cb8-b753-43ce-83af-4443a404741b',
+  '100',
+  '127.0.0.1',
+  NULL,
+  '{}',
+  TRUE
+);

--- a/packages/file_copier/src/fixtures/create_test_files.sql
+++ b/packages/file_copier/src/fixtures/create_test_files.sql
@@ -1,0 +1,23 @@
+INSERT INTO
+file (
+  fileid,
+  archiveid,
+  status,
+  createddt,
+  updateddt
+)
+VALUES
+(
+  100,
+  1,
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
+),
+(
+  101,
+  1,
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
+);

--- a/packages/file_copier/src/fixtures/create_test_record_files.sql
+++ b/packages/file_copier/src/fixtures/create_test_record_files.sql
@@ -1,0 +1,26 @@
+INSERT INTO
+record_file (
+  recordid,
+  fileid,
+  status,
+  type,
+  createddt,
+  updateddt
+)
+VALUES
+(
+  1,
+  100,
+  'status.generic.ok',
+  'type.generic.placeholder',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
+),
+(
+  2,
+  101,
+  'status.generic.ok',
+  'type.generic.placeholder',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
+);

--- a/packages/file_copier/src/fixtures/create_test_records.sql
+++ b/packages/file_copier/src/fixtures/create_test_records.sql
@@ -1,0 +1,44 @@
+INSERT INTO
+record (
+  recordid,
+  archiveid,
+  publicdt,
+  displayname,
+  uploadaccountid,
+  size,
+  uploadpayeraccountid,
+  uploadfilename,
+  downloadname,
+  status,
+  type,
+  updateddt
+)
+VALUES
+(
+  1,
+  1,
+  NULL,
+  'Original File',
+  2,
+  1024,
+  2,
+  'original_file.jpg',
+  'original_file.jpg',
+  'status.generic.ok',
+  'type.record.image',
+  CURRENT_TIMESTAMP
+),
+(
+  2,
+  1,
+  NULL,
+  'New File',
+  2,
+  1024,
+  2,
+  'new_file.jpg',
+  'new_file.jpg',
+  'status.generic.ok',
+  'type.record.image',
+  CURRENT_TIMESTAMP
+);

--- a/packages/file_copier/src/index.test.ts
+++ b/packages/file_copier/src/index.test.ts
@@ -1,0 +1,353 @@
+import type { Context, SQSRecord } from "aws-lambda";
+import { S3Client, CopyObjectCommand } from "@aws-sdk/client-s3";
+import { mock } from "jest-mock-extended";
+import { constructSignedCdnUrl } from "@stela/s3-utils";
+import { logger } from "@stela/logger";
+import { db } from "./database";
+import { handler, extractFileDataFromFileCopyMessage } from "./index";
+
+jest.mock("./database");
+jest.mock("@stela/logger");
+jest.mock("@aws-sdk/client-s3");
+jest.mock("@stela/s3-utils", (): unknown => ({
+	...jest.requireActual("@stela/s3-utils"),
+	constructSignedCdnUrl: jest.fn(),
+}));
+
+const mockS3Send = jest.fn();
+
+const originalCloudPath = "originals/100/100";
+const newCloudPath = "originals/101/101";
+const testFileUrl = "https://cdn.example.com/file.jpg";
+const testDownloadUrl = "https://cdn.example.com/download.jpg";
+const testEventId = "63b9b137-d049-4697-9b91-24c1caf9f1db";
+
+const buildSqsRecord = (
+	messageBody: unknown,
+	messageId = "test-message-id",
+): SQSRecord => ({
+	messageId,
+	receiptHandle: "1",
+	body: JSON.stringify({
+		Message: JSON.stringify(messageBody),
+	}),
+	attributes: {
+		ApproximateReceiveCount: "1",
+		SentTimestamp: "1",
+		SenderId: "1",
+		ApproximateFirstReceiveTimestamp: "1",
+	},
+	messageAttributes: {},
+	md5OfBody: "1",
+	eventSource: "1",
+	eventSourceARN: "1",
+	awsRegion: "1",
+});
+
+const buildFileCopyRecord = (): SQSRecord =>
+	buildSqsRecord({
+		id: testEventId,
+		entity: "file",
+		action: "copy",
+		body: {
+			file: { fileid: 100, cloudpath: originalCloudPath },
+			newFile: { fileid: 101 },
+		},
+	});
+
+describe("extractFileDataFromFileCopyMessage", () => {
+	test("should extract file data from a well-formed message", () => {
+		const result = extractFileDataFromFileCopyMessage(
+			buildSqsRecord({
+				id: "test-event-id",
+				entity: "file",
+				action: "copy",
+				body: {
+					file: { fileid: 100, cloudpath: originalCloudPath },
+					newFile: { fileid: 101 },
+				},
+			}),
+		);
+
+		expect(result).toEqual({
+			eventId: "test-event-id",
+			originalFileId: "100",
+			newFileId: "101",
+			originalFileCloudPath: originalCloudPath,
+		});
+	});
+
+	test("should throw if the SQS body is missing the Message field", () => {
+		let error = null;
+		try {
+			extractFileDataFromFileCopyMessage({
+				...buildSqsRecord({}),
+				body: JSON.stringify({ notMessage: "wrong" }),
+			});
+		} catch (err) {
+			error = err;
+		} finally {
+			expect(error).not.toBeNull();
+			expect(logger.error).toHaveBeenCalled();
+		}
+	});
+
+	test("should throw if the inner message is not a valid file copy event", () => {
+		let error = null;
+		try {
+			extractFileDataFromFileCopyMessage(
+				buildSqsRecord({ entity: "record", action: "create" }),
+			);
+		} catch (err) {
+			error = err;
+		} finally {
+			expect(error).not.toBeNull();
+		}
+	});
+});
+
+describe("handler", () => {
+	const loadFixtures = async (): Promise<void> => {
+		await db.sql("fixtures.create_test_accounts");
+		await db.sql("fixtures.create_test_archives");
+		await db.sql("fixtures.create_test_records");
+		await db.sql("fixtures.create_test_files");
+		await db.sql("fixtures.create_test_record_files");
+		await db.sql("fixtures.create_test_events");
+	};
+
+	const clearDatabase = async (): Promise<void> => {
+		await db.query(
+			`TRUNCATE
+        account,
+        archive,
+        record,
+        record_file,
+        file,
+        event
+      CASCADE`,
+		);
+	};
+
+	beforeEach(async () => {
+		jest.mocked(S3Client).mockImplementation(
+			jest.fn().mockReturnValue({
+				send: mockS3Send.mockResolvedValue({}),
+			}),
+		);
+		jest
+			.mocked(constructSignedCdnUrl)
+			.mockReturnValueOnce(testFileUrl)
+			.mockReturnValueOnce(testDownloadUrl);
+		await loadFixtures();
+	});
+
+	afterEach(async () => {
+		await clearDatabase();
+		jest.clearAllMocks();
+		jest.restoreAllMocks();
+	});
+
+	test("should copy the S3 object and update the file record", async () => {
+		await handler(
+			{ Records: [buildFileCopyRecord()] },
+			mock<Context>(),
+			jest.fn(),
+		);
+
+		const commandInput = jest.mocked(CopyObjectCommand).mock.calls.at(0)?.[0];
+		expect(commandInput?.CopySource).toEqual(`/${originalCloudPath}`);
+		expect(commandInput?.Key).toEqual(newCloudPath);
+
+		const {
+			rows: [updatedFile],
+		} = await db.query<{
+			fileurl: string;
+			downloadurl: string;
+			urldt: string;
+			cloudpath: string;
+		}>(
+			"SELECT fileurl, downloadurl, urldt, cloudpath FROM file WHERE fileid = 101",
+		);
+		expect(updatedFile?.fileurl).toEqual(testFileUrl);
+		expect(updatedFile?.downloadurl).toEqual(testDownloadUrl);
+		expect(updatedFile?.urldt).not.toBeNull();
+		expect(updatedFile?.cloudpath).toEqual(newCloudPath);
+	});
+
+	test("should copy an old file not stored in originals to originals", async () => {
+		const messageWithOldFile = buildSqsRecord({
+			id: testEventId,
+			entity: "file",
+			action: "copy",
+			body: {
+				file: { fileid: 100, cloudpath: "100" },
+				newFile: { fileid: 101 },
+			},
+		});
+
+		await handler(
+			{ Records: [messageWithOldFile] },
+			mock<Context>(),
+			jest.fn(),
+		);
+
+		const {
+			rows: [updatedFile],
+		} = await db.query<{
+			fileurl: string;
+			downloadurl: string;
+			urldt: string;
+			cloudpath: string;
+		}>(
+			"SELECT fileurl, downloadurl, urldt, cloudpath FROM file WHERE fileid = 101",
+		);
+		expect(updatedFile?.cloudpath).toEqual(newCloudPath);
+	});
+
+	test("should copy an old file in a local environment correctly", async () => {
+		const messageWithOldFile = buildSqsRecord({
+			id: testEventId,
+			entity: "file",
+			action: "copy",
+			body: {
+				file: { fileid: 100, cloudpath: "_DevName/100" },
+				newFile: { fileid: 101 },
+			},
+		});
+
+		await handler(
+			{ Records: [messageWithOldFile] },
+			mock<Context>(),
+			jest.fn(),
+		);
+
+		const {
+			rows: [updatedFile],
+		} = await db.query<{
+			fileurl: string;
+			downloadurl: string;
+			urldt: string;
+			cloudpath: string;
+		}>(
+			"SELECT fileurl, downloadurl, urldt, cloudpath FROM file WHERE fileid = 101",
+		);
+		expect(updatedFile?.cloudpath).toEqual(`_DevName/${newCloudPath}`);
+	});
+
+	test("should throw if the S3 copy fails", async () => {
+		const testError = new Error("S3 error");
+		mockS3Send.mockRejectedValueOnce(testError);
+
+		let error = null;
+		try {
+			await handler(
+				{ Records: [buildFileCopyRecord()] },
+				mock<Context>(),
+				jest.fn(),
+			);
+		} catch (err) {
+			error = err;
+		} finally {
+			expect(error).not.toBeNull();
+			expect(logger.error).toHaveBeenCalledWith(testError);
+		}
+	});
+
+	test("should throw if the new file does not exist in the database", async () => {
+		const messageWithMissingFile = buildSqsRecord({
+			id: testEventId,
+			entity: "file",
+			action: "copy",
+			body: {
+				file: { fileid: 100, cloudpath: originalCloudPath },
+				newFile: { fileid: 999 },
+			},
+		});
+
+		let error = null;
+		try {
+			await handler(
+				{ Records: [messageWithMissingFile] },
+				mock<Context>(),
+				jest.fn(),
+			);
+		} catch (err) {
+			error = err;
+		} finally {
+			expect(logger.error).toHaveBeenCalledWith("Failed to look up new file");
+			expect(error).not.toBeNull();
+		}
+	});
+
+	test("should throw if the get_file_upload_name query fails", async () => {
+		const testError = new Error("database error");
+
+		jest.spyOn(db, "sql").mockRejectedValueOnce(testError);
+
+		let error = null;
+		try {
+			await handler(
+				{ Records: [buildFileCopyRecord()] },
+				mock<Context>(),
+				jest.fn(),
+			);
+		} catch (err) {
+			error = err;
+		} finally {
+			expect(logger.error).toHaveBeenCalledWith(testError);
+			expect(error).not.toBeNull();
+		}
+	});
+
+	test("should not insert a duplicate event when the message is processed twice", async () => {
+		await handler(
+			{ Records: [buildFileCopyRecord()] },
+			mock<Context>(),
+			jest.fn(),
+		);
+
+		jest
+			.mocked(constructSignedCdnUrl)
+			.mockReturnValueOnce(testFileUrl)
+			.mockReturnValueOnce(testDownloadUrl);
+
+		await handler(
+			{ Records: [buildFileCopyRecord()] },
+			mock<Context>(),
+			jest.fn(),
+		);
+
+		const { rows } = await db.query<{ count: string }>(
+			`SELECT COUNT(*) AS count FROM event WHERE entity = 'record' AND action = 'copy'`,
+		);
+		expect(rows[0]?.count).toEqual("1");
+	});
+
+	test("should throw if the update_file_and_send_event query fails", async () => {
+		const testError = new Error("database error");
+
+		jest
+			.spyOn(db, "sql")
+			.mockResolvedValueOnce({
+				command: "",
+				row_count: 1,
+				rows: [{ uploadFileName: "new_file.jpg" }],
+			})
+			.mockRejectedValueOnce(testError);
+
+		let error = null;
+		try {
+			await handler(
+				{ Records: [buildFileCopyRecord()] },
+				mock<Context>(),
+				jest.fn(),
+			);
+		} catch (err) {
+			error = err;
+		} finally {
+			expect(logger.error).toHaveBeenCalledWith(testError);
+			expect(error).not.toBeNull();
+		}
+	});
+});

--- a/packages/file_copier/src/index.ts
+++ b/packages/file_copier/src/index.ts
@@ -1,0 +1,137 @@
+import type { SQSHandler, SQSEvent, SQSRecord } from "aws-lambda";
+import { S3Client, CopyObjectCommand } from "@aws-sdk/client-s3";
+import * as Sentry from "@sentry/aws-serverless";
+import { constructSignedCdnUrl, validateSqsMessage } from "@stela/s3-utils";
+import { logger } from "@stela/logger";
+import { validateFileCopyEvent } from "./validator";
+import { db } from "./database";
+
+export const extractFileDataFromFileCopyMessage = (
+	message: SQSRecord,
+): {
+	eventId: string;
+	originalFileId: string;
+	newFileId: string;
+	originalFileCloudPath: string;
+} => {
+	const { body } = message;
+	const parsedBody: unknown = JSON.parse(body);
+	if (!validateSqsMessage(parsedBody)) {
+		logger.error(`Invalid message body: ${body}`);
+		throw new Error("Invalid message body");
+	}
+	const parsedMessage: unknown = JSON.parse(parsedBody.Message);
+	validateFileCopyEvent(parsedMessage);
+
+	return {
+		eventId: parsedMessage.id,
+		originalFileId: parsedMessage.body.file.fileid.toString(),
+		newFileId: parsedMessage.body.newFile.fileid.toString(),
+		originalFileCloudPath: parsedMessage.body.file.cloudpath,
+	};
+};
+
+const generateNewFileCloudPath = (
+	originalFileCloudPath: string,
+	originalFileId: string,
+	newFileId: string,
+): string => {
+	const originalFileCloudPathWithNewFileIds = originalFileCloudPath.replace(
+		new RegExp(`(?<=^|/)${originalFileId}(?=/|$)`, "vg"),
+		newFileId,
+	);
+
+	// Currently, cloudPaths for original files are in the format "originals/fileId/fileId".
+	// This allows us to generate a cloudPath for the copy by simply replacing the original
+	// file's ID with the copy's ID everywhere it appears in the cloudPath. However, some
+	// older files have cloudPaths of simply "fileId". In those cases, we to generate a cloudPath
+	// for the copy in the new format. Since in the previous step we replaced all instances of
+	// the original fileId with the copy's fileId, this is usually just a matter of adding
+	// "originals/newFileId/" as a prefix. However, in developers' local environments cloudPaths
+	// in the old and new formats have a prefix of "_NameOfDeveloper/", so if we're converting an
+	// old-format cloudPath to a new-format cloudPath we check such a prefix and include it in the
+	// generated cloudPath.
+	return originalFileCloudPathWithNewFileIds.includes("originals")
+		? originalFileCloudPathWithNewFileIds
+		: originalFileCloudPathWithNewFileIds.replace(
+				/^(?<localPrefix>.*\/)?/v,
+				`$1originals/${newFileId}/`,
+			);
+};
+
+const getFileUploadName = async (fileId: string): Promise<string> => {
+	const newFile = await db
+		.sql<{ uploadFileName: string }>("queries.get_file_upload_name", {
+			fileId,
+		})
+		.catch((err: unknown) => {
+			logger.error(err);
+			throw err;
+		});
+	if (newFile.rows[0] === undefined) {
+		const errorMessage = "Failed to look up new file";
+		logger.error(errorMessage);
+		throw new Error(errorMessage);
+	}
+
+	return newFile.rows[0].uploadFileName;
+};
+
+export const handler: SQSHandler = Sentry.wrapHandler(
+	async (event: SQSEvent) => {
+		const s3Client = new S3Client({
+			region: process.env["AWS_REGION"] ?? "",
+		});
+		await Promise.all(
+			event.Records.map(async (message) => {
+				const { eventId, originalFileId, newFileId, originalFileCloudPath } =
+					extractFileDataFromFileCopyMessage(message);
+
+				const newFileCloudPath = generateNewFileCloudPath(
+					originalFileCloudPath,
+					originalFileId,
+					newFileId,
+				);
+
+				await s3Client
+					.send(
+						new CopyObjectCommand({
+							Bucket: process.env["S3_BUCKET"] ?? "",
+							CopySource: encodeURI(
+								`${process.env["S3_BUCKET"] ?? ""}/${originalFileCloudPath}`,
+							),
+							Key: newFileCloudPath,
+						}),
+					)
+					.catch((err: unknown) => {
+						logger.error(err);
+						throw err;
+					});
+
+				const cdnExpirationTime = new Date();
+				cdnExpirationTime.setFullYear(cdnExpirationTime.getFullYear() + 1);
+
+				const newFileUploadFileName = await getFileUploadName(newFileId);
+
+				await db
+					.sql("queries.update_file_and_send_event", {
+						newFileId,
+						originalFileId,
+						eventId,
+						cloudPath: newFileCloudPath,
+						fileUrl: constructSignedCdnUrl(newFileCloudPath),
+						downloadUrl: constructSignedCdnUrl(
+							newFileCloudPath,
+							newFileUploadFileName,
+						),
+						urlExpirationTimestamp: cdnExpirationTime.toISOString(),
+						env: process.env["ENV"] ?? "local",
+					})
+					.catch((err: unknown) => {
+						logger.error(err);
+						throw err;
+					});
+			}),
+		);
+	},
+);

--- a/packages/file_copier/src/instrument.ts
+++ b/packages/file_copier/src/instrument.ts
@@ -1,0 +1,8 @@
+import * as Sentry from "@sentry/aws-serverless";
+
+const env = process.env["ENV"] ?? "";
+Sentry.init({
+	dsn: process.env["SENTRY_DSN"] ?? "",
+	tracesSampleRate: 1.0,
+	environment: env === "local" ? `local-${process.env["DEV_NAME"] ?? ""}` : env,
+});

--- a/packages/file_copier/src/models.ts
+++ b/packages/file_copier/src/models.ts
@@ -1,0 +1,14 @@
+export interface FileCopyEvent {
+	id: string;
+	entity: "file";
+	action: "copy";
+	body: {
+		file: {
+			fileid: number;
+			cloudpath: string;
+		};
+		newFile: {
+			fileid: number;
+		};
+	};
+}

--- a/packages/file_copier/src/queries/get_file_upload_name.sql
+++ b/packages/file_copier/src/queries/get_file_upload_name.sql
@@ -1,0 +1,8 @@
+SELECT record.uploadfilename AS "uploadFileName"
+FROM
+  record
+INNER JOIN
+  record_file
+  ON record.recordid = record_file.recordid
+WHERE
+  record_file.fileid = :fileId;

--- a/packages/file_copier/src/queries/update_file_and_send_event.sql
+++ b/packages/file_copier/src/queries/update_file_and_send_event.sql
@@ -1,0 +1,219 @@
+WITH update_file AS (
+  UPDATE
+    file
+  SET
+    cloudpath = :cloudPath,
+    fileurl = :fileUrl,
+    downloadurl = :downloadUrl,
+    urldt = :urlExpirationTimestamp
+  WHERE
+    fileid = :newFileId
+    AND cloudpath IS DISTINCT FROM :cloudPath
+  RETURNING fileid
+)
+
+INSERT INTO event (
+  entity,
+  action,
+  version,
+  actor_type, actor_id,
+  entity_id,
+  ip,
+  user_agent,
+  body
+)
+SELECT
+  'record' AS entity,
+  'copy' AS action,
+  2 AS version,
+  'user' AS actor_type,
+  actor_id,
+  (
+    SELECT record_file.recordid
+    FROM record_file
+    WHERE record_file.fileid = :originalFileId
+  ) AS entity_id,
+  ip,
+  user_agent,
+  JSON_BUILD_OBJECT(
+    'analytics',
+    JSON_BUILD_OBJECT(
+      'event',
+      'Copy Record',
+      'distinctId',
+      COALESCE(:env || ':', '')
+      || (
+        SELECT record.uploadaccountid
+        FROM record
+        INNER JOIN record_file ON record.recordid = record_file.recordid
+        WHERE record_file.fileid = :newFileId
+      ),
+      'data',
+      JSON_BUILD_OBJECT(
+        'workspace',
+        CASE
+          WHEN (
+            SELECT record.publicdt
+            FROM record
+            INNER JOIN record_file ON record.recordid = record_file.recordid
+            WHERE record_file.fileid = :newFileId
+          ) IS NOT NULL THEN 'Public Files'
+          ELSE 'Private Files'
+        END
+      )
+    ),
+    'record',
+    (
+      SELECT
+        JSON_BUILD_OBJECT(
+          'recordId', record.recordid,
+          'archiveId', record.archiveid,
+          'archiveNbr', record.archivenbr,
+          'publicDt', record.publicdt,
+          'displayName', record.displayname,
+          'note', record.note,
+          'description', record.description,
+          'uploadFilename', record.uploadfilename,
+          'downloadName', record.downloadname,
+          'downloadNameOk', record.downloadnameok,
+          'uploadAccountId', record.uploadaccountid,
+          'size', record.size,
+          'displayDt', record.displaydt,
+          'derivedDt', record.deriveddt,
+          'displayEndDt', record.displayenddt,
+          'derivedEndDt', record.derivedenddt,
+          'derivedCreatedDt', record.derivedcreateddt,
+          'timezoneId', record.timezoneid,
+          'locnId', record.locnid,
+          'view', record.view,
+          'viewProperty', record.viewproperty,
+          'imageRatio', record.imageratio,
+          'encryption', record.encryption,
+          'metaToken', record.metatoken,
+          'refArchiveNbr', record.refarchivenbr,
+          'thumbStatus', record.thumbstatus,
+          'thumbUrl200', record.thumburl200,
+          'thumbUrl500', record.thumburl500,
+          'thumbUrl1000', record.thumburl1000,
+          'thumbUrl2000', record.thumburl2000,
+          'thumbDt', record.thumbdt,
+          'fileStatus', record.filestatus,
+          'status', record.status,
+          'type', record.type,
+          'processedDt', record.processeddt,
+          'createdDt', record.createddt,
+          'updatedDt', record.updateddt
+        )
+      FROM record
+      WHERE record.recordid = (
+        SELECT record_file.recordid
+        FROM record_file
+        WHERE record_file.fileid = :originalFileId
+      )
+    ),
+    'newRecord',
+    (
+      SELECT
+        JSON_BUILD_OBJECT(
+          'recordId', record.recordid,
+          'archiveId', record.archiveid,
+          'archiveNbr', record.archivenbr,
+          'publicDt', record.publicdt,
+          'displayName', record.displayname,
+          'note', record.note,
+          'description', record.description,
+          'uploadFilename', record.uploadfilename,
+          'downloadName', record.downloadname,
+          'downloadNameOk', record.downloadnameok,
+          'uploadAccountId', record.uploadaccountid,
+          'size', record.size,
+          'displayDt', record.displaydt,
+          'derivedDt', record.deriveddt,
+          'displayEndDt', record.displayenddt,
+          'derivedEndDt', record.derivedenddt,
+          'derivedCreatedDt', record.derivedcreateddt,
+          'timezoneId', record.timezoneid,
+          'locnId', record.locnid,
+          'view', record.view,
+          'viewProperty', record.viewproperty,
+          'imageRatio', record.imageratio,
+          'encryption', record.encryption,
+          'metaToken', record.metatoken,
+          'refArchiveNbr', record.refarchivenbr,
+          'thumbStatus', record.thumbstatus,
+          'thumbUrl200', record.thumburl200,
+          'thumbUrl500', record.thumburl500,
+          'thumbUrl1000', record.thumburl1000,
+          'thumbUrl2000', record.thumburl2000,
+          'thumbDt', record.thumbdt,
+          'fileStatus', record.filestatus,
+          'status', record.status,
+          'type', record.type,
+          'processedDt', record.processeddt,
+          'createdDt', record.createddt,
+          'updatedDt', record.updateddt
+        )
+      FROM record
+      WHERE record.recordid = (
+        SELECT record_file.recordid
+        FROM record_file
+        WHERE record_file.fileid = :newFileId
+      )
+    ),
+    'destination',
+    (
+      SELECT
+        JSON_BUILD_OBJECT(
+          'folderId', folder.folderid,
+          'archiveNbr', folder.archivenbr,
+          'archiveId', folder.archiveid,
+          'displayName', folder.displayname,
+          'downloadName', folder.downloadname,
+          'downloadNameOk', folder.downloadnameok,
+          'displayDt', folder.displaydt,
+          'displayEndDt', folder.displayenddt,
+          'derivedDt', folder.deriveddt,
+          'derivedEndDt', folder.derivedenddt,
+          'timezoneId', folder.timezoneid,
+          'note', folder.note,
+          'description', folder.description,
+          'special', folder.special,
+          'sort', folder.sort,
+          'locnId', folder.locnid,
+          'view', folder.view,
+          'viewProperty', folder.viewproperty,
+          'thumbArchiveNbr', folder.thumbarchivenbr,
+          'imageRatio', folder.imageratio,
+          'thumbStatus', folder.thumbstatus,
+          'thumbUrl200', folder.thumburl200,
+          'thumbUrl500', folder.thumburl500,
+          'thumbUrl1000', folder.thumburl1000,
+          'thumbUrl2000', folder.thumburl2000,
+          'thumbDt', folder.thumbdt,
+          'status', folder.status,
+          'type', folder.type,
+          'publicDt', folder.publicdt,
+          'createdDt', folder.createddt,
+          'updatedDt', folder.updateddt
+        )
+      FROM folder
+      WHERE folder.folderid = (
+        SELECT folder_link.parentfolderid
+        FROM folder_link
+        INNER JOIN record_file ON folder_link.recordid = record_file.recordid
+        WHERE record_file.fileid = :newFileId
+      )
+    ),
+    'public',
+    (
+      SELECT record.publicdt
+      FROM record
+      INNER JOIN record_file ON record.recordid = record_file.recordid
+      WHERE record_file.fileid = :newFileId
+    ) IS NOT NULL
+  ) AS body
+FROM
+  event
+WHERE
+  id = :eventId
+  AND EXISTS (SELECT update_file.fileid FROM update_file)

--- a/packages/file_copier/src/validator.ts
+++ b/packages/file_copier/src/validator.ts
@@ -1,0 +1,30 @@
+import Joi from "joi";
+import { logger } from "@stela/logger";
+import type { FileCopyEvent } from "./models";
+
+export const validateFileCopyEvent: (
+	data: unknown,
+) => asserts data is FileCopyEvent = (
+	data: unknown,
+): asserts data is FileCopyEvent => {
+	const validation = Joi.object({
+		id: Joi.string().required(),
+		entity: Joi.string().valid("file").required(),
+		action: Joi.string().valid("copy").required(),
+		body: Joi.object({
+			file: Joi.object({
+				fileid: Joi.number().integer().required(),
+				cloudpath: Joi.string().required(),
+			}).unknown(true),
+			newFile: Joi.object({
+				fileid: Joi.number().integer().required(),
+			}).unknown(true),
+		}).unknown(true),
+	})
+		.unknown(true)
+		.validate(data);
+	if (validation.error !== undefined) {
+		logger.error(validation.error);
+		throw validation.error;
+	}
+};

--- a/packages/file_copier/tsconfig.build.json
+++ b/packages/file_copier/tsconfig.build.json
@@ -1,0 +1,8 @@
+{
+	"extends": "../../tsconfig.build.json",
+	"compilerOptions": {
+		"outDir": "./dist/",
+		"typeRoots": ["../../node_modules/@types", "src/types"]
+	},
+	"include": ["./src"]
+}

--- a/packages/file_copier/tsconfig.json
+++ b/packages/file_copier/tsconfig.json
@@ -1,0 +1,9 @@
+{
+	"exclude": ["node_modules", "packages/*/dist"],
+	"extends": "../../tsconfig.build.json",
+	"compilerOptions": {
+		"outDir": "./dist/",
+		"typeRoots": ["../../node_modules/@types", "src/types"]
+	},
+	"include": ["./src"]
+}

--- a/packages/file_copier/tsconfig.tscp.json
+++ b/packages/file_copier/tsconfig.tscp.json
@@ -1,0 +1,9 @@
+{
+	"extends": "../../tsconfig.build.json",
+	"compilerOptions": {
+		"rootDir": "./src/",
+		"outDir": "./dist",
+		"typeRoots": ["../../node_modules/@types", "src/types"]
+	},
+	"include": ["./src"]
+}

--- a/terraform/prod_cluster/file_copier_prod_lambda.tf
+++ b/terraform/prod_cluster/file_copier_prod_lambda.tf
@@ -1,0 +1,122 @@
+resource "aws_sqs_queue" "file_copier_prod_deadletter_queue" {
+  name = "file-copier-prod-deadletter-queue"
+}
+
+resource "aws_sqs_queue" "file_copier_prod_queue" {
+  name = "file-copier-prod-queue"
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.file_copier_prod_deadletter_queue.arn
+    maxReceiveCount     = 3
+  })
+}
+
+resource "aws_sqs_queue_policy" "file_copier_prod_queue_policy" {
+  queue_url = aws_sqs_queue.file_copier_prod_queue.id
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Service = "sns.amazonaws.com"
+        },
+        Action   = "sqs:SendMessage",
+        Resource = aws_sqs_queue.file_copier_prod_queue.arn,
+        Condition = {
+          ArnEquals = {
+            "aws:SourceArn" = var.event_topic_arn
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_sns_topic_subscription" "file_copier_prod_subscription" {
+  topic_arn = var.event_topic_arn
+  protocol  = "sqs"
+  endpoint  = aws_sqs_queue.file_copier_prod_queue.arn
+  filter_policy = jsonencode({
+    Entity = ["file"],
+    Action = ["copy"]
+  })
+}
+
+data "aws_iam_policy_document" "assume_prod_file_copier_lambda_role" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "file_copier_prod_lambda_role" {
+  name               = "file-copier-prod-lambda-role"
+  assume_role_policy = data.aws_iam_policy_document.assume_prod_file_copier_lambda_role.json
+}
+
+resource "aws_iam_role_policy" "file_copier_prod_lambda_policy" {
+  name = "file-copier-lambda-policy"
+  role = aws_iam_role.file_copier_prod_lambda_role.name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "ec2:CreateNetworkInterface",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DeleteNetworkInterface",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeSubnets",
+          "sqs:ReceiveMessage",
+          "sqs:DeleteMessage",
+          "sqs:GetQueueAttributes",
+          "s3:GetObject",
+          "s3:PutObject",
+        ]
+        Effect   = "Allow"
+        Resource = ["*", aws_sqs_queue.file_copier_prod_queue.arn]
+      },
+    ]
+  })
+}
+
+resource "aws_lambda_function" "file_copier_prod_lambda" {
+  package_type  = "Image"
+  image_uri     = var.file_copier_lambda_image
+  function_name = "file-copier-prod-lambda"
+  role          = aws_iam_role.file_copier_prod_lambda_role.arn
+  timeout       = 30
+
+  vpc_config {
+    security_group_ids = [var.prod_security_group_id]
+    subnet_ids         = var.private_subnet_ids
+  }
+
+  environment {
+    variables = {
+      ENV                    = var.env
+      SENTRY_DSN             = var.sentry_dsn
+      DATABASE_URL           = var.prod_database_url
+      S3_BUCKET              = var.s3_bucket
+      CLOUDFRONT_URL         = var.cloudfront_url
+      CLOUDFRONT_KEY_PAIR_ID = var.cloudfront_key_pair_id
+      CLOUDFRONT_PRIVATE_KEY = var.cloudfront_private_key
+      NODE_OPTIONS           = "--import ./packages/file_copier/dist/instrument.js"
+    }
+  }
+}
+
+resource "aws_lambda_event_source_mapping" "file_copier_prod_event_source_mapping" {
+  event_source_arn                   = aws_sqs_queue.file_copier_prod_queue.arn
+  function_name                      = aws_lambda_function.file_copier_prod_lambda.arn
+  batch_size                         = 10
+  maximum_batching_window_in_seconds = 0
+}

--- a/terraform/prod_cluster/variables.tf
+++ b/terraform/prod_cluster/variables.tf
@@ -83,6 +83,11 @@ variable "metadata_attacher_lambda_image" {
   type        = string
 }
 
+variable "file_copier_lambda_image" {
+  description = "Tag of file copier lambda image to deploy"
+  type        = string
+}
+
 variable "prod_security_group_id" {
   description = "ID of the Production security group"
   type        = string

--- a/terraform/test_cluster/file_copier_dev_lambda.tf
+++ b/terraform/test_cluster/file_copier_dev_lambda.tf
@@ -1,0 +1,126 @@
+data "aws_lambda_function" "file_copier_dev_lambda" {
+  count         = local.need_dev_images ? 1 : 0
+  function_name = "file-copier-dev-lambda"
+}
+
+resource "aws_sqs_queue" "file_copier_dev_deadletter_queue" {
+  name = "file-copier-dev-deadletter-queue"
+}
+
+resource "aws_sqs_queue" "file_copier_dev_queue" {
+  name = "file-copier-dev-queue"
+
+  redrive_policy = jsonencode({ deadLetterTargetArn = aws_sqs_queue.file_copier_dev_deadletter_queue.arn
+    maxReceiveCount = 3
+  })
+}
+
+resource "aws_sqs_queue_policy" "file_copier_dev_queue_policy" {
+  queue_url = aws_sqs_queue.file_copier_dev_queue.id
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Service = "sns.amazonaws.com"
+        },
+        Action   = "sqs:SendMessage",
+        Resource = aws_sqs_queue.file_copier_dev_queue.arn,
+        Condition = {
+          ArnEquals = {
+            "aws:SourceArn" = var.dev_event_topic_arn
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_sns_topic_subscription" "file_copier_dev_subscription" {
+  topic_arn = var.dev_event_topic_arn
+  protocol  = "sqs"
+  endpoint  = aws_sqs_queue.file_copier_dev_queue.arn
+  filter_policy = jsonencode({
+    Entity = ["file"],
+    Action = ["copy"]
+  })
+}
+
+data "aws_iam_policy_document" "assume_dev_file_copier_lambda_role" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "file_copier_dev_lambda_role" {
+  name               = "file-copier-dev-lambda-role"
+  assume_role_policy = data.aws_iam_policy_document.assume_dev_file_copier_lambda_role.json
+}
+
+resource "aws_iam_role_policy" "file_copier_dev_lambda_policy" {
+  name = "file-copier-lambda-policy"
+  role = aws_iam_role.file_copier_dev_lambda_role.name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "ec2:CreateNetworkInterface",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DeleteNetworkInterface",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeSubnets",
+          "sqs:ReceiveMessage",
+          "sqs:DeleteMessage",
+          "sqs:GetQueueAttributes",
+          "s3:GetObject",
+          "s3:PutObject",
+        ]
+        Effect   = "Allow"
+        Resource = ["*", aws_sqs_queue.file_copier_dev_queue.arn]
+      },
+    ]
+  })
+}
+
+resource "aws_lambda_function" "file_copier_dev_lambda" {
+  package_type  = "Image"
+  image_uri     = local.desired_images["file-copier-dev-lambda"]
+  function_name = "file-copier-dev-lambda"
+  role          = aws_iam_role.file_copier_dev_lambda_role.arn
+  timeout       = 30
+
+  vpc_config {
+    security_group_ids = [var.dev_security_group_id]
+    subnet_ids         = var.private_subnet_ids
+  }
+
+  environment {
+    variables = {
+      ENV                    = var.dev_env
+      SENTRY_DSN             = var.sentry_dsn
+      DATABASE_URL           = var.dev_database_url
+      S3_BUCKET              = var.dev_s3_bucket
+      CLOUDFRONT_URL         = var.dev_cloudfront_url
+      CLOUDFRONT_KEY_PAIR_ID = var.cloudfront_key_pair_id
+      CLOUDFRONT_PRIVATE_KEY = var.cloudfront_private_key
+      NODE_OPTIONS           = "--import ./packages/file_copier/dist/instrument.js"
+    }
+  }
+}
+
+resource "aws_lambda_event_source_mapping" "file_copier_dev_event_source_mapping" {
+  event_source_arn                   = aws_sqs_queue.file_copier_dev_queue.arn
+  function_name                      = aws_lambda_function.file_copier_dev_lambda.arn
+  batch_size                         = 10
+  maximum_batching_window_in_seconds = 0
+}

--- a/terraform/test_cluster/file_copier_staging_lambda.tf
+++ b/terraform/test_cluster/file_copier_staging_lambda.tf
@@ -1,0 +1,127 @@
+data "aws_lambda_function" "file_copier_staging_lambda" {
+  count         = local.need_staging_images ? 1 : 0
+  function_name = "file-copier-staging-lambda"
+}
+
+resource "aws_sqs_queue" "file_copier_staging_deadletter_queue" {
+  name = "file-copier-staging-deadletter-queue"
+}
+
+resource "aws_sqs_queue" "file_copier_staging_queue" {
+  name = "file-copier-staging-queue"
+
+  redrive_policy = jsonencode({
+    deadLetterTargetArn = aws_sqs_queue.file_copier_staging_deadletter_queue.arn
+    maxReceiveCount     = 3
+  })
+}
+
+resource "aws_sqs_queue_policy" "file_copier_staging_queue_policy" {
+  queue_url = aws_sqs_queue.file_copier_staging_queue.id
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Service = "sns.amazonaws.com"
+        },
+        Action   = "sqs:SendMessage",
+        Resource = aws_sqs_queue.file_copier_staging_queue.arn,
+        Condition = {
+          ArnEquals = {
+            "aws:SourceArn" = var.staging_event_topic_arn
+          }
+        }
+      }
+    ]
+  })
+}
+
+resource "aws_sns_topic_subscription" "file_copier_staging_subscription" {
+  topic_arn = var.staging_event_topic_arn
+  protocol  = "sqs"
+  endpoint  = aws_sqs_queue.file_copier_staging_queue.arn
+  filter_policy = jsonencode({
+    Entity = ["file"],
+    Action = ["copy"]
+  })
+}
+
+data "aws_iam_policy_document" "assume_staging_file_copier_lambda_role" {
+  statement {
+    effect = "Allow"
+    principals {
+      type        = "Service"
+      identifiers = ["lambda.amazonaws.com"]
+    }
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+resource "aws_iam_role" "file_copier_staging_lambda_role" {
+  name               = "file-copier-staging-lambda-role"
+  assume_role_policy = data.aws_iam_policy_document.assume_staging_file_copier_lambda_role.json
+}
+
+resource "aws_iam_role_policy" "file_copier_staging_lambda_policy" {
+  name = "file-copier-lambda-policy"
+  role = aws_iam_role.file_copier_staging_lambda_role.name
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Action = [
+          "logs:CreateLogGroup",
+          "logs:CreateLogStream",
+          "logs:PutLogEvents",
+          "ec2:CreateNetworkInterface",
+          "ec2:DescribeNetworkInterfaces",
+          "ec2:DeleteNetworkInterface",
+          "ec2:DescribeSecurityGroups",
+          "ec2:DescribeSubnets",
+          "sqs:ReceiveMessage",
+          "sqs:DeleteMessage",
+          "sqs:GetQueueAttributes",
+          "s3:GetObject",
+          "s3:PutObject",
+        ]
+        Effect   = "Allow"
+        Resource = ["*", aws_sqs_queue.file_copier_staging_queue.arn]
+      },
+    ]
+  })
+}
+
+resource "aws_lambda_function" "file_copier_staging_lambda" {
+  package_type  = "Image"
+  image_uri     = local.desired_images["file-copier-staging-lambda"]
+  function_name = "file-copier-staging-lambda"
+  role          = aws_iam_role.file_copier_staging_lambda_role.arn
+  timeout       = 30
+
+  vpc_config {
+    security_group_ids = [var.staging_security_group_id]
+    subnet_ids         = var.private_subnet_ids
+  }
+
+  environment {
+    variables = {
+      ENV                    = var.staging_env
+      SENTRY_DSN             = var.sentry_dsn
+      DATABASE_URL           = var.staging_database_url
+      S3_BUCKET              = var.staging_s3_bucket
+      CLOUDFRONT_URL         = var.staging_cloudfront_url
+      CLOUDFRONT_KEY_PAIR_ID = var.cloudfront_key_pair_id
+      CLOUDFRONT_PRIVATE_KEY = var.cloudfront_private_key
+      NODE_OPTIONS           = "--import ./packages/file_copier/dist/instrument.js"
+    }
+  }
+}
+
+resource "aws_lambda_event_source_mapping" "file_copier_staging_event_source_mapping" {
+  event_source_arn                   = aws_sqs_queue.file_copier_staging_queue.arn
+  function_name                      = aws_lambda_function.file_copier_staging_lambda.arn
+  batch_size                         = 10
+  maximum_batching_window_in_seconds = 0
+}

--- a/terraform/test_cluster/locals.tf
+++ b/terraform/test_cluster/locals.tf
@@ -4,6 +4,7 @@ locals {
     "account-space-update-dev-lambda",
     "archivematica-cleanup-dev",
     "event-send-dev",
+    "file-copier-dev-lambda",
     "file-url-refresh-dev",
     "metadata-attacher-dev-lambda",
     "record-thumbnail-dev-lambda",
@@ -16,6 +17,7 @@ locals {
     "account-space-update-staging-lambda",
     "archivematica-cleanup-staging",
     "event-send-staging",
+    "file-copier-staging-lambda",
     "file-url-refresh-staging",
     "metadata-attacher-staging-lambda",
     "record-thumbnail-staging-lambda",
@@ -44,6 +46,8 @@ locals {
     account-space-update-staging-lambda  = try(data.aws_lambda_function.account_space_update_staging_lambda[0].image_uri, null)
     access-copy-dev-lambda               = try(data.aws_lambda_function.access_copy_dev_lambda[0].image_uri, null)
     access-copy-staging-lambda           = try(data.aws_lambda_function.access_copy_staging_lambda[0].image_uri, null)
+    file-copier-dev-lambda               = try(data.aws_lambda_function.file_copier_dev_lambda[0].image_uri, null)
+    file-copier-staging-lambda           = try(data.aws_lambda_function.file_copier_staging_lambda[0].image_uri, null)
     metadata-attacher-dev-lambda         = try(data.aws_lambda_function.metadata_attacher_dev_lambda[0].image_uri, null)
     metadata-attacher-staging-lambda     = try(data.aws_lambda_function.metadata_attacher_staging_lambda[0].image_uri, null)
     record-thumbnail-dev-lambda          = try(data.aws_lambda_function.record_thumbnail_dev_lambda[0].image_uri, null)


### PR DESCRIPTION
This is best tested in conjunction with the copy endpoint added in https://github.com/PermanentOrg/stela/pull/747; ideally by the time you are testing this that has been merged. Then you can test by simply hitting that endpoint and checking that after a short time to allow async processes to run:
- The copy has an original file that you can download
- The copy has an access copy that you can download
- The copy has a thumbnail
Right now it looks to me like the web-app isn't displaying thumbnails when only an Archivematica thumbnail exists, which is the expected end state for these copies.