### PR TITLE
Allow metadata files with a single MediaInfo track

### DIFF
--- a/packages/metadata_attacher/src/fixtures/video_mediainfo_single_track.xml
+++ b/packages/metadata_attacher/src/fixtures/video_mediainfo_single_track.xml
@@ -1,0 +1,77 @@
+<mets:mets xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:mets="http://www.loc.gov/METS/" xsi:schemaLocation="http://www.loc.gov/METS/ http://www.loc.gov/standards/mets/version1121/mets.xsd">
+<mets:metsHdr CREATEDATE="2025-10-28T19:07:44"/>
+<mets:dmdSec ID="dmdSec_1" CREATED="2025-10-28T19:07:44" STATUS="original">
+<mets:mdWrap MDTYPE="PREMIS:OBJECT">
+<mets:xmlData>
+<premis:object xmlns:premis="http://www.loc.gov/premis/v3" xsi:type="premis:intellectualEntity" xsi:schemaLocation="http://www.loc.gov/premis/v3 http://www.loc.gov/standards/premis/v3/premis.xsd" version="3.0">
+<premis:objectIdentifier>
+<premis:objectIdentifierType>UUID</premis:objectIdentifierType>
+<premis:objectIdentifierValue>4a64ba7c-ceac-4547-ac13-c487b2711d5a</premis:objectIdentifierValue>
+</premis:objectIdentifier>
+<premis:originalName>test_video_upload-4a64ba7c-ceac-4547-ac13-c487b2711d5a</premis:originalName>
+</premis:object>
+</mets:xmlData>
+</mets:mdWrap>
+</mets:dmdSec>
+<mets:amdSec ID="amdSec_1">
+<mets:techMD ID="techMD_1">
+<mets:mdWrap MDTYPE="PREMIS:OBJECT">
+<mets:xmlData>
+<premis:object xmlns:premis="http://www.loc.gov/premis/v3" xsi:type="premis:file" xsi:schemaLocation="http://www.loc.gov/premis/v3 http://www.loc.gov/standards/premis/v3/premis.xsd" version="3.0">
+<premis:objectIdentifier>
+<premis:objectIdentifierType>UUID</premis:objectIdentifierType>
+<premis:objectIdentifierValue>b3c97850-9697-451a-8ad5-9f085188e890</premis:objectIdentifierValue>
+</premis:objectIdentifier>
+<premis:objectCharacteristics>
+<premis:compositionLevel>0</premis:compositionLevel>
+<premis:fixity>
+<premis:messageDigestAlgorithm>sha256</premis:messageDigestAlgorithm>
+<premis:messageDigest>abc123def456789</premis:messageDigest>
+</premis:fixity>
+<premis:size>5242880</premis:size>
+<premis:format>
+<premis:formatDesignation>
+<premis:formatName>MPEG-4 Media File</premis:formatName>
+<premis:formatVersion>2</premis:formatVersion>
+</premis:formatDesignation>
+<premis:formatRegistry>
+<premis:formatRegistryName>PRONOM</premis:formatRegistryName>
+<premis:formatRegistryKey>fmt/199</premis:formatRegistryKey>
+</premis:formatRegistry>
+</premis:format>
+<premis:creatingApplication>
+<premis:dateCreatedByApplication>2024-05-20T08:45:00Z</premis:dateCreatedByApplication>
+</premis:creatingApplication>
+<premis:objectCharacteristicsExtension>
+<MediaInfo xmlns="https://mediaarea.net/mediainfo" xsi:schemaLocation="https://mediaarea.net/mediainfo https://mediaarea.net/mediainfo/mediainfo_2_0.xsd" version="2.0">
+<creatingLibrary version="25.09" url="https://mediaarea.net/MediaInfo">MediaInfoLib</creatingLibrary>
+<media ref="/var/archivematica/test_video.mp4">
+<track type="General">
+<Count>300</Count>
+<StreamCount>1</StreamCount>
+<StreamKind>General</StreamKind>
+<StreamKind_String>General</StreamKind_String>
+<StreamKindID>0</StreamKindID>
+<Format>MPEG-4</Format>
+<Format_String>MPEG-4</Format_String>
+<InternetMediaType>video/mp4</InternetMediaType>
+<FileSize>5242880</FileSize>
+<Duration>120.5</Duration>
+<File_Created_Date>2024-05-20 08:45:00 UTC</File_Created_Date>
+</track>
+</media>
+</MediaInfo>
+<rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+<rdf:Description xmlns:File="http://ns.exiftool.org/File/1.0/" rdf:about="/var/archivematica/test_video.mp4">
+<File:MIMEType>video/mp4</File:MIMEType>
+</rdf:Description>
+</rdf:RDF>
+</premis:objectCharacteristicsExtension>
+</premis:objectCharacteristics>
+<premis:originalName>%transferDirectory%objects/4a64ba7c-ceac-4547-ac13-c487b2711d5a</premis:originalName>
+</premis:object>
+</mets:xmlData>
+</mets:mdWrap>
+</mets:techMD>
+</mets:amdSec>
+</mets:mets>

--- a/packages/metadata_attacher/src/index.test.ts
+++ b/packages/metadata_attacher/src/index.test.ts
@@ -851,6 +851,68 @@ describe("handler", () => {
 		expect(recordMetadata?.altText).toEqual(null);
 	});
 
+	test("should extract timestamp from video with a single MediaInfo track object", async () => {
+		const metsContent = await loadMetsFile("video_mediainfo_single_track.xml");
+		mockS3Send.mockResolvedValue({
+			Body: {
+				transformToString: jest.fn().mockResolvedValue(metsContent),
+			},
+		});
+
+		const event = {
+			Records: [
+				{
+					messageId: "1",
+					receiptHandle: "1",
+					body: JSON.stringify({
+						Message: JSON.stringify({
+							Records: [
+								{
+									s3: {
+										bucket: {
+											name: "test-bucket",
+										},
+										object: {
+											key: "access_copies/53f9/8c3d/a29e/4fbf/8a4a/4fd9/991e/313d/1_upload-4a64ba7c-ceac-4547-ac13-c487b2711d5a/METS.4a64ba7c-ceac-4547-ac13-c487b2711d5a.xml",
+										},
+									},
+								},
+							],
+						}),
+					}),
+					attributes: {
+						ApproximateReceiveCount: "1",
+						SentTimestamp: "1",
+						SenderId: "1",
+						ApproximateFirstReceiveTimestamp: "1",
+					},
+					messageAttributes: {},
+					md5OfBody: "1",
+					eventSource: "1",
+					eventSourceARN: "1",
+					awsRegion: "1",
+				},
+			],
+		};
+
+		await handler(event, mock<Context>(), jest.fn());
+
+		expect(mockS3Send).toHaveBeenCalledTimes(1);
+
+		const recordMetadata = await getRecordMetadata("1");
+		expect(recordMetadata).toBeDefined();
+		expect(recordMetadata?.derivedTimestamp).toEqual(
+			new Date("2024-05-20T08:45:00.000Z"),
+		);
+		expect(recordMetadata?.originalFileCreationTime).toEqual(
+			"2024-05-20T08:45:00Z",
+		);
+		expect(recordMetadata?.displayName).toEqual("test_file.jpg");
+		expect(recordMetadata?.description).toEqual(null);
+		expect(recordMetadata?.tags.length).toEqual(0);
+		expect(recordMetadata?.altText).toEqual(null);
+	});
+
 	test("should handle video with no timestamp metadata", async () => {
 		const metsContent = await loadMetsFile("video_no_timestamp.xml");
 		mockS3Send.mockResolvedValue({

--- a/packages/metadata_attacher/src/index.ts
+++ b/packages/metadata_attacher/src/index.ts
@@ -157,10 +157,13 @@ const getVideoMetadataFromMediaInfo = (
 			creationTimeInEdtf: string | undefined;
 	  }
 	| undefined => {
-	const tracks = embeddedMetadata.MediaInfo?.media.track;
-	if (tracks === undefined) {
+	const tracksFromMediaInfo = embeddedMetadata.MediaInfo?.media.track;
+	if (tracksFromMediaInfo === undefined) {
 		return undefined;
 	}
+	const tracks = Array.isArray(tracksFromMediaInfo)
+		? tracksFromMediaInfo
+		: [tracksFromMediaInfo];
 
 	const generalTracks = tracks.filter(
 		(track: TrackMetadata) => track.StreamKind === "General",

--- a/packages/metadata_attacher/src/models.ts
+++ b/packages/metadata_attacher/src/models.ts
@@ -55,7 +55,7 @@ export interface EmbeddedMetadata {
 	MediaInfo:
 		| {
 				media: {
-					track: TrackMetadata[];
+					track: TrackMetadata[] | TrackMetadata;
 				};
 		  }
 		| undefined;

--- a/packages/metadata_attacher/src/validators.ts
+++ b/packages/metadata_attacher/src/validators.ts
@@ -35,7 +35,9 @@ const embeddedMetadataSchema = Joi.object({
 		.unknown(true),
 	MediaInfo: Joi.object({
 		media: Joi.object({
-			track: Joi.array().items(trackMetadataSchema).required(),
+			track: Joi.alternatives()
+				.try(Joi.array().items(trackMetadataSchema), trackMetadataSchema)
+				.required(),
 		})
 			.required()
 			.unknown(true),


### PR DESCRIPTION
Currently, our metadata attacher lambda expects a MediaInfo object in the metadata file to contain multiple tracks. This isn't always the case, so this commit updates the lambda to accept metadata files with only one track.