### PR TITLE
Add EDTF Level 2 support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
 		"": {
 			"name": "stela",
 			"version": "0.0.0",
+			"hasInstallScript": true,
 			"license": "AGPL-3.0",
 			"workspaces": [
 				"./packages/logger",
@@ -28,6 +29,9 @@
 				"./packages/metadata_attacher",
 				"./packages/file_copier"
 			],
+			"dependencies": {
+				"patch-package": "^8.0.1"
+			},
 			"devDependencies": {
 				"@redocly/cli": "^2.33.2",
 				"@tsconfig/node24": "^24.0.3",
@@ -113,8 +117,6 @@
 		},
 		"node_modules/@aws-crypto/crc32c": {
 			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/crc32c/-/crc32c-5.2.0.tgz",
-			"integrity": "sha512-+iWb8qaHLYKrNvGRbiYRHSdKRWhto5XlZUEBwDjYNf+ly5SVYG6zEoYIdxvf5R3zyeP16w4PLBn3rH1xc74Rag==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/util": "^5.2.0",
@@ -273,8 +275,6 @@
 		},
 		"node_modules/@aws-sdk/client-s3": {
 			"version": "3.1053.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-s3/-/client-s3-3.1053.0.tgz",
-			"integrity": "sha512-/oGxoB6p1Nqs935Blt+v1o+anSCEf2n3RjIrcLz84i4cn2Gr+Z7JpDdUkG5+74r5ctqEPG7k/phTGbJ9fNKnHg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha1-browser": "5.2.0",
@@ -302,8 +302,6 @@
 		},
 		"node_modules/@aws-sdk/client-sns": {
 			"version": "3.1053.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sns/-/client-sns-3.1053.0.tgz",
-			"integrity": "sha512-QcKGAt9ugnjm8dRdrY4AHg+dDNQRp8drC8YjYAs4RyylUV3NUlA1+PZIjrkvvEjh82JJXFGLqgWIKTDpdr8q3g==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
@@ -323,8 +321,6 @@
 		},
 		"node_modules/@aws-sdk/core": {
 			"version": "3.974.15",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/core/-/core-3.974.15.tgz",
-			"integrity": "sha512-UpA0rTGW/tHGITcCqHisbuuEPraYg9GG+mWmXjY5+RxZBMLGe6aL9oe0ix50LztwAcPIkGZLH0yWdMIkCM10hw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "^3.973.9",
@@ -342,8 +338,6 @@
 		},
 		"node_modules/@aws-sdk/crc64-nvme": {
 			"version": "3.972.9",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/crc64-nvme/-/crc64-nvme-3.972.9.tgz",
-			"integrity": "sha512-P+QGozmXn2mZZI7sDgk+aUm+RTI61MPSFB+Ir2vjEjEbEsE4e7hYtzrDvAUxZy9ko81h53e11+F/GYlvwDkaOQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.14.2",
@@ -355,8 +349,6 @@
 		},
 		"node_modules/@aws-sdk/credential-provider-env": {
 			"version": "3.972.41",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.972.41.tgz",
-			"integrity": "sha512-n1EbJ98yvPWWdHZZv8bRBMqqDQJrtgtxyJ4xLy2Uqrh25BCOZQ7nnS1CsFXvuH8r0b0KVHDZEGEH5FxmEMP8jg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.974.15",
@@ -371,8 +363,6 @@
 		},
 		"node_modules/@aws-sdk/credential-provider-http": {
 			"version": "3.972.43",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-http/-/credential-provider-http-3.972.43.tgz",
-			"integrity": "sha512-TT76RN1NkI9WoyZqCNxOw6/WBMF7pYOTJcXbMokNFU+euSG40Kaf/t/FhDACVZWP+43wEM6ZynIPIkzS1wR1iA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.974.15",
@@ -389,8 +379,6 @@
 		},
 		"node_modules/@aws-sdk/credential-provider-ini": {
 			"version": "3.972.46",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.972.46.tgz",
-			"integrity": "sha512-hvcgcwOiS0nb2XFb5Op1Pz/vYaWz5K8kKullziGpdNRuG0NwzRXseuPt2CoBqknHGaSPVesu1aOn2OcctEYdCA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.974.15",
@@ -413,8 +401,6 @@
 		},
 		"node_modules/@aws-sdk/credential-provider-login": {
 			"version": "3.972.45",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-login/-/credential-provider-login-3.972.45.tgz",
-			"integrity": "sha512-MZQv4SNjByk1iOKmrqmzcUF/uCB05wjvEHyXKxmGQTUANTIVayX6HPUF0bzkWLvtnkH7sAn9kUCfkXbSpj9sDA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.974.15",
@@ -430,8 +416,6 @@
 		},
 		"node_modules/@aws-sdk/credential-provider-node": {
 			"version": "3.972.47",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.972.47.tgz",
-			"integrity": "sha512-HrId+C0DWA5qDIyLG64/kjUB2RNtPypxmABnIctK+TA1P1kHlOYoE/Wf5T5tKOMKgb08P7k/zNyhvfJ3lh5Oag==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/credential-provider-env": "^3.972.41",
@@ -452,8 +436,6 @@
 		},
 		"node_modules/@aws-sdk/credential-provider-process": {
 			"version": "3.972.41",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.972.41.tgz",
-			"integrity": "sha512-7I/n1zkysouLOWvkEhjNEP4vMnD2v4kzzr3/3QBdrripEpn7ap1/I5DF3Hou1SUqkKWo1f3oPGMyFAA1FAMvsQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.974.15",
@@ -468,8 +450,6 @@
 		},
 		"node_modules/@aws-sdk/credential-provider-sso": {
 			"version": "3.972.45",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.972.45.tgz",
-			"integrity": "sha512-oHgbz/eFD8IKiksqDsz9ZMU4A59BpQq4QwJedBnGD80ZqYcHPPHZBwjBnxLVkB7iRVVHWpDclR8yWdD2PkQIUA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.974.15",
@@ -486,8 +466,6 @@
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity": {
 			"version": "3.972.45",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.972.45.tgz",
-			"integrity": "sha512-CDhzKdb2onv5bpnjn/acgdNmJOQthPDLsPizU7rZflsEcgMMp8Mlri+U5hdxf8ldvZJpvM3vLU6D56vfJm5AMQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.974.15",
@@ -503,8 +481,6 @@
 		},
 		"node_modules/@aws-sdk/middleware-bucket-endpoint": {
 			"version": "3.972.17",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-bucket-endpoint/-/middleware-bucket-endpoint-3.972.17.tgz",
-			"integrity": "sha512-lbDmWuHenc+kiwCNrxz4MyN6nkxCWyTXPIWuspJN0ibziu+8CXci7vI1bK9MAkwy8cwJOEXNu0gBM5S0uTGRIg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.974.15",
@@ -519,8 +495,6 @@
 		},
 		"node_modules/@aws-sdk/middleware-expect-continue": {
 			"version": "3.972.14",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-expect-continue/-/middleware-expect-continue-3.972.14.tgz",
-			"integrity": "sha512-3TNFEVGO4sWZj9TEXOCZLzGEctXHnaO4fk2EQ8KVaboTbwHmEPEQrm17Xb9koImUIXEw0sgi2xtHjg7LuTS3rA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "^3.973.9",
@@ -534,8 +508,6 @@
 		},
 		"node_modules/@aws-sdk/middleware-flexible-checksums": {
 			"version": "3.974.23",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-flexible-checksums/-/middleware-flexible-checksums-3.974.23.tgz",
-			"integrity": "sha512-4nPKARo2lfKvQGUt2fPA5NlS/mEohckdxpuC9ecbjVfj7B7NFFYHeTg+Bf5BEQwdn3yRfUIzFiEkPp8Yuaw3wA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/crc32": "5.2.0",
@@ -554,8 +526,6 @@
 		},
 		"node_modules/@aws-sdk/middleware-location-constraint": {
 			"version": "3.972.11",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-location-constraint/-/middleware-location-constraint-3.972.11.tgz",
-			"integrity": "sha512-hkfspNUP4criAH6ton6BGKgnm5dZx+7bUOy1YqlTfejDeUPAM23D81q/IX+hdlS3KUsfwGz5ADTqZWKBEUpf4A==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "^3.973.9",
@@ -568,8 +538,6 @@
 		},
 		"node_modules/@aws-sdk/middleware-sdk-s3": {
 			"version": "3.972.44",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-s3/-/middleware-sdk-s3-3.972.44.tgz",
-			"integrity": "sha512-8HQsRg1NpX8vR4vNl1E8pyLnqZroq9VSL2vZQVSgBqp6wv6365LzYD08/c9FFh/9FTg7YRc7aTtEmXF0ir/pqg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.974.15",
@@ -585,8 +553,6 @@
 		},
 		"node_modules/@aws-sdk/middleware-ssec": {
 			"version": "3.972.11",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-ssec/-/middleware-ssec-3.972.11.tgz",
-			"integrity": "sha512-7PQvGNhtveKlvVqNahqWx5yrwxP7ecwAoB1dYBf8eKwfo2tzzCbNnW+q2nO3N066ktQaB4iBQbDRWtizm+amoQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "^3.973.9",
@@ -599,8 +565,6 @@
 		},
 		"node_modules/@aws-sdk/nested-clients": {
 			"version": "3.997.13",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/nested-clients/-/nested-clients-3.997.13.tgz",
-			"integrity": "sha512-2pA6eyb5nSo/ZD2cayhOTEMoGQYgspq0RI05GDLkzQ3ajZ6isS6waV6E92Am/hz4LIlLUTrbwPLurJ/fuiHvkg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/sha256-browser": "5.2.0",
@@ -620,8 +584,6 @@
 		},
 		"node_modules/@aws-sdk/signature-v4-multi-region": {
 			"version": "3.996.30",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4-multi-region/-/signature-v4-multi-region-3.996.30.tgz",
-			"integrity": "sha512-HULDLMVzkmTSEv6//7kx2kRevp/VYUpm8hJNNFbmhxDn0fUiGTxVcM9yg31TukvTq8nyOBDUN2gH0o5IRbKjdw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/types": "^3.973.9",
@@ -635,8 +597,6 @@
 		},
 		"node_modules/@aws-sdk/token-providers": {
 			"version": "3.1056.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.1056.0.tgz",
-			"integrity": "sha512-81duvlltQlsfn5K+o8zILcystBRdbT1G2JJYVCML5NZHBz4CL/zf+sAemCtBh/uh6RQUMyInGeZLQ7/8igZhbA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-sdk/core": "^3.974.15",
@@ -652,8 +612,6 @@
 		},
 		"node_modules/@aws-sdk/types": {
 			"version": "3.973.9",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.973.9.tgz",
-			"integrity": "sha512-kuBfgQVdcz5Bmapc4A13YbpVw/pXkesfhetcFYwbntqas8sF41OHyd4o28+/TG2ZQdHBsv90Lsu5y6oitvYCdg==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.14.2",
@@ -675,8 +633,6 @@
 		},
 		"node_modules/@aws-sdk/xml-builder": {
 			"version": "3.972.26",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/xml-builder/-/xml-builder-3.972.26.tgz",
-			"integrity": "sha512-cDbrqvDS73whl6YAPSPq0U6whzG6UWI9PuWh0wrUuGoZexhWEqhdunbukV7iBoaWnFV1AODutM5hOD6rtn439g==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/types": "^4.14.2",
@@ -1197,25 +1153,25 @@
 			}
 		},
 		"node_modules/@edtf-ts/core": {
-			"version": "0.4.2",
+			"version": "0.5.0",
 			"license": "MIT"
 		},
 		"node_modules/@emnapi/core": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
-			"integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+			"integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
 			"dependencies": {
-				"@emnapi/wasi-threads": "1.2.1",
+				"@emnapi/wasi-threads": "1.2.2",
 				"tslib": "^2.4.0"
 			}
 		},
 		"node_modules/@emnapi/runtime": {
-			"version": "1.10.0",
-			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
-			"integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
+			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+			"integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -1224,9 +1180,9 @@
 			}
 		},
 		"node_modules/@emnapi/wasi-threads": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
-			"integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+			"integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
 			"dev": true,
 			"license": "MIT",
 			"optional": true,
@@ -1487,12 +1443,10 @@
 			}
 		},
 		"node_modules/@grpc/grpc-js": {
-			"version": "1.14.4",
-			"resolved": "https://registry.npmjs.org/@grpc/grpc-js/-/grpc-js-1.14.4.tgz",
-			"integrity": "sha512-k9Dj3DV/itK9D06Y8f190Qgop7/Ui+D0njFV3LHMPwPT75DpXLQohE9Wmz0QElrJnzsjB7KPWiKJbOl7IPDArQ==",
+			"version": "1.13.4",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@grpc/proto-loader": "^0.8.0",
+				"@grpc/proto-loader": "^0.7.13",
 				"@js-sdsl/ordered-map": "^4.4.2"
 			},
 			"engines": {
@@ -1500,14 +1454,12 @@
 			}
 		},
 		"node_modules/@grpc/proto-loader": {
-			"version": "0.8.1",
-			"resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
-			"integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+			"version": "0.7.15",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"lodash.camelcase": "^4.3.0",
 				"long": "^5.0.0",
-				"protobufjs": "^7.5.5",
+				"protobufjs": "^7.2.5",
 				"yargs": "^17.7.2"
 			},
 			"bin": {
@@ -1519,8 +1471,6 @@
 		},
 		"node_modules/@grpc/proto-loader/node_modules/cliui": {
 			"version": "8.0.1",
-			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
 			"license": "ISC",
 			"dependencies": {
 				"string-width": "^4.2.0",
@@ -1533,8 +1483,6 @@
 		},
 		"node_modules/@grpc/proto-loader/node_modules/yargs": {
 			"version": "17.7.2",
-			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
 			"license": "MIT",
 			"dependencies": {
 				"cliui": "^8.0.1",
@@ -2464,8 +2412,6 @@
 		},
 		"node_modules/@opentelemetry/api-logs": {
 			"version": "0.214.0",
-			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.214.0.tgz",
-			"integrity": "sha512-40lSJeqYO8Uz2Yj7u94/SJWE/wONa7rmMKjI1ZcIjgf3MHNHv1OZUCrCETGuaRF62d5pQD1wKIW+L4lmSMTzZA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@opentelemetry/api": "^1.3.0"
@@ -2896,8 +2842,6 @@
 		},
 		"node_modules/@protobufjs/codegen": {
 			"version": "2.0.5",
-			"resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
-			"integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/eventemitter": {
@@ -2918,8 +2862,6 @@
 		},
 		"node_modules/@protobufjs/inquire": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@protobufjs/inquire/-/inquire-1.1.1.tgz",
-			"integrity": "sha512-mnzgDV26ueAvk7rsbt9L7bE0SuAoqyuys/sMMrmVcN5x9VsxpcG3rqAUSgDyLp0UZlmNfIbQ4fHfCtreVBk8Ew==",
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@protobufjs/path": {
@@ -2932,8 +2874,6 @@
 		},
 		"node_modules/@protobufjs/utf8": {
 			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
-			"integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
 			"license": "BSD-3-Clause"
 		},
 		"node_modules/@redocly/ajv": {
@@ -3000,8 +2940,6 @@
 		},
 		"node_modules/@redocly/cli-otel": {
 			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/@redocly/cli-otel/-/cli-otel-0.3.1.tgz",
-			"integrity": "sha512-TbC4bK2zLtU/O9I2pszHPP0rtJOvFhQmEwQ/FHxERPu71fgKG8POUDP2jSiGmsXE7NdGSHBKqnf+y9Acn2jq5g==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3010,8 +2948,6 @@
 		},
 		"node_modules/@redocly/cli-otel/node_modules/ulid": {
 			"version": "2.4.0",
-			"resolved": "https://registry.npmjs.org/ulid/-/ulid-2.4.0.tgz",
-			"integrity": "sha512-fIRiVTJNcSRmXKPZtGzFQv9WRrZ3M9eoptl/teFJvjOzmpU+/K/JH6HZ8deBfb5vMEpicJcLn7JmvdknlMq7Zg==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -3021,8 +2957,6 @@
 		"node_modules/@redocly/cli/node_modules/ajv": {
 			"name": "@redocly/ajv",
 			"version": "8.18.1",
-			"resolved": "https://registry.npmjs.org/@redocly/ajv/-/ajv-8.18.1.tgz",
-			"integrity": "sha512-Ifm/pP/tul1qmAecpbVxCBluVE32rKfjf8gYXH4xI2gCv9mRWFhJMHzkPDM4TXlxwPQYIFegymlsy8lXz7optA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3049,8 +2983,6 @@
 		},
 		"node_modules/@redocly/cli/node_modules/glob": {
 			"version": "13.0.6",
-			"resolved": "https://registry.npmjs.org/glob/-/glob-13.0.6.tgz",
-			"integrity": "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
@@ -3067,8 +2999,6 @@
 		},
 		"node_modules/@redocly/cli/node_modules/lru-cache": {
 			"version": "11.5.1",
-			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.5.1.tgz",
-			"integrity": "sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"engines": {
@@ -3077,8 +3007,6 @@
 		},
 		"node_modules/@redocly/cli/node_modules/minipass": {
 			"version": "7.1.3",
-			"resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
-			"integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"engines": {
@@ -3087,8 +3015,6 @@
 		},
 		"node_modules/@redocly/cli/node_modules/path-scurry": {
 			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-2.0.2.tgz",
-			"integrity": "sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==",
 			"dev": true,
 			"license": "BlueOak-1.0.0",
 			"dependencies": {
@@ -3104,8 +3030,6 @@
 		},
 		"node_modules/@redocly/cli/node_modules/picomatch": {
 			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-			"integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -3426,8 +3350,6 @@
 		},
 		"node_modules/@smithy/core": {
 			"version": "3.24.5",
-			"resolved": "https://registry.npmjs.org/@smithy/core/-/core-3.24.5.tgz",
-			"integrity": "sha512-Kt8phUg45M15EjhYAbZ+fFikYneijLu9Liugz8ZsYz2i8j0hzGv27LWKpEHYRfvj+LyCOSijpcR/2i8RouV+cA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@aws-crypto/crc32": "5.2.0",
@@ -3440,8 +3362,6 @@
 		},
 		"node_modules/@smithy/credential-provider-imds": {
 			"version": "4.3.6",
-			"resolved": "https://registry.npmjs.org/@smithy/credential-provider-imds/-/credential-provider-imds-4.3.6.tgz",
-			"integrity": "sha512-tHhdiWZfG1ZIh2YcRfPJmY2gHcBmqbAzqm3ER4TIDFYsSEqTD5tICT7cgQ/kI8LRakxp12myOYyK68XPn7MnHw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/core": "^3.24.5",
@@ -3454,8 +3374,6 @@
 		},
 		"node_modules/@smithy/fetch-http-handler": {
 			"version": "5.4.5",
-			"resolved": "https://registry.npmjs.org/@smithy/fetch-http-handler/-/fetch-http-handler-5.4.5.tgz",
-			"integrity": "sha512-SK3VMeH0fibgdTg2QeB+O4p7Yy/2E5HBOHJeC58FshkDdeuX8lOgO7PfjYfLyPLP1ch55j91cQqKBzDS0mRjSQ==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/core": "^3.24.5",
@@ -3468,8 +3386,6 @@
 		},
 		"node_modules/@smithy/node-http-handler": {
 			"version": "4.7.5",
-			"resolved": "https://registry.npmjs.org/@smithy/node-http-handler/-/node-http-handler-4.7.5.tgz",
-			"integrity": "sha512-3dA9TQ+ybRSZ/m0wnbZhiBy4Dezjgq1Ib/ZZrYTpJDBgpoLLU/SDzZc/g0x0MNAdOJe1wPcM+x2PBRmoOur+Sw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/core": "^3.24.5",
@@ -3482,8 +3398,6 @@
 		},
 		"node_modules/@smithy/signature-v4": {
 			"version": "5.4.5",
-			"resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-5.4.5.tgz",
-			"integrity": "sha512-QBJKWGqIknH0dc9LWpfH1mkdokAx6iXYN3UcQ3eY6uIEyScuoQAhfl94ge7ozUy9WgFUdE8xsvwBjaYBbWmPNA==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"@smithy/core": "^3.24.5",
@@ -3496,8 +3410,6 @@
 		},
 		"node_modules/@smithy/types": {
 			"version": "4.14.2",
-			"resolved": "https://registry.npmjs.org/@smithy/types/-/types-4.14.2.tgz",
-			"integrity": "sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==",
 			"license": "Apache-2.0",
 			"dependencies": {
 				"tslib": "^2.6.2"
@@ -3516,8 +3428,6 @@
 		},
 		"node_modules/@standard-schema/spec": {
 			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
-			"integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
 			"license": "MIT"
 		},
 		"node_modules/@stela/access_copy_attacher": {
@@ -3839,8 +3749,6 @@
 		},
 		"node_modules/@types/pg": {
 			"version": "8.20.0",
-			"resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.20.0.tgz",
-			"integrity": "sha512-bEPFOaMAHTEP1EzpvHTbmwR8UsFyHSKsRisLIHVMXnpNefSbGA1bD6CVy+qKjGSqmZqNqBDV2azOBo8TgkcVow==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3935,8 +3843,6 @@
 		},
 		"node_modules/@typescript-eslint/eslint-plugin": {
 			"version": "8.59.4",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.59.4.tgz",
-			"integrity": "sha512-PegsU+XfyJJNjd4+u/k6f9yTyp0lEXXiPopUNobZcIAUJFGICFLN+sP0Rb3JehVmiij1Ph0dFGYqODoRo/2+6A==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3972,8 +3878,6 @@
 		},
 		"node_modules/@typescript-eslint/parser": {
 			"version": "8.59.4",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.59.4.tgz",
-			"integrity": "sha512-zORHqO/tuhxY1zWuTvMUqddRxpiFJ72xVfcNoWpqdLjs6lfPbuQBJuW4pk+49/uBMy7Ssr4bzgjiKmmDB1UbZQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -3997,8 +3901,6 @@
 		},
 		"node_modules/@typescript-eslint/project-service": {
 			"version": "8.59.4",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.59.4.tgz",
-			"integrity": "sha512-Ly00Vu4oAacfDeHp2Zg85ioNG6l8HG+tN1D7J+xTHSxu9y0awYKJ2zH1rFBn8ZSfuGK+7FxK3Cgl3uAz0aZZLg==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4019,8 +3921,6 @@
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
 			"version": "8.59.4",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.59.4.tgz",
-			"integrity": "sha512-mUeR/3H1WrTAddJrwut8OoPjfauaztMQmRwV5fQTUyNVJCLiUXXe4lGEyYIL2oFDpP7UtgbGJXCt72wT0z2S3Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4037,8 +3937,6 @@
 		},
 		"node_modules/@typescript-eslint/tsconfig-utils": {
 			"version": "8.59.4",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.59.4.tgz",
-			"integrity": "sha512-DLCpnKgD4alVxTBSKulK+gU1KCqOgUXfDRDXh2mZgzokQKa/70ax93I2uVO3m/LLvIAtWZIFoiifudmIqAxpMA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4054,8 +3952,6 @@
 		},
 		"node_modules/@typescript-eslint/type-utils": {
 			"version": "8.59.4",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.59.4.tgz",
-			"integrity": "sha512-uonTuPAAKr9XaBGqJ3LjYTh72zy5DyGesljO9gtmk/eFW0W1fRHjnwVYKB35Lm8d5Q5CluEW3gPHjTvZTmgrfA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4079,8 +3975,6 @@
 		},
 		"node_modules/@typescript-eslint/types": {
 			"version": "8.59.4",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.59.4.tgz",
-			"integrity": "sha512-F1o7WJcCq+bc8dwcO/YsSEOudAH8RDtaOhM6wcAQhcUsFhnWQl81JKy48q1hoxAU0qrzM89+31GYh1515Zde3Q==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -4093,8 +3987,6 @@
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
 			"version": "8.59.4",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.59.4.tgz",
-			"integrity": "sha512-F+RuOmcDXo4+TPdfd/TCLS3m2nw8gE9XXyZLrA3JBfaA5tz9TtdkyD3YJFmPxulyc2cKbEok/CvFE3MgSLWnag==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4121,8 +4013,6 @@
 		},
 		"node_modules/@typescript-eslint/utils": {
 			"version": "8.59.4",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.59.4.tgz",
-			"integrity": "sha512-cYXeNAUsG4lJo5dbc1FcKm+JwIWrj1/UpTORsC6tGMjEZ81DYcvIr9/ueikhMa/Y/gDQYGp+YX9/xQrXje5BJw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4145,8 +4035,6 @@
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
 			"version": "8.59.4",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.59.4.tgz",
-			"integrity": "sha512-U3gxVaDVnuZKhSspW/MzMxE1kq7zOdc072FcSNoqA1I9p8HyKbBFfEHoWckBAMgNMph4MamwS5iTVzFmrnt8TQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -4163,8 +4051,6 @@
 		},
 		"node_modules/@typescript-eslint/visitor-keys/node_modules/eslint-visitor-keys": {
 			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-5.0.1.tgz",
-			"integrity": "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA==",
 			"dev": true,
 			"license": "Apache-2.0",
 			"engines": {
@@ -4289,6 +4175,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4303,6 +4192,9 @@
 				"arm64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4317,6 +4209,9 @@
 				"ppc64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4331,6 +4226,9 @@
 				"riscv64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4345,6 +4243,9 @@
 				"riscv64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4359,6 +4260,9 @@
 				"s390x"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4371,6 +4275,9 @@
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"glibc"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4379,10 +4286,15 @@
 		},
 		"node_modules/@unrs/resolver-binding-linux-x64-musl": {
 			"version": "1.11.1",
+			"resolved": "https://registry.npmjs.org/@unrs/resolver-binding-linux-x64-musl/-/resolver-binding-linux-x64-musl-1.11.1.tgz",
+			"integrity": "sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==",
 			"cpu": [
 				"x64"
 			],
 			"dev": true,
+			"libc": [
+				"musl"
+			],
 			"license": "MIT",
 			"optional": true,
 			"os": [
@@ -4447,6 +4359,10 @@
 			"os": [
 				"win32"
 			]
+		},
+		"node_modules/@yarnpkg/lockfile": {
+			"version": "1.1.0",
+			"license": "BSD-2-Clause"
 		},
 		"node_modules/accepts": {
 			"version": "1.3.8",
@@ -4830,8 +4746,6 @@
 		},
 		"node_modules/axios": {
 			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
-			"integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
 			"license": "MIT",
 			"dependencies": {
 				"follow-redirects": "^1.16.0",
@@ -4842,8 +4756,6 @@
 		},
 		"node_modules/axios/node_modules/agent-base": {
 			"version": "6.0.2",
-			"resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
-			"integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
 			"license": "MIT",
 			"dependencies": {
 				"debug": "4"
@@ -4854,8 +4766,6 @@
 		},
 		"node_modules/axios/node_modules/https-proxy-agent": {
 			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
-			"integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
 			"license": "MIT",
 			"dependencies": {
 				"agent-base": "6",
@@ -5112,7 +5022,6 @@
 		},
 		"node_modules/braces": {
 			"version": "3.0.3",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"fill-range": "^7.1.1"
@@ -5228,7 +5137,6 @@
 		},
 		"node_modules/call-bind": {
 			"version": "1.0.8",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"call-bind-apply-helpers": "^1.0.0",
@@ -5320,7 +5228,6 @@
 		},
 		"node_modules/chalk": {
 			"version": "4.1.2",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"ansi-styles": "^4.1.0",
@@ -5713,7 +5620,6 @@
 		},
 		"node_modules/cross-spawn": {
 			"version": "7.0.6",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"path-key": "^3.1.0",
@@ -5878,7 +5784,6 @@
 		},
 		"node_modules/define-data-property": {
 			"version": "1.1.4",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-define-property": "^1.0.0",
@@ -6013,8 +5918,6 @@
 		},
 		"node_modules/dotenv": {
 			"version": "17.4.2",
-			"resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.4.2.tgz",
-			"integrity": "sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==",
 			"license": "BSD-2-Clause",
 			"engines": {
 				"node": ">=12"
@@ -6092,8 +5995,6 @@
 		},
 		"node_modules/enhanced-resolve": {
 			"version": "5.22.1",
-			"resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.22.1.tgz",
-			"integrity": "sha512-6QEuw3zoX1SJQc7b87aBXke/no+mG2bTBgw29gWMQonLmpEkWoCAVkl+M49e48AZlWzxiDzDZzYdp6kobcyLww==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6376,8 +6277,6 @@
 		},
 		"node_modules/eslint-compat-utils": {
 			"version": "0.5.1",
-			"resolved": "https://registry.npmjs.org/eslint-compat-utils/-/eslint-compat-utils-0.5.1.tgz",
-			"integrity": "sha512-3z3vFexKIEnjHE3zCMRo6fn/e44U7T1khUjg+Hp0ZQMCigh28rALD0nPFBcGZuiLC5rLZa2ubQHDRln09JfU2Q==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6392,8 +6291,6 @@
 		},
 		"node_modules/eslint-config-love": {
 			"version": "154.0.0",
-			"resolved": "https://registry.npmjs.org/eslint-config-love/-/eslint-config-love-154.0.0.tgz",
-			"integrity": "sha512-vPWss66epd/UTPWC3ItR0VMY1Hkd3JWuOlVxWp40wq9Fpki0w07DsvdT33tgA2LUatV6XhxObpNmfIQkZ+rT1A==",
 			"dev": true,
 			"funding": [
 				{
@@ -6477,8 +6374,6 @@
 		},
 		"node_modules/eslint-plugin-es-x": {
 			"version": "7.8.0",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-es-x/-/eslint-plugin-es-x-7.8.0.tgz",
-			"integrity": "sha512-7Ds8+wAAoV3T+LAKeu39Y5BzXCrGKrcISfgKEqTS4BDN8SFEDQd0S43jiQ8vIa3wUKD07qitZdfzlenSi8/0qQ==",
 			"dev": true,
 			"funding": [
 				"https://github.com/sponsors/ota-meshi",
@@ -6567,8 +6462,6 @@
 		},
 		"node_modules/eslint-plugin-jest": {
 			"version": "29.15.2",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-29.15.2.tgz",
-			"integrity": "sha512-kEN4r9RZl1xcsb4arGq89LrcVdOUFII/JSCwtTPJyv16mDwmPrcuEQwpxqZHeINvcsd7oK5O/rhdGlxFRaZwvQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6597,8 +6490,6 @@
 		},
 		"node_modules/eslint-plugin-n": {
 			"version": "18.0.1",
-			"resolved": "https://registry.npmjs.org/eslint-plugin-n/-/eslint-plugin-n-18.0.1.tgz",
-			"integrity": "sha512-q3ARhk+eZRc7myR0KHx+R3/GJeOHF+Ir6PK95Pu2tEX8Sl/4BIpmmVLva2kPrjC2gCmn6WHlHm+3yeo6Rxhycw==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -6633,8 +6524,6 @@
 		},
 		"node_modules/eslint-plugin-n/node_modules/globals": {
 			"version": "15.15.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-15.15.0.tgz",
-			"integrity": "sha512-7ACyT3wmyp3I61S4fG682L0VA2RGD9otkqGJIwNUMF1SWUombIIk+af1unuDYgMm082aHYwD+mzJvv9Iu8dsgg==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -7260,8 +7149,6 @@
 		},
 		"node_modules/fast-uri": {
 			"version": "3.1.2",
-			"resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-			"integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
 			"funding": [
 				{
 					"type": "github",
@@ -7276,8 +7163,6 @@
 		},
 		"node_modules/fast-xml-builder": {
 			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/fast-xml-builder/-/fast-xml-builder-1.2.0.tgz",
-			"integrity": "sha512-00aAWieqff+ZJhsXA4g1g7M8k+7AYoMUUHF+/zFb5U6Uv/P0Vl4QZo84/IcufzYalLuEj9928bXN9PbbFzMF0Q==",
 			"funding": [
 				{
 					"type": "github",
@@ -7292,8 +7177,6 @@
 		},
 		"node_modules/fast-xml-parser": {
 			"version": "5.7.3",
-			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-5.7.3.tgz",
-			"integrity": "sha512-C0AaNuC+mscy6vrAQKAc/rMq+zAPHodfHGZu4sGVehvAQt/JLG1O5zEcYcXSY5zSqr4YVgxsB+pHXTq0i7eDlg==",
 			"funding": [
 				{
 					"type": "github",
@@ -7360,7 +7243,6 @@
 		},
 		"node_modules/fill-range": {
 			"version": "7.1.1",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"to-regex-range": "^5.0.1"
@@ -7403,6 +7285,13 @@
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/find-yarn-workspace-root": {
+			"version": "2.0.0",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"micromatch": "^4.0.2"
 			}
 		},
 		"node_modules/flat-cache": {
@@ -7499,16 +7388,14 @@
 			}
 		},
 		"node_modules/form-data": {
-			"version": "4.0.6",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
-			"integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+			"version": "4.0.5",
 			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
 				"es-set-tostringtag": "^2.1.0",
-				"hasown": "^2.0.4",
-				"mime-types": "^2.1.35"
+				"hasown": "^2.0.2",
+				"mime-types": "^2.1.12"
 			},
 			"engines": {
 				"node": ">= 6"
@@ -7754,8 +7641,6 @@
 		},
 		"node_modules/get-tsconfig": {
 			"version": "4.14.0",
-			"resolved": "https://registry.npmjs.org/get-tsconfig/-/get-tsconfig-4.14.0.tgz",
-			"integrity": "sha512-yTb+8DXzDREzgvYmh6s9vHsSVCHeC0G3PI5bEXNBHtmshPnO+S5O7qgLEOn0I5QvMy6kpZN8K1NKGyilLb93wA==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -8052,8 +7937,6 @@
 		},
 		"node_modules/globrex": {
 			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
-			"integrity": "sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==",
 			"dev": true,
 			"license": "MIT"
 		},
@@ -8104,7 +7987,6 @@
 		},
 		"node_modules/has-flag": {
 			"version": "4.0.0",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -8112,7 +7994,6 @@
 		},
 		"node_modules/has-property-descriptors": {
 			"version": "1.0.2",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"es-define-property": "^1.0.0"
@@ -8227,9 +8108,7 @@
 			}
 		},
 		"node_modules/hasown": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
-			"integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+			"version": "2.0.2",
 			"license": "MIT",
 			"dependencies": {
 				"function-bind": "^1.1.2"
@@ -8612,6 +8491,19 @@
 				"node": ">= 0.4"
 			}
 		},
+		"node_modules/is-docker": {
+			"version": "2.2.1",
+			"license": "MIT",
+			"bin": {
+				"is-docker": "cli.js"
+			},
+			"engines": {
+				"node": ">=8"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
 		"node_modules/is-extendable": {
 			"version": "1.0.1",
 			"dev": true,
@@ -8726,7 +8618,6 @@
 		},
 		"node_modules/is-number": {
 			"version": "7.0.0",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.12.0"
@@ -8925,14 +8816,22 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/is-wsl": {
+			"version": "2.2.0",
+			"license": "MIT",
+			"dependencies": {
+				"is-docker": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=8"
+			}
+		},
 		"node_modules/isarray": {
 			"version": "2.0.5",
-			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/isexe": {
 			"version": "2.0.0",
-			"dev": true,
 			"license": "ISC"
 		},
 		"node_modules/isobject": {
@@ -9711,8 +9610,6 @@
 		},
 		"node_modules/joi": {
 			"version": "18.2.1",
-			"resolved": "https://registry.npmjs.org/joi/-/joi-18.2.1.tgz",
-			"integrity": "sha512-2/OKlogiESf2Nh3TFCrRjrr9z1DRHeW0I+KReF67+4J0Ns+8hBtHRmoWAZ2OFU6I5+TWLEe6sVlSdXPjHm5UbQ==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"@hapi/address": "^5.1.1",
@@ -9826,6 +9723,23 @@
 			"version": "1.0.0",
 			"license": "MIT"
 		},
+		"node_modules/json-stable-stringify": {
+			"version": "1.3.0",
+			"license": "MIT",
+			"dependencies": {
+				"call-bind": "^1.0.8",
+				"call-bound": "^1.0.4",
+				"isarray": "^2.0.5",
+				"jsonify": "^0.0.1",
+				"object-keys": "^1.1.1"
+			},
+			"engines": {
+				"node": ">= 0.4"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
+			}
+		},
 		"node_modules/json-stable-stringify-without-jsonify": {
 			"version": "1.0.1",
 			"dev": true,
@@ -9848,13 +9762,19 @@
 		},
 		"node_modules/jsonfile": {
 			"version": "6.1.0",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"universalify": "^2.0.0"
 			},
 			"optionalDependencies": {
 				"graceful-fs": "^4.1.6"
+			}
+		},
+		"node_modules/jsonify": {
+			"version": "0.0.1",
+			"license": "Public Domain",
+			"funding": {
+				"url": "https://github.com/sponsors/ljharb"
 			}
 		},
 		"node_modules/jsonpath-rfc9535": {
@@ -9891,6 +9811,13 @@
 			"license": "MIT",
 			"engines": {
 				"node": ">=0.10.0"
+			}
+		},
+		"node_modules/klaw-sync": {
+			"version": "6.0.0",
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.1.11"
 			}
 		},
 		"node_modules/kuler": {
@@ -9938,8 +9865,6 @@
 		},
 		"node_modules/lodash": {
 			"version": "4.18.1",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.18.1.tgz",
-			"integrity": "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==",
 			"license": "MIT"
 		},
 		"node_modules/lodash.camelcase": {
@@ -10167,7 +10092,6 @@
 		},
 		"node_modules/micromatch": {
 			"version": "4.0.8",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"braces": "^3.0.3",
@@ -10257,7 +10181,6 @@
 		},
 		"node_modules/minimist": {
 			"version": "1.2.8",
-			"devOptional": true,
 			"license": "MIT",
 			"funding": {
 				"url": "https://github.com/sponsors/ljharb"
@@ -10516,6 +10439,24 @@
 				"@prisma/prisma-fmt-wasm": "^4.17.0-16.27eb2449f178cd9fe1a4b892d732cc4795f75085"
 			}
 		},
+		"node_modules/newrelic/node_modules/@grpc/proto-loader": {
+			"version": "0.8.1",
+			"resolved": "https://registry.npmjs.org/@grpc/proto-loader/-/proto-loader-0.8.1.tgz",
+			"integrity": "sha512-wtF6h+DY6M3YaDBPAmvuuA6jV8Sif9MjtOI5euKFWRgCDl5PeDpPsHR9u2l6St5ceY8AZgoNDww5+HvEsXFsGg==",
+			"license": "Apache-2.0",
+			"dependencies": {
+				"lodash.camelcase": "^4.3.0",
+				"long": "^5.0.0",
+				"protobufjs": "^7.5.5",
+				"yargs": "^17.7.2"
+			},
+			"bin": {
+				"proto-loader-gen-types": "build/bin/proto-loader-gen-types.js"
+			},
+			"engines": {
+				"node": ">=6"
+			}
+		},
 		"node_modules/newrelic/node_modules/@opentelemetry/api-logs": {
 			"version": "0.217.0",
 			"resolved": "https://registry.npmjs.org/@opentelemetry/api-logs/-/api-logs-0.217.0.tgz",
@@ -10685,6 +10626,20 @@
 				"node": ">= 20"
 			}
 		},
+		"node_modules/newrelic/node_modules/cliui": {
+			"version": "8.0.1",
+			"resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+			"integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+			"license": "ISC",
+			"dependencies": {
+				"string-width": "^4.2.0",
+				"strip-ansi": "^6.0.1",
+				"wrap-ansi": "^7.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
 		"node_modules/newrelic/node_modules/https-proxy-agent": {
 			"version": "9.1.0",
 			"resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-9.1.0.tgz",
@@ -10697,6 +10652,24 @@
 			},
 			"engines": {
 				"node": ">= 20"
+			}
+		},
+		"node_modules/newrelic/node_modules/yargs": {
+			"version": "17.7.2",
+			"resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+			"integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+			"license": "MIT",
+			"dependencies": {
+				"cliui": "^8.0.1",
+				"escalade": "^3.1.1",
+				"get-caller-file": "^2.0.5",
+				"require-directory": "^2.1.1",
+				"string-width": "^4.2.3",
+				"y18n": "^5.0.5",
+				"yargs-parser": "^21.1.1"
+			},
+			"engines": {
+				"node": ">=12"
 			}
 		},
 		"node_modules/next-tick": {
@@ -10997,7 +10970,6 @@
 		},
 		"node_modules/object-keys": {
 			"version": "1.1.1",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 0.4"
@@ -11124,6 +11096,20 @@
 			},
 			"engines": {
 				"node": ">=6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/sindresorhus"
+			}
+		},
+		"node_modules/open": {
+			"version": "7.4.2",
+			"license": "MIT",
+			"dependencies": {
+				"is-docker": "^2.0.0",
+				"is-wsl": "^2.1.1"
+			},
+			"engines": {
+				"node": ">=8"
 			},
 			"funding": {
 				"url": "https://github.com/sponsors/sindresorhus"
@@ -11269,6 +11255,78 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/patch-package": {
+			"version": "8.0.1",
+			"license": "MIT",
+			"dependencies": {
+				"@yarnpkg/lockfile": "^1.1.0",
+				"chalk": "^4.1.2",
+				"ci-info": "^3.7.0",
+				"cross-spawn": "^7.0.3",
+				"find-yarn-workspace-root": "^2.0.0",
+				"fs-extra": "^10.0.0",
+				"json-stable-stringify": "^1.0.2",
+				"klaw-sync": "^6.0.0",
+				"minimist": "^1.2.6",
+				"open": "^7.4.2",
+				"semver": "^7.5.3",
+				"slash": "^2.0.0",
+				"tmp": "^0.2.4",
+				"yaml": "^2.2.2"
+			},
+			"bin": {
+				"patch-package": "index.js"
+			},
+			"engines": {
+				"node": ">=14",
+				"npm": ">5"
+			}
+		},
+		"node_modules/patch-package/node_modules/ci-info": {
+			"version": "3.9.0",
+			"funding": [
+				{
+					"type": "github",
+					"url": "https://github.com/sponsors/sibiraj-s"
+				}
+			],
+			"license": "MIT",
+			"engines": {
+				"node": ">=8"
+			}
+		},
+		"node_modules/patch-package/node_modules/fs-extra": {
+			"version": "10.1.0",
+			"license": "MIT",
+			"dependencies": {
+				"graceful-fs": "^4.2.0",
+				"jsonfile": "^6.0.1",
+				"universalify": "^2.0.0"
+			},
+			"engines": {
+				"node": ">=12"
+			}
+		},
+		"node_modules/patch-package/node_modules/slash": {
+			"version": "2.0.0",
+			"license": "MIT",
+			"engines": {
+				"node": ">=6"
+			}
+		},
+		"node_modules/patch-package/node_modules/yaml": {
+			"version": "2.9.0",
+			"license": "ISC",
+			"bin": {
+				"yaml": "bin.mjs"
+			},
+			"engines": {
+				"node": ">= 14.6"
+			},
+			"funding": {
+				"url": "https://github.com/sponsors/eemeli"
+			}
+		},
 		"node_modules/path-browserify": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
@@ -11311,7 +11369,6 @@
 		},
 		"node_modules/path-key": {
 			"version": "3.1.1",
-			"devOptional": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -11388,8 +11445,6 @@
 		},
 		"node_modules/pg": {
 			"version": "8.21.0",
-			"resolved": "https://registry.npmjs.org/pg/-/pg-8.21.0.tgz",
-			"integrity": "sha512-AUP1EYJuHraQGsVoCQVIcM7TEJVGtDzxWtGFZd8rds9d+CCXlU5Js1rYgfLNvxy9iJrpHjGrRjoi/3BT9fRyiA==",
 			"license": "MIT",
 			"dependencies": {
 				"pg-connection-string": "^2.13.0",
@@ -11415,15 +11470,11 @@
 		},
 		"node_modules/pg-cloudflare": {
 			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.4.0.tgz",
-			"integrity": "sha512-Vo7z/6rrQYxpNRylp4Tlob2elzbh+N/MOQbxFVWCxS7oEx6jF53GTJFxK2WWpKuBRkmiin4Mt+xofFDjx09R0A==",
 			"license": "MIT",
 			"optional": true
 		},
 		"node_modules/pg-connection-string": {
 			"version": "2.13.0",
-			"resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.13.0.tgz",
-			"integrity": "sha512-EMnU9E2fSULdsbErBbMaXJvFeD9B4+nPcM3f+4lsiCR0BHLPrLVjv3DbyM2hgQQviKJaTWIRRTjKjWlHg3p2ig==",
 			"license": "MIT"
 		},
 		"node_modules/pg-int8": {
@@ -11435,8 +11486,6 @@
 		},
 		"node_modules/pg-pool": {
 			"version": "3.14.0",
-			"resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.14.0.tgz",
-			"integrity": "sha512-gKtPkFdQPU3DksooVLi9LsjZxrsBUZIpa+7aVx+LV5pNh0KzP4Zleud2po+ConrxbuXGBJ6Hfer6hdgpIBpBaw==",
 			"license": "MIT",
 			"peerDependencies": {
 				"pg": ">=8.0"
@@ -11444,8 +11493,6 @@
 		},
 		"node_modules/pg-protocol": {
 			"version": "1.14.0",
-			"resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.14.0.tgz",
-			"integrity": "sha512-n5taZ1kO3s9ngDTVxsEznOqCyToTgz0FLuPq0B33COy5pPpuWJpY3/2oRBVETuOgzdqRXfWpM9HIhp2LBBT1BA==",
 			"license": "MIT"
 		},
 		"node_modules/pg-types": {
@@ -11476,7 +11523,6 @@
 		},
 		"node_modules/picomatch": {
 			"version": "2.3.1",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8.6"
@@ -11764,8 +11810,6 @@
 		},
 		"node_modules/protobufjs": {
 			"version": "7.5.8",
-			"resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.5.8.tgz",
-			"integrity": "sha512-dvpCIeLPbXZS/Ete7yLaO7RenOdken2NHKykBXbsaGxZT0UTltcarBciw+A78SRQs9iMAAVpsYA+l8b1hTePIA==",
 			"hasInstallScript": true,
 			"license": "BSD-3-Clause",
 			"dependencies": {
@@ -11871,8 +11915,6 @@
 		},
 		"node_modules/qs": {
 			"version": "6.15.2",
-			"resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
-			"integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
 			"license": "BSD-3-Clause",
 			"dependencies": {
 				"side-channel": "^1.1.0"
@@ -12272,8 +12314,6 @@
 		},
 		"node_modules/resolve-pkg-maps": {
 			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-pkg-maps/-/resolve-pkg-maps-1.0.0.tgz",
-			"integrity": "sha512-seS2Tj26TBVOC2NIc2rOe2y2ZO7efxITtLZcGSOnHHNOQ7CkiUBfw0Iw2ck6xkIhPwLhKNLS8BO+hEpngQlqzw==",
 			"dev": true,
 			"license": "MIT",
 			"funding": {
@@ -12572,7 +12612,6 @@
 		},
 		"node_modules/set-function-length": {
 			"version": "1.2.2",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"define-data-property": "^1.1.4",
@@ -12652,7 +12691,6 @@
 		},
 		"node_modules/shebang-command": {
 			"version": "2.0.0",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"shebang-regex": "^3.0.0"
@@ -12663,7 +12701,6 @@
 		},
 		"node_modules/shebang-regex": {
 			"version": "3.0.0",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">=8"
@@ -13451,15 +13488,13 @@
 			}
 		},
 		"node_modules/superagent/node_modules/form-data": {
-			"version": "2.5.6",
-			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
-			"integrity": "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==",
+			"version": "2.5.5",
 			"license": "MIT",
 			"dependencies": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.8",
 				"es-set-tostringtag": "^2.1.0",
-				"hasown": "^2.0.4",
+				"hasown": "^2.0.2",
 				"mime-types": "^2.1.35",
 				"safe-buffer": "^5.2.1"
 			},
@@ -13576,7 +13611,6 @@
 		},
 		"node_modules/supports-color": {
 			"version": "7.2.0",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"has-flag": "^4.0.0"
@@ -13640,8 +13674,6 @@
 		},
 		"node_modules/tapable": {
 			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
-			"integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -13837,6 +13869,13 @@
 				"uuid": "dist/bin/uuid"
 			}
 		},
+		"node_modules/tmp": {
+			"version": "0.2.7",
+			"license": "MIT",
+			"engines": {
+				"node": ">=14.14"
+			}
+		},
 		"node_modules/tmpl": {
 			"version": "1.0.5",
 			"dev": true,
@@ -13880,7 +13919,6 @@
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
-			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"is-number": "^7.0.0"
@@ -14307,8 +14345,6 @@
 		},
 		"node_modules/typescript-eslint": {
 			"version": "8.59.4",
-			"resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.59.4.tgz",
-			"integrity": "sha512-Rw6+44QNFaXtgHSjPy+Kw8hrJniMYzR85E9yLmOLcfZ91/rz+JXQbDTCmc6ccxMPY6K6PgAq26f0JCBfR7LIPQ==",
 			"dev": true,
 			"license": "MIT",
 			"dependencies": {
@@ -14349,8 +14385,6 @@
 		},
 		"node_modules/ua-parser-js": {
 			"version": "2.0.10",
-			"resolved": "https://registry.npmjs.org/ua-parser-js/-/ua-parser-js-2.0.10.tgz",
-			"integrity": "sha512-t+3Ktbq0Ies2vaSezfOaWiolH4OigQIO1dk+1xDpOydB1COVPocVYOrEV5rqZ0kFY9XYG1v9LutCyMgYBpABcw==",
 			"funding": [
 				{
 					"type": "opencollective",
@@ -14402,8 +14436,6 @@
 		},
 		"node_modules/ulid": {
 			"version": "3.0.2",
-			"resolved": "https://registry.npmjs.org/ulid/-/ulid-3.0.2.tgz",
-			"integrity": "sha512-yu26mwteFYzBAot7KVMqFGCVpsF6g8wXfJzQUHvu1no3+rRRSFcSV2nKeYvNPLD2J4b08jYBDhHUjeH0ygIl9w==",
 			"dev": true,
 			"license": "MIT",
 			"bin": {
@@ -14429,8 +14461,6 @@
 		},
 		"node_modules/undici": {
 			"version": "6.24.0",
-			"resolved": "https://registry.npmjs.org/undici/-/undici-6.24.0.tgz",
-			"integrity": "sha512-lVLNosgqo5EkGqh5XUDhGfsMSoO8K0BAN0TyJLvwNRSl4xWGZlCVYsAIpa/OpA3TvmnM01GWcoKmc3ZWo5wKKA==",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -14507,7 +14537,6 @@
 		},
 		"node_modules/universalify": {
 			"version": "2.0.1",
-			"dev": true,
 			"license": "MIT",
 			"engines": {
 				"node": ">= 10.0.0"
@@ -14722,7 +14751,6 @@
 		},
 		"node_modules/which": {
 			"version": "2.0.2",
-			"dev": true,
 			"license": "ISC",
 			"dependencies": {
 				"isexe": "^2.0.0"
@@ -14920,9 +14948,7 @@
 			}
 		},
 		"node_modules/ws": {
-			"version": "7.5.11",
-			"resolved": "https://registry.npmjs.org/ws/-/ws-7.5.11.tgz",
-			"integrity": "sha512-zS54Oen9bITtp7kp2XM3AydrCIq1D+HwJOuH+c+e4LfpL/lotP5osijd+UoMnxwAam1GN8R4KtLAyIrIcBNpiA==",
+			"version": "7.5.10",
 			"dev": true,
 			"license": "MIT",
 			"engines": {
@@ -14943,8 +14969,6 @@
 		},
 		"node_modules/xml-naming": {
 			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
-			"integrity": "sha512-k8KO9hrMyNk6tUWqUfkTEZbezRRpONVOzUTnc97VnCvyj6Tf9lyUR9EDAIeiVLv56jsMcoXEwjW8Kv5yPY52lw==",
 			"funding": [
 				{
 					"type": "github",
@@ -15095,7 +15119,7 @@
 			"version": "1.0.0",
 			"license": "AGPL-3.0",
 			"dependencies": {
-				"@edtf-ts/core": "^0.4.2",
+				"@edtf-ts/core": "^0.5.0",
 				"@fusionauth/typescript-client": "^1.60.0",
 				"@mailchimp/mailchimp_marketing": "^3.0.80",
 				"@mailchimp/mailchimp_transactional": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
 		"build": "npm run build --ws",
 		"lint": "npm run lint --ws",
 		"test": "npm run test --ws --if-present",
-		"format": "npm run format --ws --if-present"
+		"format": "npm run format --ws --if-present",
+		"postinstall": "if test -d node_modules/@edtf-ts/core; then patch-package; fi"
 	},
 	"workspaces": [
 		"./packages/logger",
@@ -41,6 +42,9 @@
 	"homepage": "https://permanent.org",
 	"engines": {
 		"node": ">=24.0"
+	},
+	"dependencies": {
+		"patch-package": "^8.0.1"
 	},
 	"devDependencies": {
 		"@redocly/cli": "^2.33.2",

--- a/packages/access_copy_attacher/Dockerfile
+++ b/packages/access_copy_attacher/Dockerfile
@@ -9,6 +9,7 @@ COPY tsconfig.build.json ./
 COPY tsconfig.json ./
 COPY jest.config.js ./
 COPY packages ./packages
+COPY patches ./patches
 
 RUN npm install
 RUN npm install -ws

--- a/packages/account_space_updater/Dockerfile
+++ b/packages/account_space_updater/Dockerfile
@@ -9,6 +9,7 @@ COPY tsconfig.build.json ./
 COPY tsconfig.json ./
 COPY jest.config.js ./
 COPY packages ./packages
+COPY patches ./patches
 
 RUN npm install
 RUN npm install -ws

--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -9,6 +9,7 @@ COPY tsconfig.build.json ./
 COPY tsconfig.json ./
 COPY jest.config.js ./
 COPY packages ./packages
+COPY patches ./patches
 
 RUN npm install
 RUN npm install -ws
@@ -29,6 +30,7 @@ RUN echo -e $AWS_RDS_CERT_BUNDLE > /etc/ca-certificates/rds-us-west-2-ca-bundle.
 
 COPY --from=builder /usr/local/apps/stela/packages/api/dist ./packages/api/dist
 COPY --from=builder /usr/local/apps/stela/packages/api/package.json ./packages/api/package.json
+COPY --from=builder /usr/local/apps/stela/patches ./patches
 COPY --from=builder /usr/local/apps/stela/packages/logger/dist ./packages/logger/dist
 COPY --from=builder /usr/local/apps/stela/packages/logger/package.json ./packages/logger/package.json
 COPY --from=builder /usr/local/apps/stela/packages/publisher-utils/dist ./packages/publisher-utils/dist
@@ -38,6 +40,7 @@ COPY --from=builder /usr/local/apps/stela/packages/permanent_models/package.json
 COPY --from=builder /usr/local/apps/stela/package.json ./package.json
 COPY --from=builder /usr/local/apps/stela/package-lock.json ./package-lock.json
 
+RUN npm install --workspaces=false
 RUN npm install --workspace @stela/api
 
 ENV PORT=80

--- a/packages/api/Dockerfile.dev
+++ b/packages/api/Dockerfile.dev
@@ -8,6 +8,7 @@ COPY package-lock.json ./
 COPY tsconfig.json ./
 COPY tsconfig.build.json ./
 COPY packages ./packages
+COPY patches ./patches
 COPY .env ./
 
 RUN npm cache clean --force

--- a/packages/api/Dockerfile.test
+++ b/packages/api/Dockerfile.test
@@ -9,6 +9,7 @@ COPY package-lock.json ./
 COPY tsconfig.build.json ./
 COPY tsconfig.json ./
 COPY jest.config.js ./
+COPY patches ./patches
 COPY packages/api/package.json ./packages/api/package.json
 COPY packages/logger ./packages/logger
 COPY packages/publisher-utils ./packages/publisher-utils

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -36,7 +36,7 @@
 	},
 	"dependencies": {
 		"@stela/publisher-utils": "^1.0.0",
-		"@edtf-ts/core": "^0.4.2",
+		"@edtf-ts/core": "^0.5.0",
 		"@fusionauth/typescript-client": "^1.60.0",
 		"@mailchimp/mailchimp_marketing": "^3.0.80",
 		"@mailchimp/mailchimp_transactional": "1.1.2",

--- a/packages/api/src/constants.ts
+++ b/packages/api/src/constants.ts
@@ -1,6 +1,8 @@
 export const KB = 1024;
 export const GB = KB * KB * KB;
 
+export const EDTF_LEVEL_2 = 2;
+
 export const ACCESS_ROLE = {
 	Contributor: "access.role.contributor",
 	Curator: "access.role.curator",

--- a/packages/api/src/folder/controller/patch_folder.test.ts
+++ b/packages/api/src/folder/controller/patch_folder.test.ts
@@ -109,10 +109,10 @@ describe("patch folder", () => {
 		expect(result.rows[0]).toEqual({ displaytime: null });
 	});
 
-	test("expect 400 error when displayTime is not valid Level 1 EDTF", async () => {
+	test("expect 400 error when displayTime is not valid Level 2 EDTF", async () => {
 		await agent
 			.patch("/api/v2/folders/2")
-			.send({ displayTime: "2024-33" })
+			.send({ displayTime: "2024-42" })
 			.expect(400);
 	});
 
@@ -985,6 +985,338 @@ describe("patch folder", () => {
 			);
 
 			expect(result.rows[0]).toStrictEqual({ displaytimelowerbound: null });
+		});
+
+		test("expect displaytimelowerbound is set for southern hemisphere spring (YYYY-29)", async () => {
+			await agent
+				.patch("/api/v2/folder/1")
+				.send({ displayTime: "2024-29" })
+				.expect(200);
+
+			const result = await db.query(
+				"SELECT to_char(displaytimelowerbound, 'YYYY-MM-DD HH24:MI:SS') as displaytimelowerbound FROM folder WHERE folderid = :folderId",
+				{ folderId: 1 },
+			);
+
+			expect(result.rows[0]).toEqual({
+				displaytimelowerbound: "2024-09-01 00:00:00",
+			});
+		});
+
+		test("expect displaytimelowerbound is set for southern hemisphere summer (YYYY-30)", async () => {
+			await agent
+				.patch("/api/v2/folder/1")
+				.send({ displayTime: "2024-30" })
+				.expect(200);
+
+			const result = await db.query(
+				"SELECT to_char(displaytimelowerbound, 'YYYY-MM-DD HH24:MI:SS') as displaytimelowerbound FROM folder WHERE folderid = :folderId",
+				{ folderId: 1 },
+			);
+
+			expect(result.rows[0]).toEqual({
+				displaytimelowerbound: "2024-12-01 00:00:00",
+			});
+		});
+
+		test("expect displaytimelowerbound is set for southern hemisphere autumn (YYYY-31)", async () => {
+			await agent
+				.patch("/api/v2/folder/1")
+				.send({ displayTime: "2024-31" })
+				.expect(200);
+
+			const result = await db.query(
+				"SELECT to_char(displaytimelowerbound, 'YYYY-MM-DD HH24:MI:SS') as displaytimelowerbound FROM folder WHERE folderid = :folderId",
+				{ folderId: 1 },
+			);
+
+			expect(result.rows[0]).toEqual({
+				displaytimelowerbound: "2024-03-01 00:00:00",
+			});
+		});
+
+		test("expect displaytimelowerbound is set for southern hemisphere winter (YYYY-32)", async () => {
+			await agent
+				.patch("/api/v2/folder/1")
+				.send({ displayTime: "2024-32" })
+				.expect(200);
+
+			const result = await db.query(
+				"SELECT to_char(displaytimelowerbound, 'YYYY-MM-DD HH24:MI:SS') as displaytimelowerbound FROM folder WHERE folderid = :folderId",
+				{ folderId: 1 },
+			);
+
+			expect(result.rows[0]).toEqual({
+				displaytimelowerbound: "2024-06-01 00:00:00",
+			});
+		});
+
+		test("expect displaytimelowerbound is set for quarter 1 (YYYY-33)", async () => {
+			await agent
+				.patch("/api/v2/folder/1")
+				.send({ displayTime: "2024-33" })
+				.expect(200);
+
+			const result = await db.query(
+				"SELECT to_char(displaytimelowerbound, 'YYYY-MM-DD HH24:MI:SS') as displaytimelowerbound FROM folder WHERE folderid = :folderId",
+				{ folderId: 1 },
+			);
+
+			expect(result.rows[0]).toEqual({
+				displaytimelowerbound: "2024-01-01 00:00:00",
+			});
+		});
+
+		test("expect displaytimelowerbound is set for quarter 2 (YYYY-34)", async () => {
+			await agent
+				.patch("/api/v2/folder/1")
+				.send({ displayTime: "2024-34" })
+				.expect(200);
+
+			const result = await db.query(
+				"SELECT to_char(displaytimelowerbound, 'YYYY-MM-DD HH24:MI:SS') as displaytimelowerbound FROM folder WHERE folderid = :folderId",
+				{ folderId: 1 },
+			);
+
+			expect(result.rows[0]).toEqual({
+				displaytimelowerbound: "2024-04-01 00:00:00",
+			});
+		});
+
+		test("expect displaytimelowerbound is set for quarter 3 (YYYY-35)", async () => {
+			await agent
+				.patch("/api/v2/folder/1")
+				.send({ displayTime: "2024-35" })
+				.expect(200);
+
+			const result = await db.query(
+				"SELECT to_char(displaytimelowerbound, 'YYYY-MM-DD HH24:MI:SS') as displaytimelowerbound FROM folder WHERE folderid = :folderId",
+				{ folderId: 1 },
+			);
+
+			expect(result.rows[0]).toEqual({
+				displaytimelowerbound: "2024-07-01 00:00:00",
+			});
+		});
+
+		test("expect displaytimelowerbound is set for quarter 4 (YYYY-36)", async () => {
+			await agent
+				.patch("/api/v2/folder/1")
+				.send({ displayTime: "2024-36" })
+				.expect(200);
+
+			const result = await db.query(
+				"SELECT to_char(displaytimelowerbound, 'YYYY-MM-DD HH24:MI:SS') as displaytimelowerbound FROM folder WHERE folderid = :folderId",
+				{ folderId: 1 },
+			);
+
+			expect(result.rows[0]).toEqual({
+				displaytimelowerbound: "2024-10-01 00:00:00",
+			});
+		});
+
+		test("expect displaytimelowerbound is set for quadrimester 1 (YYYY-37)", async () => {
+			await agent
+				.patch("/api/v2/folder/1")
+				.send({ displayTime: "2024-37" })
+				.expect(200);
+
+			const result = await db.query(
+				"SELECT to_char(displaytimelowerbound, 'YYYY-MM-DD HH24:MI:SS') as displaytimelowerbound FROM folder WHERE folderid = :folderId",
+				{ folderId: 1 },
+			);
+
+			expect(result.rows[0]).toEqual({
+				displaytimelowerbound: "2024-01-01 00:00:00",
+			});
+		});
+
+		test("expect displaytimelowerbound is set for quadrimester 2 (YYYY-38)", async () => {
+			await agent
+				.patch("/api/v2/folder/1")
+				.send({ displayTime: "2024-38" })
+				.expect(200);
+
+			const result = await db.query(
+				"SELECT to_char(displaytimelowerbound, 'YYYY-MM-DD HH24:MI:SS') as displaytimelowerbound FROM folder WHERE folderid = :folderId",
+				{ folderId: 1 },
+			);
+
+			expect(result.rows[0]).toEqual({
+				displaytimelowerbound: "2024-05-01 00:00:00",
+			});
+		});
+
+		test("expect displaytimelowerbound is set for quadrimester 3 (YYYY-39)", async () => {
+			await agent
+				.patch("/api/v2/folder/1")
+				.send({ displayTime: "2024-39" })
+				.expect(200);
+
+			const result = await db.query(
+				"SELECT to_char(displaytimelowerbound, 'YYYY-MM-DD HH24:MI:SS') as displaytimelowerbound FROM folder WHERE folderid = :folderId",
+				{ folderId: 1 },
+			);
+
+			expect(result.rows[0]).toEqual({
+				displaytimelowerbound: "2024-09-01 00:00:00",
+			});
+		});
+
+		test("expect displaytimelowerbound is set for semestral 1 (YYYY-40)", async () => {
+			await agent
+				.patch("/api/v2/folder/1")
+				.send({ displayTime: "2024-40" })
+				.expect(200);
+
+			const result = await db.query(
+				"SELECT to_char(displaytimelowerbound, 'YYYY-MM-DD HH24:MI:SS') as displaytimelowerbound FROM folder WHERE folderid = :folderId",
+				{ folderId: 1 },
+			);
+
+			expect(result.rows[0]).toEqual({
+				displaytimelowerbound: "2024-01-01 00:00:00",
+			});
+		});
+
+		test("expect displaytimelowerbound is set for semestral 2 (YYYY-41)", async () => {
+			await agent
+				.patch("/api/v2/folder/1")
+				.send({ displayTime: "2024-41" })
+				.expect(200);
+
+			const result = await db.query(
+				"SELECT to_char(displaytimelowerbound, 'YYYY-MM-DD HH24:MI:SS') as displaytimelowerbound FROM folder WHERE folderid = :folderId",
+				{ folderId: 1 },
+			);
+
+			expect(result.rows[0]).toEqual({
+				displaytimelowerbound: "2024-07-01 00:00:00",
+			});
+		});
+
+		test("expect displaytimelowerbound is set for significant digits (1950S2)", async () => {
+			await agent
+				.patch("/api/v2/folder/1")
+				.send({ displayTime: "1950S2" })
+				.expect(200);
+
+			const result = await db.query(
+				"SELECT to_char(displaytimelowerbound, 'YYYY-MM-DD HH24:MI:SS') as displaytimelowerbound FROM folder WHERE folderid = :folderId",
+				{ folderId: 1 },
+			);
+
+			expect(result.rows[0]).toEqual({
+				displaytimelowerbound: "1950-01-01 00:00:00",
+			});
+		});
+
+		test("expect displaytimelowerbound is infinity for positive exponential year beyond PostgreSQL range (Y17E7)", async () => {
+			await agent
+				.patch("/api/v2/folder/1")
+				.send({ displayTime: "Y17E7" })
+				.expect(200);
+
+			const result = await db.query(
+				"SELECT displaytimelowerbound FROM folder WHERE folderid = :folderId",
+				{ folderId: 1 },
+			);
+
+			expect(result.rows[0]).toEqual({ displaytimelowerbound: Infinity });
+		});
+
+		test("expect displaytimelowerbound is -infinity for negative exponential year beyond PostgreSQL range (Y-17E7)", async () => {
+			await agent
+				.patch("/api/v2/folder/1")
+				.send({ displayTime: "Y-17E7" })
+				.expect(200);
+
+			const result = await db.query(
+				"SELECT displaytimelowerbound FROM folder WHERE folderid = :folderId",
+				{ folderId: 1 },
+			);
+
+			expect(result.rows[0]).toEqual({ displaytimelowerbound: -Infinity });
+		});
+
+		test("expect displaytimelowerbound is set for uncertain year component (?YYYY-MM-DD)", async () => {
+			await agent
+				.patch("/api/v2/folder/1")
+				.send({ displayTime: "?2004-06-11" })
+				.expect(200);
+
+			const result = await db.query(
+				"SELECT to_char(displaytimelowerbound, 'YYYY-MM-DD HH24:MI:SS') as displaytimelowerbound FROM folder WHERE folderid = :folderId",
+				{ folderId: 1 },
+			);
+
+			expect(result.rows[0]).toEqual({
+				displaytimelowerbound: "2004-06-11 00:00:00",
+			});
+		});
+
+		test("expect displaytimelowerbound is set for uncertain month component (YYYY-?MM-DD)", async () => {
+			await agent
+				.patch("/api/v2/folder/1")
+				.send({ displayTime: "2004-?06-11" })
+				.expect(200);
+
+			const result = await db.query(
+				"SELECT to_char(displaytimelowerbound, 'YYYY-MM-DD HH24:MI:SS') as displaytimelowerbound FROM folder WHERE folderid = :folderId",
+				{ folderId: 1 },
+			);
+
+			expect(result.rows[0]).toEqual({
+				displaytimelowerbound: "2004-06-11 00:00:00",
+			});
+		});
+
+		test("expect displaytimelowerbound is set for approximate day component (YYYY-MM-~DD)", async () => {
+			await agent
+				.patch("/api/v2/folder/1")
+				.send({ displayTime: "2004-06-~11" })
+				.expect(200);
+
+			const result = await db.query(
+				"SELECT to_char(displaytimelowerbound, 'YYYY-MM-DD HH24:MI:SS') as displaytimelowerbound FROM folder WHERE folderid = :folderId",
+				{ folderId: 1 },
+			);
+
+			expect(result.rows[0]).toEqual({
+				displaytimelowerbound: "2004-06-11 00:00:00",
+			});
+		});
+
+		test("expect displaytimelowerbound is set for set of years ({YYYY,YYYY,YYYY..YYYY})", async () => {
+			await agent
+				.patch("/api/v2/folder/1")
+				.send({ displayTime: "{1667,1668,1670..1672}" })
+				.expect(200);
+
+			const result = await db.query(
+				"SELECT to_char(displaytimelowerbound, 'YYYY-MM-DD HH24:MI:SS') as displaytimelowerbound FROM folder WHERE folderid = :folderId",
+				{ folderId: 1 },
+			);
+
+			expect(result.rows[0]).toEqual({
+				displaytimelowerbound: "1667-01-01 00:00:00",
+			});
+		});
+
+		test("expect displaytimelowerbound is set for list of years ([YYYY,YYYY,YYYY..YYYY])", async () => {
+			await agent
+				.patch("/api/v2/folder/1")
+				.send({ displayTime: "[1667,1668,1670..1672]" })
+				.expect(200);
+
+			const result = await db.query(
+				"SELECT to_char(displaytimelowerbound, 'YYYY-MM-DD HH24:MI:SS') as displaytimelowerbound FROM folder WHERE folderid = :folderId",
+				{ folderId: 1 },
+			);
+
+			expect(result.rows[0]).toEqual({
+				displaytimelowerbound: "1667-01-01 00:00:00",
+			});
 		});
 	});
 });

--- a/packages/api/src/folder/validators.ts
+++ b/packages/api/src/folder/validators.ts
@@ -3,6 +3,7 @@ import { parse as parseEDTF } from "@edtf-ts/core";
 import type { PatchFolderRequest } from "./models";
 import { fieldsFromUserAuthentication } from "../validators";
 import { locationInputSchema } from "../location/validators";
+import { EDTF_LEVEL_2 } from "../constants";
 
 export const validateFolderRequest: (
 	data: unknown,
@@ -31,12 +32,12 @@ export const validatePatchFolderRequest: (
 			displayEndDate: Joi.string().optional().allow(null),
 			displayTime: Joi.string()
 				.custom((value: string) => {
-					const result = parseEDTF(value, 1);
+					const result = parseEDTF(value, EDTF_LEVEL_2);
 					if (result.success) {
 						return value;
 					}
 					const detail = result.errors.map((e) => e.message).join("; ");
-					throw new Error(`${value} is not valid Level 1 EDTF: ${detail}`);
+					throw new Error(`${value} is not valid Level 2 EDTF: ${detail}`);
 				})
 				.optional()
 				.allow(null),

--- a/packages/api/src/record/controller/update_record.test.ts
+++ b/packages/api/src/record/controller/update_record.test.ts
@@ -165,11 +165,11 @@ describe("PATCH /records", () => {
 			.expect(400);
 	});
 
-	test("expect 400 error if display time is not valid Level 1 EDTF", async () => {
+	test("expect 400 error if display time is not valid Level 2 EDTF", async () => {
 		await agent
 			.patch("/api/v2/records/10001")
 			.send({
-				displayTime: "2001-34", // This is Level 2 EDTF for "Q2 of 2001"
+				displayTime: "2001-42", // Beyond the valid sub-year range of 21-41
 			})
 			.expect(400);
 	});

--- a/packages/api/src/record/validators.ts
+++ b/packages/api/src/record/validators.ts
@@ -3,6 +3,7 @@ import { parse as parseEDTF } from "@edtf-ts/core";
 import type { CreateRecordCopyRequest, PatchRecordRequest } from "./models";
 import { fieldsFromUserAuthentication } from "../validators";
 import { locationInputSchema } from "../location/validators";
+import { EDTF_LEVEL_2 } from "../constants";
 
 export const validateGetRecordQuery: (
 	data: unknown,
@@ -49,12 +50,12 @@ export const validatePatchRecordRequest: (
 			displayName: Joi.string().min(1).optional(),
 			displayTime: Joi.string()
 				.custom((value: string) => {
-					const result = parseEDTF(value, 1);
+					const result = parseEDTF(value, EDTF_LEVEL_2);
 					if (result.success) {
 						return value;
 					}
 					const detail = result.errors.map((e) => e.message).join("; ");
-					throw new Error(`${value} is not valid Level 1 EDTF: ${detail}`);
+					throw new Error(`${value} is not valid Level 2 EDTF: ${detail}`);
 				})
 				.optional()
 				.allow(null),

--- a/packages/archivematica_cleanup/Dockerfile
+++ b/packages/archivematica_cleanup/Dockerfile
@@ -9,6 +9,7 @@ COPY tsconfig.build.json ./
 COPY tsconfig.json ./
 COPY jest.config.js ./
 COPY packages ./packages
+COPY patches ./patches
 
 RUN npm install
 RUN npm install -ws

--- a/packages/event_send/Dockerfile
+++ b/packages/event_send/Dockerfile
@@ -9,6 +9,7 @@ COPY tsconfig.build.json ./
 COPY tsconfig.json ./
 COPY jest.config.js ./
 COPY packages ./packages
+COPY patches ./patches
 
 RUN npm install
 RUN npm install -ws

--- a/packages/file_copier/Dockerfile
+++ b/packages/file_copier/Dockerfile
@@ -9,6 +9,7 @@ COPY tsconfig.build.json ./
 COPY tsconfig.json ./
 COPY jest.config.js ./
 COPY packages ./packages
+COPY patches ./patches
 
 RUN npm install
 RUN npm install -ws

--- a/packages/file_url_refresh/Dockerfile
+++ b/packages/file_url_refresh/Dockerfile
@@ -9,6 +9,7 @@ COPY tsconfig.build.json ./
 COPY tsconfig.json ./
 COPY jest.config.js ./
 COPY packages ./packages
+COPY patches ./patches
 
 RUN npm install
 RUN npm install -ws

--- a/packages/metadata_attacher/Dockerfile
+++ b/packages/metadata_attacher/Dockerfile
@@ -9,6 +9,7 @@ COPY tsconfig.build.json ./
 COPY tsconfig.json ./
 COPY jest.config.js ./
 COPY packages ./packages
+COPY patches ./patches
 
 RUN npm install
 RUN npm install -ws

--- a/packages/record_thumbnail_attacher/Dockerfile
+++ b/packages/record_thumbnail_attacher/Dockerfile
@@ -9,6 +9,7 @@ COPY tsconfig.build.json ./
 COPY tsconfig.json ./
 COPY jest.config.js ./
 COPY packages ./packages
+COPY patches ./patches
 
 RUN npm install
 RUN npm install -ws

--- a/packages/thumbnail_refresh/Dockerfile
+++ b/packages/thumbnail_refresh/Dockerfile
@@ -9,6 +9,7 @@ COPY tsconfig.build.json ./
 COPY tsconfig.json ./
 COPY jest.config.js ./
 COPY packages ./packages
+COPY patches ./patches
 
 RUN npm install
 RUN npm install -ws

--- a/packages/trigger_archivematica/Dockerfile
+++ b/packages/trigger_archivematica/Dockerfile
@@ -9,6 +9,7 @@ COPY tsconfig.build.json ./
 COPY tsconfig.json ./
 COPY jest.config.js ./
 COPY packages ./packages
+COPY patches ./patches
 
 RUN npm install
 RUN npm install -ws

--- a/patches/@edtf-ts+core+0.5.0.patch
+++ b/patches/@edtf-ts+core+0.5.0.patch
@@ -1,0 +1,50 @@
+diff --git a/node_modules/@edtf-ts/core/dist/index.cjs b/node_modules/@edtf-ts/core/dist/index.cjs
+index 8158ce6..7f99b83 100644
+--- a/node_modules/@edtf-ts/core/dist/index.cjs
++++ b/node_modules/@edtf-ts/core/dist/index.cjs
+@@ -972,11 +972,16 @@ var DEFAULT_SEASON_MAPPINGS = {
+   // September-November
+   24: { startMonth: 12, endMonth: 2, name: "Winter" },
+   // December-February (crosses year)
++  // Northern Hemisphere seasons
++  25: { startMonth: 3, endMonth: 5, name: "Spring (NH)" },
++  26: { startMonth: 6, endMonth: 8, name: "Summer (NH)" },
++  27: { startMonth: 9, endMonth: 11, name: "Autumn (NH)" },
++  28: { startMonth: 12, endMonth: 2, name: "Winter (NH)" },
+   // Southern Hemisphere seasons (offset by 6 months)
+-  25: { startMonth: 9, endMonth: 11, name: "Spring (SH)" },
+-  26: { startMonth: 12, endMonth: 2, name: "Summer (SH)" },
+-  27: { startMonth: 3, endMonth: 5, name: "Autumn (SH)" },
+-  28: { startMonth: 6, endMonth: 8, name: "Winter (SH)" },
++  29: { startMonth: 9, endMonth: 11, name: "Spring (SH)" },
++  30: { startMonth: 12, endMonth: 2, name: "Summer (SH)" },
++  31: { startMonth: 3, endMonth: 5, name: "Autumn (SH)" },
++  32: { startMonth: 6, endMonth: 8, name: "Winter (SH)" },
+   // Quarters
+   33: { startMonth: 1, endMonth: 3, name: "Quarter 1" },
+   // Q1
+diff --git a/node_modules/@edtf-ts/core/dist/index.js b/node_modules/@edtf-ts/core/dist/index.js
+index ae819a9..9762578 100644
+--- a/node_modules/@edtf-ts/core/dist/index.js
++++ b/node_modules/@edtf-ts/core/dist/index.js
+@@ -970,11 +970,16 @@ var DEFAULT_SEASON_MAPPINGS = {
+   // September-November
+   24: { startMonth: 12, endMonth: 2, name: "Winter" },
+   // December-February (crosses year)
++  // Northern Hemisphere seasons
++  25: { startMonth: 3, endMonth: 5, name: "Spring (NH)" },
++  26: { startMonth: 6, endMonth: 8, name: "Summer (NH)" },
++  27: { startMonth: 9, endMonth: 11, name: "Autumn (NH)" },
++  28: { startMonth: 12, endMonth: 2, name: "Winter (NH)" },
+   // Southern Hemisphere seasons (offset by 6 months)
+-  25: { startMonth: 9, endMonth: 11, name: "Spring (SH)" },
+-  26: { startMonth: 12, endMonth: 2, name: "Summer (SH)" },
+-  27: { startMonth: 3, endMonth: 5, name: "Autumn (SH)" },
+-  28: { startMonth: 6, endMonth: 8, name: "Winter (SH)" },
++  29: { startMonth: 9, endMonth: 11, name: "Spring (SH)" },
++  30: { startMonth: 12, endMonth: 2, name: "Summer (SH)" },
++  31: { startMonth: 3, endMonth: 5, name: "Autumn (SH)" },
++  32: { startMonth: 6, endMonth: 8, name: "Winter (SH)" },
+   // Quarters
+   33: { startMonth: 1, endMonth: 3, name: "Quarter 1" },
+   // Q1


### PR DESCRIPTION
We would like our users to be able to use all the features of EDTF, so this commit updates our record and folder endpoints to support EDTF Level 2. It also adds tests to cover handling of Level 2 features by the database trigger that calculates minimum possible timestamps from EDTF statements.