### PR TITLE
Allow numeric strings in metadata

### DIFF
--- a/packages/metadata_attacher/src/fixtures/numeric_caption_abstract.xml
+++ b/packages/metadata_attacher/src/fixtures/numeric_caption_abstract.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:premis="info:lc/xmlns/premis-v2" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <mets:amdSec>
+    <mets:techMD>
+      <mets:mdWrap>
+        <mets:xmlData>
+          <premis:object>
+            <premis:originalName>objects/1</premis:originalName>
+            <premis:objectCharacteristics>
+              <premis:objectCharacteristicsExtension>
+                <rdf:RDF>
+                  <rdf:Description xmlns:File="http://ns.exiftool.org/File/1.0/" xmlns:IPTC="http://ns.exiftool.org/IPTC/IPTC/1.0/">
+                    <File:MIMEType>image/jpeg</File:MIMEType>
+                    <IPTC:Caption-Abstract>12345</IPTC:Caption-Abstract>
+                  </rdf:Description>
+                </rdf:RDF>
+              </premis:objectCharacteristicsExtension>
+            </premis:objectCharacteristics>
+          </premis:object>
+        </mets:xmlData>
+      </mets:mdWrap>
+    </mets:techMD>
+  </mets:amdSec>
+</mets:mets>

--- a/packages/metadata_attacher/src/index.test.ts
+++ b/packages/metadata_attacher/src/index.test.ts
@@ -913,6 +913,57 @@ describe("handler", () => {
 		expect(recordMetadata?.altText).toEqual(null);
 	});
 
+	test("should handle a numeric IPTC:Caption-Abstract without failing validation", async () => {
+		const metsContent = await loadMetsFile("numeric_caption_abstract.xml");
+		mockS3Send.mockResolvedValue({
+			Body: {
+				transformToString: jest.fn().mockResolvedValue(metsContent),
+			},
+		});
+
+		const event = {
+			Records: [
+				{
+					messageId: "1",
+					receiptHandle: "1",
+					body: JSON.stringify({
+						Message: JSON.stringify({
+							Records: [
+								{
+									s3: {
+										bucket: {
+											name: "test-bucket",
+										},
+										object: {
+											key: "access_copies/53f9/8c3d/a29e/4fbf/8a4a/4fd9/991e/313d/1_upload-4a64ba7c-ceac-4547-ac13-c487b2711d5a/METS.4a64ba7c-ceac-4547-ac13-c487b2711d5a.xml",
+										},
+									},
+								},
+							],
+						}),
+					}),
+					attributes: {
+						ApproximateReceiveCount: "1",
+						SentTimestamp: "1",
+						SenderId: "1",
+						ApproximateFirstReceiveTimestamp: "1",
+					},
+					messageAttributes: {},
+					md5OfBody: "1",
+					eventSource: "1",
+					eventSourceARN: "1",
+					awsRegion: "1",
+				},
+			],
+		};
+
+		await handler(event, mock<Context>(), jest.fn());
+
+		const recordMetadata = await getRecordMetadata("1");
+		expect(recordMetadata).toBeDefined();
+		expect(recordMetadata?.description).toEqual("12345");
+	});
+
 	test("should handle video with no timestamp metadata", async () => {
 		const metsContent = await loadMetsFile("video_no_timestamp.xml");
 		mockS3Send.mockResolvedValue({

--- a/packages/metadata_attacher/src/index.ts
+++ b/packages/metadata_attacher/src/index.ts
@@ -79,7 +79,7 @@ const getEmbeddedMetadataFromS3 = async (
 		throw Error("metadata file is empty");
 	}
 
-	const xmlParser = new XMLParser();
+	const xmlParser = new XMLParser({ parseTagValue: false });
 	const metadata: unknown = xmlParser.parse(metadataFileContents);
 	validateMetsMetadata(metadata);
 


### PR DESCRIPTION
Currently, our metadata validation fails if a field we expect to be a string contains a purely numeric value. This is because we have our XML parser set to parse fields it thinks are numbers as numbers. This commit turns that feature off, because it is legitimate for a string field to have a numeric value. This does mean that when we implement location metadata parsing we'll likely have to convert coordinates and elevations to numbers ourselves before writing to the database.