### PR TITLE
Add GET /accounts endpoint

### DIFF
--- a/packages/api/docs/src/models/account.yaml
+++ b/packages/api/docs/src/models/account.yaml
@@ -79,6 +79,16 @@ account:
           type: string
         country:
           type: string
+    status:
+      type: string
+      enum:
+        - ok
+        - invited
+    type:
+      type: string
+      enum:
+        - standard
+        - test
     settings:
       type: object
       required: [hideChecklist, allowSftpDeletion, notificationsEnabled]

--- a/packages/api/docs/src/paths/account.yaml
+++ b/packages/api/docs/src/paths/account.yaml
@@ -41,6 +41,57 @@ account:
         $ref: "../errors.yaml#/400"
       "500":
         $ref: "../errors.yaml#/500"
+  get:
+    summary: Get account objects. Requires admin authentication.
+    parameters:
+      - name: accountIds
+        in: query
+        required: false
+        description: |
+          An array of account IDs to retrieve.
+          If this parameter is provided, accountEmails must not be provided
+        schema:
+          type: array
+          items:
+            type: string
+      - name: accountEmails
+        in: query
+        required: false
+        description: |
+          An array of account emails to retrieve.
+          If this parameter is provided, accountIds must not be provided
+        schema:
+          type: array
+          items:
+            type: string
+    operationId: getAccount
+    security:
+      - bearerHttpAuthentication: []
+    tags:
+      - accounts
+      - admin
+    responses:
+      "200":
+        description: >
+          The accounts requested.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                items:
+                  type: array
+                  items:
+                    $ref: "../models/account.yaml#/account"
+                pagination:
+                  $ref: "../models/pagination_metadata.yaml#/pagination"
+      "400":
+        $ref: "../errors.yaml#/400"
+      "401":
+        $ref: "../errors.yaml#/401"
+      "500":
+        $ref: "../errors.yaml#/500"
+
 storage-adjustment:
   post:
     parameters:

--- a/packages/api/src/account/controller/controller.ts
+++ b/packages/api/src/account/controller/controller.ts
@@ -10,15 +10,35 @@ import {
 import {
 	validateUpdateTagsRequest,
 	validateBodyFromAuthentication,
+	validateBodyFromAdminAuthentication,
 	validateLeaveArchiveParams,
 	validateLeaveArchiveRequest,
 	validateCreateStorageAdjustmentRequest,
 	validateCreateStorageAdjustmentParams,
+	validateGetAccountsQuery,
 } from "../validators";
-import { accountService, createStorageAdjustment } from "../service";
+import {
+	accountService,
+	createStorageAdjustment,
+	getAccounts,
+} from "../service";
 import type { LeaveArchiveRequest } from "../models";
 
 export const accountController = Router();
+accountController.get(
+	"/",
+	verifyAdminAuthentication,
+	async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+		try {
+			validateBodyFromAdminAuthentication(req.body);
+			validateGetAccountsQuery(req.query);
+			const result = await getAccounts(req.query);
+			res.status(HTTP_STATUS.SUCCESSFUL.OK).json(result);
+		} catch (err) {
+			next(err);
+		}
+	},
+);
 accountController.put(
 	"/tags",
 	verifyUserAuthentication,

--- a/packages/api/src/account/controller/get_accounts.test.ts
+++ b/packages/api/src/account/controller/get_accounts.test.ts
@@ -1,0 +1,266 @@
+import request from "supertest";
+import { logger } from "@stela/logger";
+import { app } from "../../app";
+import { db } from "../../database";
+import { verifyAdminAuthentication } from "../../middleware";
+import { mockVerifyAdminAuthentication } from "../../../test/middleware_mocks";
+import type { Account } from "../models";
+
+jest.mock("../../database");
+jest.mock("../../middleware");
+jest.mock("@stela/logger");
+
+const setupDatabase = async (): Promise<void> => {
+	await db.sql("account.fixtures.create_test_accounts");
+};
+
+const clearDatabase = async (): Promise<void> => {
+	await db.query("TRUNCATE account CASCADE");
+};
+
+describe("GET /account", () => {
+	const agent = request(app);
+
+	beforeEach(async () => {
+		mockVerifyAdminAuthentication(
+			"admin@permanent.org",
+			"13bb917e-7c75-4971-a8ee-b22e82432888",
+		);
+		await clearDatabase();
+		await setupDatabase();
+	});
+
+	afterEach(async () => {
+		await clearDatabase();
+		jest.clearAllMocks();
+	});
+
+	test("should call verifyAdminAuthentication", async () => {
+		await agent.get("/api/v2/account?accountIds[]=2&pageSize=10");
+		expect(verifyAdminAuthentication).toHaveBeenCalled();
+	});
+
+	test("should return 400 if email from auth token is missing", async () => {
+		mockVerifyAdminAuthentication(
+			undefined,
+			"13bb917e-7c75-4971-a8ee-b22e82432888",
+		);
+		await agent.get("/api/v2/account?accountIds[]=2&pageSize=10").expect(400);
+	});
+
+	test("should return 400 if admin subject from auth token is missing", async () => {
+		mockVerifyAdminAuthentication("admin@permanent.org");
+		await agent.get("/api/v2/account?accountIds[]=2&pageSize=10").expect(400);
+	});
+
+	test("should return 400 if neither accountIds nor accountEmails is provided", async () => {
+		await agent.get("/api/v2/account?pageSize=10").expect(400);
+	});
+
+	test("should return 400 if pageSize is not provided", async () => {
+		await agent.get("/api/v2/account?accountIds[]=2").expect(400);
+	});
+
+	test("should return 400 if both accountIds and accountEmails are provided", async () => {
+		await agent
+			.get(
+				"/api/v2/account?accountIds[]=2&accountEmails[]=test@permanent.org&pageSize=10",
+			)
+			.expect(400);
+	});
+
+	test("should return 400 if accountEmails contains an invalid email", async () => {
+		await agent
+			.get("/api/v2/account?accountEmails[]=not-an-email&pageSize=10")
+			.expect(400);
+	});
+
+	test("should return accounts matching the given accountIds", async () => {
+		const response = await agent
+			.get("/api/v2/account?accountIds[]=2&accountIds[]=3&pageSize=10")
+			.expect(200);
+
+		const {
+			body: { items },
+		} = response as { body: { items: Account[] } };
+		expect(items).toHaveLength(2);
+		const ids = items.map((a: { id: string }) => a.id);
+		expect(ids).toContain("2");
+		expect(ids).toContain("3");
+	});
+
+	test("should return the correct account shape when filtering by accountIds", async () => {
+		const response = await agent
+			.get("/api/v2/account?accountIds[]=2&pageSize=10")
+			.expect(200);
+
+		const {
+			body: {
+				items: [account],
+			},
+		} = response as { body: { items: Account[] } };
+		if (account === undefined) {
+			expect(account).toBeDefined();
+		} else {
+			expect(account.id).toBe("2");
+			expect(account.primaryEmail.address).toBe("test@permanent.org");
+			expect(account.primaryEmail.verified).toBe(false);
+			expect(account.fullName).toBe("Jack Rando");
+			expect(account.address).toEqual({
+				lineOne: null,
+				lineTwo: null,
+				city: null,
+				state: null,
+				zip: null,
+				country: null,
+			});
+			expect(account.settings.hideChecklist).toBe(false);
+			expect(account.settings.allowSftpDeletion).toBe(false);
+			expect(account.settings.notificationsEnabled).toEqual({});
+			expect(account.type).toEqual("standard");
+			expect(account.status).toEqual("ok");
+		}
+	});
+
+	test("should not return a deleted account", async () => {
+		const response = await agent
+			.get("/api/v2/account?accountIds[]=34&pageSize=10")
+			.expect(200);
+
+		const {
+			body: { items },
+		} = response as { body: { items: Account[] } };
+		expect(items.length).toEqual(0);
+	});
+
+	test("should return accounts matching the given accountEmails", async () => {
+		const response = await agent
+			.get("/api/v2/account?accountEmails[]=test@permanent.org&pageSize=10")
+			.expect(200);
+
+		const {
+			body: { items },
+		} = response as { body: { items: Account[] } };
+		expect(items).toHaveLength(1);
+		expect(items[0]?.id).toBe("2");
+	});
+
+	test("should lookup accounts by email case-insensitively", async () => {
+		const response = await agent
+			.get("/api/v2/account?accountEmails[]=TEST@permanent.org&pageSize=10")
+			.expect(200);
+
+		const {
+			body: { items },
+		} = response as { body: { items: Account[] } };
+		expect(items).toHaveLength(1);
+		expect(items[0]?.id).toBe("2");
+	});
+
+	test("should return accounts matching multiple given accountEmails", async () => {
+		const response = await agent
+			.get(
+				"/api/v2/account?accountEmails[]=test@permanent.org&accountEmails[]=test%2B1@permanent.org&pageSize=10",
+			)
+			.expect(200);
+
+		const {
+			body: { items },
+		} = response as { body: { items: Account[] } };
+		expect(items).toHaveLength(2);
+		const ids = items.map((a: { id: string }) => a.id);
+		expect(ids).toContain("2");
+		expect(ids).toContain("3");
+	});
+
+	test("should match accountEmails case-insensitively", async () => {
+		const response = await agent
+			.get("/api/v2/account?accountEmails[]=TEST@PERMANENT.ORG&pageSize=10")
+			.expect(200);
+
+		const {
+			body: { items },
+		} = response as { body: { items: Account[] } };
+		expect(items).toHaveLength(1);
+		expect(items[0]?.id).toBe("2");
+	});
+
+	test("should return empty items array when no accounts match", async () => {
+		const response = await agent
+			.get("/api/v2/account?accountIds[]=99999&pageSize=10")
+			.expect(200);
+
+		const {
+			body: { items, pagination },
+		} = response as {
+			body: {
+				items: Account[];
+				pagination: {
+					nextCursor: string;
+					nextPage: string;
+					totalPages: number;
+				};
+			};
+		};
+		expect(items).toHaveLength(0);
+		expect(pagination.totalPages).toBe(0);
+	});
+
+	test("should return a pagination object", async () => {
+		const response = await agent
+			.get("/api/v2/account?accountIds[]=2&accountIds[]=3&pageSize=1")
+			.expect(200);
+
+		const {
+			body: { pagination },
+		} = response as {
+			body: {
+				items: Account[];
+				pagination: {
+					nextCursor: string;
+					nextPage: string;
+					totalPages: number;
+				};
+			};
+		};
+		expect(pagination).toBeDefined();
+		expect(pagination.totalPages).toBe(2);
+		expect(pagination.nextCursor).toBe("2");
+		expect(pagination.nextPage).toBe(
+			"https:///api/v2/accounts?pageSize=1&cursor=2",
+		);
+	});
+
+	test("should access a later page when given a cursor", async () => {
+		const response = await agent
+			.get("/api/v2/account?accountIds[]=2&accountIds[]=3&pageSize=1&cursor=2")
+			.expect(200);
+
+		const {
+			body: { items },
+		} = response as { body: { items: Account[] } };
+		expect(items).toHaveLength(1);
+		expect(items[0]?.id).toBe("3");
+	});
+
+	test("should log error and return 500 if database query fails", async () => {
+		const testError = new Error("test error");
+		jest.spyOn(db, "sql").mockRejectedValueOnce(testError);
+
+		await agent.get("/api/v2/account?accountIds[]=2&pageSize=10").expect(500);
+
+		expect(logger.error).toHaveBeenCalledWith(testError);
+	});
+
+	test("should accept a single accountId string (not array)", async () => {
+		const response = await agent
+			.get("/api/v2/account?accountIds=2&pageSize=10")
+			.expect(200);
+
+		const {
+			body: { items },
+		} = response as { body: { items: Account[] } };
+		expect(items).toHaveLength(1);
+		expect(items[0]?.id).toBe("2");
+	});
+});

--- a/packages/api/src/account/models.ts
+++ b/packages/api/src/account/models.ts
@@ -112,14 +112,6 @@ export interface GetAccountArchiveResult {
 	type: string;
 	status: string;
 }
-export interface GetCurrentAccountArchiveResult {
-	accountArchiveId: string;
-	accountId: string;
-	archiveId: string;
-	accessRole: string;
-	type: string;
-	status: string;
-}
 export interface LeaveArchiveRequest {
 	emailFromAuthToken: string;
 	userSubjectFromAuthToken: string;

--- a/packages/api/src/account/models.ts
+++ b/packages/api/src/account/models.ts
@@ -1,3 +1,100 @@
+interface NotificationTypePreference {
+	apps?: { confirmations?: boolean };
+	share?: {
+		requests?: boolean;
+		activities?: boolean;
+		confirmations?: boolean;
+	};
+	account?: {
+		confirmations?: boolean;
+		recommendations?: boolean;
+	};
+	archive?: {
+		requests?: boolean;
+		confirmations?: boolean;
+	};
+	relationships?: {
+		requests?: boolean;
+		confirmations?: boolean;
+	};
+}
+
+interface RawNotificationPreferences {
+	textPreference?: NotificationTypePreference;
+	emailPreference?: NotificationTypePreference;
+	inAppPreference?: NotificationTypePreference;
+}
+
+export interface Account {
+	id: string;
+	primaryEmail: {
+		address: string;
+		verified: boolean;
+	};
+	primaryPhone?: {
+		number: string;
+		verified: boolean;
+	};
+	fullName: string | null;
+	defaultArchiveId?: string;
+	address: {
+		lineOne: string | null;
+		lineTwo: string | null;
+		city: string | null;
+		state: string | null;
+		zip: string | null;
+		country: string | null;
+	};
+	settings: {
+		hideChecklist: boolean;
+		allowSftpDeletion: boolean;
+		notificationsEnabled: {
+			sms?: NotificationTypePreference | undefined;
+			email?: NotificationTypePreference | undefined;
+			inApp?: NotificationTypePreference | undefined;
+		};
+	};
+	status: PrettyAccountStatus;
+	type: PrettyAccountType;
+}
+
+export interface AccountRow {
+	id: string;
+	primaryEmailAddress: string;
+	emailStatus: string | null;
+	primaryPhoneNumber: string | null;
+	phoneStatus: string | null;
+	fullName: string | null;
+	defaultArchiveId: string | null;
+	addressLineOne: string | null;
+	addressLineTwo: string | null;
+	city: string | null;
+	state: string | null;
+	zip: string | null;
+	country: string | null;
+	hideChecklist: boolean;
+	allowSftpDeletion: boolean;
+	notificationPreferences: RawNotificationPreferences;
+	status: AccountStatus;
+	type: AccountType;
+}
+
+export interface GetAccountsQuery {
+	accountIds?: string | string[];
+	accountEmails?: string | string[];
+	pageSize: number;
+	cursor: string | undefined;
+}
+
+export interface GetAccountsResponse {
+	items: Account[];
+	pagination: {
+		nextCursor: string | undefined;
+		nextPage: string | undefined;
+		totalPages: number;
+	};
+}
+
 export interface UpdateTagsRequest {
 	emailFromAuthToken: string;
 	addTags?: string[];
@@ -40,4 +137,24 @@ export interface StorageAdjustment {
 	newStorageTotal: number;
 	adjustmentAmount: number;
 	createdAt: Date;
+}
+
+export enum AccountStatus {
+	Ok = "status.auth.ok",
+	Invited = "status.generic.invited",
+}
+
+export enum AccountType {
+	Standard = "type.account.standard",
+	Test = "type.account.test",
+}
+
+export enum PrettyAccountStatus {
+	Ok = "ok",
+	Invited = "invited",
+}
+
+export enum PrettyAccountType {
+	Standard = "standard",
+	Test = "test",
 }

--- a/packages/api/src/account/queries/get_accounts.sql
+++ b/packages/api/src/account/queries/get_accounts.sql
@@ -1,0 +1,46 @@
+SELECT
+  account.accountid::text AS id,
+  account.primaryemail AS "primaryEmailAddress",
+  account.emailstatus AS "emailStatus",
+  account.primaryphone AS "primaryPhoneNumber",
+  account.phonestatus AS "phoneStatus",
+  account.fullname AS "fullName",
+  account.defaultarchiveid::text AS "defaultArchiveId",
+  account.address AS "addressLineOne",
+  account.address2 AS "addressLineTwo",
+  account.city,
+  account.state,
+  account.zip,
+  account.country,
+  account.hidechecklist AS "hideChecklist",
+  account.allowsftpdeletion AS "allowSftpDeletion",
+  account.notificationpreferences AS "notificationPreferences",
+  account.status,
+  account.type,
+  CEILING((
+    SELECT COUNT(account_for_count.accountid) FROM account AS account_for_count
+    WHERE
+      (
+        :filterByIds = TRUE
+        AND account_for_count.accountid::text = ANY(:accountIds::text[])
+      )
+      OR (
+        :filterByIds = FALSE
+        AND LOWER(account_for_count.primaryemail) = ANY(:accountEmails::text[])
+      )
+  ) / :pageSize) AS "totalPages"
+FROM
+  account
+WHERE
+  ((
+    :filterByIds = TRUE
+    AND account.accountid::text = ANY(:accountIds::text[])
+  )
+  OR (
+    :filterByIds = FALSE
+    AND LOWER(account.primaryemail) = ANY(:accountEmails::text[])
+  ))
+  AND account.accountid > COALESCE(:cursor, 0)
+  AND account.status != 'status.generic.deleted'
+ORDER BY account.accountid ASC
+LIMIT :pageSize;

--- a/packages/api/src/account/service.ts
+++ b/packages/api/src/account/service.ts
@@ -12,7 +12,6 @@ import {
 	type UpdateTagsRequest,
 	type SignupDetails,
 	type GetAccountArchiveResult,
-	type GetCurrentAccountArchiveResult,
 	type LeaveArchiveRequest,
 	type CreateStorageAdjustmentRequest,
 	type StorageAdjustment,
@@ -256,29 +255,11 @@ const getAccountArchive = async (
 	return accountArchiveResult.rows[0];
 };
 
-const getCurrentAccountArchiveMemberships = async (
-	email: string,
-): Promise<GetCurrentAccountArchiveResult[]> => {
-	const currentAccountArchiveResult = await db
-		.sql<GetCurrentAccountArchiveResult>(
-			"account.queries.get_current_account_archive_memberships",
-			{ email },
-		)
-		.catch((err: unknown) => {
-			logger.error(err);
-			throw new createError.InternalServerError(
-				"Failed to retrieve current account archive memberships",
-			);
-		});
-	return currentAccountArchiveResult.rows;
-};
-
 export const accountService = {
 	getSignupDetails,
 	leaveArchive,
 	updateTags,
 	getAccountArchive,
-	getCurrentAccountArchiveMemberships,
 };
 
 export const createStorageAdjustment = async (

--- a/packages/api/src/account/service.ts
+++ b/packages/api/src/account/service.ts
@@ -8,15 +8,123 @@ import { ACCESS_ROLE, EVENT_ACTION, EVENT_ENTITY, GB } from "../constants";
 import { createEvent } from "../event/service";
 import type { CreateEventRequest } from "../event/models";
 
-import type {
-	UpdateTagsRequest,
-	SignupDetails,
-	GetAccountArchiveResult,
-	LeaveArchiveRequest,
-	GetCurrentAccountArchiveResult,
-	CreateStorageAdjustmentRequest,
-	StorageAdjustment,
+import {
+	type UpdateTagsRequest,
+	type SignupDetails,
+	type GetAccountArchiveResult,
+	type GetCurrentAccountArchiveResult,
+	type LeaveArchiveRequest,
+	type CreateStorageAdjustmentRequest,
+	type StorageAdjustment,
+	type Account,
+	type AccountRow,
+	type GetAccountsQuery,
+	type GetAccountsResponse,
+	AccountType,
+	PrettyAccountType,
+	AccountStatus,
+	PrettyAccountStatus,
 } from "./models";
+
+const prettifyAccountType = (accountType: AccountType): PrettyAccountType => {
+	switch (accountType) {
+		case AccountType.Standard:
+			return PrettyAccountType.Standard;
+		case AccountType.Test:
+			return PrettyAccountType.Test;
+	}
+};
+
+const prettifyAccountStatus = (
+	accountStatus: AccountStatus,
+): PrettyAccountStatus => {
+	switch (accountStatus) {
+		case AccountStatus.Ok:
+			return PrettyAccountStatus.Ok;
+		case AccountStatus.Invited:
+			return PrettyAccountStatus.Invited;
+	}
+};
+
+const accountRowToAccount = (row: AccountRow): Account => ({
+	id: row.id,
+	primaryEmail: {
+		address: row.primaryEmailAddress,
+		verified: row.emailStatus === "status.auth.ok",
+	},
+	...(row.primaryPhoneNumber !== null && {
+		primaryPhone: {
+			number: row.primaryPhoneNumber,
+			verified: row.phoneStatus === "status.auth.ok",
+		},
+	}),
+	fullName: row.fullName,
+	...(row.defaultArchiveId !== null && {
+		defaultArchiveId: row.defaultArchiveId,
+	}),
+	address: {
+		lineOne: row.addressLineOne,
+		lineTwo: row.addressLineTwo,
+		city: row.city,
+		state: row.state,
+		zip: row.zip,
+		country: row.country,
+	},
+	settings: {
+		hideChecklist: row.hideChecklist,
+		allowSftpDeletion: row.allowSftpDeletion,
+		notificationsEnabled: {
+			sms: row.notificationPreferences.textPreference,
+			email: row.notificationPreferences.emailPreference,
+			inApp: row.notificationPreferences.inAppPreference,
+		},
+	},
+	status: prettifyAccountStatus(row.status),
+	type: prettifyAccountType(row.type),
+});
+
+export const getAccounts = async (
+	query: GetAccountsQuery,
+): Promise<GetAccountsResponse> => {
+	const filterByIds = query.accountIds !== undefined;
+	const accountIds = Array.isArray(query.accountIds)
+		? query.accountIds
+		: query.accountIds === undefined
+			? []
+			: [query.accountIds];
+	const accountEmails = Array.isArray(query.accountEmails)
+		? query.accountEmails.map((e) => e.toLowerCase())
+		: query.accountEmails === undefined
+			? []
+			: [query.accountEmails.toLowerCase()];
+
+	const result = await db
+		.sql<AccountRow & { totalPages: number }>("account.queries.get_accounts", {
+			filterByIds,
+			accountIds,
+			accountEmails,
+			cursor: query.cursor,
+			pageSize: query.pageSize,
+		})
+		.catch((err: unknown) => {
+			logger.error(err);
+			throw new createError.InternalServerError("Failed to retrieve accounts");
+		});
+
+	const accounts = result.rows.map(accountRowToAccount);
+	const nextCursor = accounts[accounts.length - 1]?.id;
+	return {
+		items: accounts,
+		pagination: {
+			nextCursor,
+			nextPage:
+				nextCursor === undefined
+					? undefined
+					: `https://${process.env["SITE_URL"] ?? ""}/api/v2/accounts?pageSize=${query.pageSize}&cursor=${nextCursor}`,
+			totalPages: result.rows[0] === undefined ? 0 : result.rows[0].totalPages,
+		},
+	};
+};
 
 const updateTags = async (requestBody: UpdateTagsRequest): Promise<void> => {
 	const tags = (requestBody.addTags ?? [])

--- a/packages/api/src/account/validators.ts
+++ b/packages/api/src/account/validators.ts
@@ -2,14 +2,17 @@ import Joi from "joi";
 import type {
 	CreateStorageAdjustmentRequest,
 	UpdateTagsRequest,
+	GetAccountsQuery,
 } from "./models";
 import {
 	fieldsFromUserAuthentication,
 	fieldsFromAdminAuthentication,
 	validateBodyFromAuthentication,
+	validateBodyFromAdminAuthentication,
 } from "../validators";
+import { paginationFields } from "../validators/shared";
 
-export { validateBodyFromAuthentication };
+export { validateBodyFromAuthentication, validateBodyFromAdminAuthentication };
 
 export const validateUpdateTagsRequest: (
 	data: unknown,
@@ -83,6 +86,28 @@ export const validateCreateStorageAdjustmentRequest: (
 			...fieldsFromAdminAuthentication,
 			storageAmount: Joi.number().integer().not(0).required(),
 		})
+		.validate(data);
+	if (validation.error !== undefined) {
+		throw validation.error;
+	}
+};
+
+export const validateGetAccountsQuery: (
+	data: unknown,
+) => asserts data is GetAccountsQuery = (
+	data: unknown,
+): asserts data is GetAccountsQuery => {
+	const validation = Joi.object()
+		.keys({
+			...paginationFields,
+			accountIds: Joi.alternatives()
+				.try(Joi.string(), Joi.array().items(Joi.string()))
+				.optional(),
+			accountEmails: Joi.alternatives()
+				.try(Joi.string().email(), Joi.array().items(Joi.string().email()))
+				.optional(),
+		})
+		.xor("accountIds", "accountEmails")
 		.validate(data);
 	if (validation.error !== undefined) {
 		throw validation.error;

--- a/packages/api/src/validators/shared.ts
+++ b/packages/api/src/validators/shared.ts
@@ -24,6 +24,11 @@ export const fieldsFromUserOrAdminAuthentication = Joi.object()
 	.nand("userEmailFromAuthToken", "adminSubjectFromAuthToken")
 	.nand("adminEmailFromAuthToken", "userSubjectFromAuthToken");
 
+export const paginationFields = {
+	cursor: Joi.string(),
+	pageSize: Joi.number().integer().min(MINIMUM_PAGE_SIZE).required(),
+};
+
 export const validateBodyFromAuthentication: (
 	data: unknown,
 ) => asserts data is {
@@ -101,12 +106,7 @@ export const validatePaginationParameters: (
 ) => asserts data is { cursor?: string; pageSize: number } = (
 	data: unknown,
 ): asserts data is { cursor?: string; pageSize: number } => {
-	const validation = Joi.object()
-		.keys({
-			cursor: Joi.string(),
-			pageSize: Joi.number().integer().min(MINIMUM_PAGE_SIZE).required(),
-		})
-		.validate(data);
+	const validation = Joi.object().keys(paginationFields).validate(data);
 
 	if (validation.error !== undefined) {
 		throw validation.error;


### PR DESCRIPTION
We're working on an admin tool that will allow administrators to add or remove storage from an account. That tool requires the ability to look up accounts by email. To enable that, this commit adds a GET /accounts endpoint. It is presently restricted to admins only.