### PR TITLE
Support plural accounts resource

### DIFF
--- a/packages/api/src/account/controller/create_storage_adjustments.test.ts
+++ b/packages/api/src/account/controller/create_storage_adjustments.test.ts
@@ -59,7 +59,7 @@ describe("/account/storage-adjustments", () => {
 	});
 
 	test("should call verifyAdminAuthentication", async () => {
-		await agent.post(`/api/v2/account/${testAccountId}/storage-adjustments`);
+		await agent.post(`/api/v2/accounts/${testAccountId}/storage-adjustments`);
 		expect(verifyAdminAuthentication).toHaveBeenCalled();
 	});
 
@@ -69,7 +69,7 @@ describe("/account/storage-adjustments", () => {
 			"13bb917e-7c75-4971-a8ee-b22e82432888",
 		);
 		await agent
-			.post(`/api/v2/account/${testAccountId}/storage-adjustments`)
+			.post(`/api/v2/accounts/${testAccountId}/storage-adjustments`)
 			.expect(400);
 	});
 
@@ -79,34 +79,34 @@ describe("/account/storage-adjustments", () => {
 			"13bb917e-7c75-4971-a8ee-b22e82432888",
 		);
 		await agent
-			.post(`/api/v2/account/${testAccountId}/storage-adjustments`)
+			.post(`/api/v2/accounts/${testAccountId}/storage-adjustments`)
 			.expect(400);
 	});
 
 	test("should return invalid request status if subject from auth token is missing", async () => {
 		mockVerifyAdminAuthentication("admin@permanent.org");
 		await agent
-			.post(`/api/v2/account/${testAccountId}/storage-adjustments`)
+			.post(`/api/v2/accounts/${testAccountId}/storage-adjustments`)
 			.expect(400);
 	});
 
 	test("should return invalid request status if subject from auth token is not a uuid", async () => {
 		mockVerifyAdminAuthentication("admin@permanent.org", "not_a_uuid");
 		await agent
-			.post(`/api/v2/account/${testAccountId}/storage-adjustments`)
+			.post(`/api/v2/accounts/${testAccountId}/storage-adjustments`)
 			.expect(400);
 	});
 
 	test("should return invalid request status if storageAmount is missing", async () => {
 		await agent
-			.post(`/api/v2/account/${testAccountId}/storage-adjustments`)
+			.post(`/api/v2/accounts/${testAccountId}/storage-adjustments`)
 			.send({})
 			.expect(400);
 	});
 
 	test("should return invalid request status if storageAmount is not a number", async () => {
 		await agent
-			.post(`/api/v2/account/${testAccountId}/storage-adjustments`)
+			.post(`/api/v2/accounts/${testAccountId}/storage-adjustments`)
 			.send({
 				storageAmount: "not_a_number",
 			})
@@ -115,14 +115,14 @@ describe("/account/storage-adjustments", () => {
 
 	test("should return invalid request status if storageAmount is not an integer", async () => {
 		await agent
-			.post(`/api/v2/account/${testAccountId}/storage-adjustments`)
+			.post(`/api/v2/accounts/${testAccountId}/storage-adjustments`)
 			.send({ storageAmount: 5.5 })
 			.expect(400);
 	});
 
 	test("should return 404 if account does not exist", async () => {
 		await agent
-			.post(`/api/v2/account/10000000/storage-adjustments`)
+			.post(`/api/v2/accounts/10000000/storage-adjustments`)
 			.send({ storageAmount: 5 })
 			.expect(404);
 	});
@@ -131,7 +131,7 @@ describe("/account/storage-adjustments", () => {
 		const initialAccountSpace = await getAccountSpace(testAccountId);
 
 		const response = await agent
-			.post(`/api/v2/account/${testAccountId}/storage-adjustments`)
+			.post(`/api/v2/accounts/${testAccountId}/storage-adjustments`)
 			.send({ storageAmount: 5 })
 			.expect(200);
 
@@ -156,7 +156,7 @@ describe("/account/storage-adjustments", () => {
 		const initialAccountSpace = await getAccountSpace(testAccountId);
 
 		const response = await agent
-			.post(`/api/v2/account/${testAccountId}/storage-adjustments`)
+			.post(`/api/v2/accounts/${testAccountId}/storage-adjustments`)
 			.send({ storageAmount: -1 })
 			.expect(200);
 
@@ -181,7 +181,7 @@ describe("/account/storage-adjustments", () => {
 		const initialAccountSpace = await getAccountSpace(testAccountId);
 
 		const response = await agent
-			.post(`/api/v2/account/${testAccountId}/storage-adjustments`)
+			.post(`/api/v2/accounts/${testAccountId}/storage-adjustments`)
 			.send({ storageAmount: 3 })
 			.expect(200);
 
@@ -203,7 +203,7 @@ describe("/account/storage-adjustments", () => {
 		const initialAccountSpace = await getAccountSpace(testAccountId);
 
 		await agent
-			.post(`/api/v2/account/${testAccountId}/storage-adjustments`)
+			.post(`/api/v2/accounts/${testAccountId}/storage-adjustments`)
 			.send({ storageAmount: 5 })
 			.expect(200);
 
@@ -284,7 +284,7 @@ describe("/account/storage-adjustments", () => {
 			.mockRejectedValueOnce(testError);
 
 		await agent
-			.post(`/api/v2/account/${testAccountId}/storage-adjustments`)
+			.post(`/api/v2/accounts/${testAccountId}/storage-adjustments`)
 			.send({ storageAmount: 5 })
 			.expect(500);
 
@@ -293,7 +293,7 @@ describe("/account/storage-adjustments", () => {
 
 	test("should handle zero storage adjustment", async () => {
 		await agent
-			.post(`/api/v2/account/${testAccountId}/storage-adjustments`)
+			.post(`/api/v2/accounts/${testAccountId}/storage-adjustments`)
 			.send({ storageAmount: 0 })
 			.expect(400);
 	});

--- a/packages/api/src/account/controller/get_signup_details.test.ts
+++ b/packages/api/src/account/controller/get_signup_details.test.ts
@@ -33,7 +33,7 @@ describe("getSignupDetails", () => {
 	});
 
 	test("should return an account's signup details", async () => {
-		const response = await agent.get("/api/v2/account/signup").expect(200);
+		const response = await agent.get("/api/v2/accounts/signup").expect(200);
 		const { body: signupDetails } = response as { body: SignupDetails };
 		expect(signupDetails.token).toEqual("earlyb1rd");
 	});
@@ -43,7 +43,7 @@ describe("getSignupDetails", () => {
 			"not_an_account@permanent.org",
 			"b5461dc2-1eb0-450e-b710-fef7b2cafe1e",
 		);
-		await agent.get("/api/v2/account/signup").expect(404);
+		await agent.get("/api/v2/accounts/signup").expect(404);
 	});
 
 	test("should throw an error if the account has no signup details", async () => {
@@ -51,7 +51,7 @@ describe("getSignupDetails", () => {
 			"test+1@permanent.org",
 			"b5461dc2-1eb0-450e-b710-fef7b2cafe1e",
 		);
-		await agent.get("/api/v2/account/signup").expect(404);
+		await agent.get("/api/v2/accounts/signup").expect(404);
 	});
 
 	test("should throw an error if database call fails unexpectedly", async () => {
@@ -62,12 +62,12 @@ describe("getSignupDetails", () => {
 					.fn()
 					.mockRejectedValueOnce(new Error("out of cheese - redo from start")),
 			);
-		await agent.get("/api/v2/account/signup").expect(500);
+		await agent.get("/api/v2/accounts/signup").expect(500);
 		expect(logger.error).toHaveBeenCalled();
 	});
 
 	test("should return a bad request error if the request is invalid", async () => {
 		mockVerifyUserAuthentication("test+1@permanent.org");
-		await agent.get("/api/v2/account/signup").expect(400);
+		await agent.get("/api/v2/accounts/signup").expect(400);
 	});
 });

--- a/packages/api/src/account/controller/leave_archive.test.ts
+++ b/packages/api/src/account/controller/leave_archive.test.ts
@@ -62,7 +62,7 @@ describe("leaveArchive", () => {
 
 		expect(accountArchiveBeforeLeaveResult.rows.length).toBe(1);
 
-		await agent.delete("/api/v2/account/archive/1").expect(204);
+		await agent.delete("/api/v2/accounts/archive/1").expect(204);
 
 		const accountArchiveAfterLeaveResult = await db.query(
 			selectAccountArchiveRow,
@@ -72,25 +72,25 @@ describe("leaveArchive", () => {
 	});
 
 	test("should throw 404 error if account archive relationship is not found", async () => {
-		await agent.delete("/api/v2/account/archive/2022").expect(404);
+		await agent.delete("/api/v2/accounts/archive/2022").expect(404);
 	});
 
 	test("should throw 400 error if the account owns the archive", async () => {
-		await agent.delete("/api/v2/account/archive/2").expect(400);
+		await agent.delete("/api/v2/accounts/archive/2").expect(400);
 	});
 
 	test("should log an event", async () => {
 		const eventsBeforeLeave = await db.query(selectEventRow);
 		expect(eventsBeforeLeave.rows.length).toBe(0);
 
-		await agent.delete("/api/v2/account/archive/1").expect(204);
+		await agent.delete("/api/v2/accounts/archive/1").expect(204);
 
 		expect(createEvent).toHaveBeenCalled();
 	});
 
 	test("should return a bad request error if the request is invalid", async () => {
 		mockVerifyUserAuthentication("test+1@permanent.org");
-		await agent.delete("/api/v2/account/archive/1").expect(400);
+		await agent.delete("/api/v2/accounts/archive/1").expect(400);
 	});
 
 	test("should return a 500 error if the deletion database call fails", async () => {
@@ -105,6 +105,6 @@ describe("leaveArchive", () => {
 					rows: [],
 				}),
 			);
-		await agent.delete("/api/v2/account/archive/1").expect(500);
+		await agent.delete("/api/v2/accounts/archive/1").expect(500);
 	});
 });

--- a/packages/api/src/account/controller/update_tags.test.ts
+++ b/packages/api/src/account/controller/update_tags.test.ts
@@ -46,7 +46,7 @@ describe("updateTags", () => {
 			.mocked(MailchimpMarketing.lists.updateListMemberTags)
 			.mockResolvedValue(null);
 
-		await agent.put("/api/v2/account/tags").send(requestBody).expect(200);
+		await agent.put("/api/v2/accounts/tags").send(requestBody).expect(200);
 
 		expect(MailchimpMarketing.lists.updateListMemberTags).toHaveBeenCalledWith(
 			expectedListId,
@@ -66,7 +66,7 @@ describe("updateTags", () => {
 				instance: "",
 			});
 		await agent
-			.put("/api/v2/account/tags")
+			.put("/api/v2/accounts/tags")
 			.send({
 				emailFromAuthToken: "test@permanent.org",
 				addTags: ["tag1", "tag2"],
@@ -77,7 +77,7 @@ describe("updateTags", () => {
 
 	test("should throw a bad request error if the request body is invalid", async () => {
 		await agent
-			.put("/api/v2/account/tags")
+			.put("/api/v2/accounts/tags")
 			.send({
 				emailFromAuthToken: "test@permanent.org",
 				addTags: [1, 2, 4],

--- a/packages/api/src/routes/index.ts
+++ b/packages/api/src/routes/index.ts
@@ -19,7 +19,8 @@ const apiRoutes = express.Router();
 apiRoutes.get("/health", healthController.getHealth);
 apiRoutes.use("/directive", directiveController);
 apiRoutes.use("/legacy-contact", legacyContactController);
-apiRoutes.use("/account", accountController);
+apiRoutes.use("/accounts", accountController);
+apiRoutes.use("/account", accountController); // Deprecated path maintained to avoid breaking changes
 apiRoutes.use("/archives", archiveController);
 apiRoutes.use("/archive", archiveController); // Deprecated path maintained to avoid breaking changes
 apiRoutes.use("/admin", adminController);


### PR DESCRIPTION
Our API standards dictate that resoure names in URIs should be plural. Presently the /account path is singular. This commit adds a /accounts path to match our standards and our documentation, while maintaining /account for backward compatibility.