### PR TITLE
Add fields to folder objects

### DIFF
--- a/packages/api/docs/src/models/folder.yaml
+++ b/packages/api/docs/src/models/folder.yaml
@@ -24,14 +24,21 @@ folder:
   properties:
     id:
       type: string
+    archiveNumber:
+      nullable: true
+      type: string
     size:
       type: integer
     location:
       $ref: "../models/location.yaml#/location"
+    folderLinkId:
+      type: string
     parentFolder:
       type: object
       properties:
         id:
+          type: string
+        folderLinkId:
           type: string
     shares:
       type: array
@@ -87,6 +94,15 @@ folder:
           type: array
           items:
             type: string
+        folderLinkIds:
+          type: array
+          items:
+            type: string
+        archiveNumbers:
+          type: array
+          items:
+            type: string
+            nullable: true
     publicAt:
       type: string
       format: date-time

--- a/packages/api/src/folder/controller/get_folder.test.ts
+++ b/packages/api/src/folder/controller/get_folder.test.ts
@@ -197,6 +197,8 @@ describe("GET /folder", () => {
 		expect(folders[0]).toBeDefined();
 		if (folders[0] !== undefined) {
 			expect(folders[0].folderId).toEqual("2");
+			expect(folders[0].folderLinkId).toEqual("1");
+			expect(folders[0].archiveNumber).toEqual("0001-0002");
 			expect(folders[0].size).toEqual(0);
 			expect(folders[0].location).toBeDefined();
 			if (folders[0].location !== undefined) {
@@ -219,6 +221,7 @@ describe("GET /folder", () => {
 				expect(folders[0].location.displayName).toEqual("Jean Valjean's House");
 			}
 			expect(folders[0].parentFolder?.id).toEqual("10");
+			expect(folders[0].parentFolder?.folderLinkId).toEqual("10");
 			expect(folders[0].shares).toBeDefined();
 			if (folders[0].shares !== undefined) {
 				expect(folders[0].shares.length).toEqual(1);
@@ -277,6 +280,11 @@ describe("GET /folder", () => {
 			expect(folders[0].paths.names.length).toEqual(2);
 			expect(folders[0].paths.names[0]).toEqual("My Files");
 			expect(folders[0].paths.names[1]).toEqual("Private Folder");
+			expect(folders[0].paths.folderLinkIds[0]).toEqual("10");
+			expect(folders[0].paths.folderLinkIds[1]).toEqual("1");
+			expect(folders[0].paths.archiveNumbers[0]).toEqual("0001-0010");
+			expect(folders[0].paths.archiveNumbers[1]).toEqual("0001-0002");
+			expect(folders[0].paths.names[1]).toEqual("Private Folder");
 			expect(folders[0].publicAt).toBeNull();
 			expect(folders[0].sort).toEqual("alphabetical-ascending");
 			expect(folders[0].thumbnailUrls).toBeDefined();
@@ -301,6 +309,16 @@ describe("GET /folder", () => {
 			expect(folders[0].status).toEqual("ok");
 			expect(folders[0].view).toEqual("grid");
 		}
+	});
+
+	test("should not return parent object for a root level folder", async () => {
+		const response = await agent
+			.get("/api/v2/folders?folderIds[]=7")
+			.expect(200);
+		const {
+			body: { items: folders },
+		} = response as { body: { items: Folder[] } };
+		expect(folders[0]?.parentFolder).toBeNull();
 	});
 
 	test("should not return pendingShares for non-manager viewer", async () => {

--- a/packages/api/src/folder/fixtures/create_test_folder_links.sql
+++ b/packages/api/src/folder/fixtures/create_test_folder_links.sql
@@ -16,7 +16,7 @@ VALUES
   NULL,
   2,
   10,
-  3,
+  10,
   1,
   1,
   'access.role.owner',

--- a/packages/api/src/folder/fixtures/create_test_folders.sql
+++ b/packages/api/src/folder/fixtures/create_test_folders.sql
@@ -58,7 +58,7 @@ VALUES
   NULL,
   'Private Folder',
   'Private Folder',
-  NULL,
+  '0001-0002',
   'status.generic.ok',
   '2025-01-01',
   'type.folder.private',

--- a/packages/api/src/folder/fixtures/create_test_shareby_urls.sql
+++ b/packages/api/src/folder/fixtures/create_test_shareby_urls.sql
@@ -45,7 +45,7 @@ VALUES (
 ),
 (
   4,
-  3,
+  10,
   '56f7c246-e4ec-41f3-b117-6df4c9377075',
   'https://local.permanent.org/share/56f7c246-e4ec-41f3-b117-6df4c9377075',
   2,

--- a/packages/api/src/folder/models.ts
+++ b/packages/api/src/folder/models.ts
@@ -16,10 +16,12 @@ export interface GetFolderChildrenResponse {
 
 export interface FolderRow {
 	folderId: string;
+	archiveNumber: string | null;
 	size: string | null;
 	location?: Location;
 	parentFolder?: {
 		id: string;
+		folderLinkId: string;
 	};
 	shares?: Share[];
 	pendingShares: PendingShare[] | null;
@@ -39,6 +41,8 @@ export interface FolderRow {
 	imageRatio?: string;
 	paths: {
 		names: string[];
+		folderLinkIds: string[];
+		archiveNumbers: Array<string | null>;
 	};
 	publicAt?: string;
 	sort: FolderSortOrder;
@@ -65,10 +69,12 @@ export interface ThumbnailUrls {
 
 export interface Folder {
 	folderId: string;
+	archiveNumber: string | null;
 	size: number | null;
 	location?: Location;
 	parentFolder?: {
 		id: string;
+		folderLinkId: string;
 	};
 	shares?: Share[];
 	pendingShares: PendingShare[] | null;
@@ -88,6 +94,8 @@ export interface Folder {
 	imageRatio?: number;
 	paths: {
 		names: string[];
+		folderLinkIds: string[];
+		archiveNumbers: Array<string | null>;
 	};
 	publicAt?: string;
 	sort: PrettyFolderSortOrder;

--- a/packages/api/src/folder/queries/get_folders.sql
+++ b/packages/api/src/folder/queries/get_folders.sql
@@ -3,7 +3,9 @@ WITH RECURSIVE folder_path AS (
     folder.folderid AS original_folder_id,
     folder.folderid,
     folder_link.parentfolderid,
+    folder_link.folder_linkid::text,
     folder.displayname,
+    folder.archivenbr,
     1 AS height
   FROM folder
   INNER JOIN folder_link ON folder.folderid = folder_link.folderid
@@ -15,7 +17,9 @@ WITH RECURSIVE folder_path AS (
     folder_path.original_folder_id,
     folder.folderid,
     folder_link.parentfolderid,
+    folder_link.folder_linkid::text,
     folder.displayname,
+    folder.archivenbr,
     folder_path.height + 1 AS height
   FROM folder_path
   INNER JOIN folder_link ON folder_path.parentfolderid = folder_link.folderid
@@ -26,7 +30,9 @@ WITH RECURSIVE folder_path AS (
 aggregated_path AS (
   SELECT
     original_folder_id AS folderid,
-    ARRAY_AGG(displayname ORDER BY height DESC) AS name_path
+    ARRAY_AGG(displayname ORDER BY height DESC) AS name_path,
+    ARRAY_AGG(archivenbr ORDER BY height DESC) AS archive_number_path,
+    ARRAY_AGG(folder_linkid ORDER BY height DESC) AS folder_link_id_path
   FROM folder_path
   GROUP BY
     original_folder_id
@@ -207,6 +213,7 @@ account_by_share AS (
 
 SELECT
   folder.folderid AS "folderId",
+  folder.archivenbr AS "archiveNumber",
   folder_size.allfilesizedeep AS size,
   aggregated_shares.folder_shares AS shares,
   aggregated_tags.tags,
@@ -279,10 +286,16 @@ SELECT
     'displayName',
     locn.displayname
   ) AS location,
-  JSON_BUILD_OBJECT(
-    'id',
-    folder_link.parentfolderid::text
-  ) AS "parentFolder",
+  CASE
+    WHEN folder_link.parentfolderid IS NOT NULL
+      THEN
+        JSON_BUILD_OBJECT(
+          'id',
+          folder_link.parentfolderid::text,
+          'folderLinkId',
+          folder_link.parentfolder_linkid::text
+        )
+  END AS "parentFolder",
   JSON_BUILD_OBJECT(
     'id',
     folder.archiveid::text,
@@ -291,7 +304,11 @@ SELECT
   ) AS archive,
   JSONB_BUILD_OBJECT(
     'names',
-    aggregated_path.name_path
+    aggregated_path.name_path,
+    'folderLinkIds',
+    aggregated_path.folder_link_id_path,
+    'archiveNumbers',
+    aggregated_path.archive_number_path
   ) AS paths,
   JSON_BUILD_OBJECT(
     '200',


### PR DESCRIPTION
In order to replace the legacy /navigateLean endpoint with this repo's /folders/{id}/children, we need to add some fields to the folder object that aren't currently returned. This commit does that.

PER-10652