### PR TITLE
Pluralize storage-adjustment in API docs

### DIFF
--- a/packages/api/docs/src/api.yaml
+++ b/packages/api/docs/src/api.yaml
@@ -44,7 +44,7 @@ paths:
     $ref: "./paths/mfa_management.yaml#/mfa-method-with-id"
   /accounts:
     $ref: "./paths/account.yaml#/account"
-  /accounts/{id}/storage-adjustment:
+  /accounts/{id}/storage-adjustments:
     $ref: "./paths/account.yaml#/storage-adjustment"
   /share-links:
     $ref: "./paths/share_link.yaml#/share-link"


### PR DESCRIPTION
Currently, the API docs say the storage adjustment endpoint is at /account/{accountId}/storage-adjustment, but in fact it's at /account/{accountId}/storage-adjustments. This commit corrects the docs.