### PR TITLE
Send invite id to clients

### DIFF
--- a/packages/api/src/folder/queries/get_folders.sql
+++ b/packages/api/src/folder/queries/get_folders.sql
@@ -76,7 +76,7 @@ aggregated_pending_shares AS (
   SELECT
     invite_share.folder_linkid,
     ARRAY_AGG(JSONB_BUILD_OBJECT(
-      'id', invite_share.invite_shareid::text,
+      'id', invite.inviteid::text,
       'email', invite.email,
       'name', invite.fullname,
       'accessRole', invite_share.accessrole

--- a/packages/api/src/record/queries/get_records.sql
+++ b/packages/api/src/record/queries/get_records.sql
@@ -109,7 +109,7 @@ aggregated_pending_shares AS (
   SELECT
     invite_share.folder_linkid,
     ARRAY_AGG(JSONB_BUILD_OBJECT(
-      'id', invite_share.invite_shareid::TEXT,
+      'id', invite.inviteid::TEXT,
       'email', invite.email,
       'name', invite.fullname,
       'accessRole', invite_share.accessrole


### PR DESCRIPTION
Send the invite id instead of the invite_shareid to clients so that they can use it to revoke invitations from a share. Followup to PER-10577 and PER-10478, to be used by VSP-1737.