### PR TITLE
Allow single IPTC keyword in metadata

### DIFF
--- a/packages/metadata_attacher/src/fixtures/single_keyword_mets.xml
+++ b/packages/metadata_attacher/src/fixtures/single_keyword_mets.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<mets:mets xmlns:mets="http://www.loc.gov/METS/" xmlns:premis="info:lc/xmlns/premis-v2" xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#">
+  <mets:amdSec>
+    <mets:techMD>
+      <mets:mdWrap>
+        <mets:xmlData>
+          <premis:object>
+            <premis:originalName>objects/710a1def-caf8-48f2-8eee-0848b4cfda10</premis:originalName>
+            <premis:objectCharacteristics>
+              <premis:objectCharacteristicsExtension>
+                <rdf:RDF>
+                  <rdf:Description xmlns:File="http://ns.exiftool.org/File/1.0/">
+                    <ExifTool:ExifToolVersion>12.40</ExifTool:ExifToolVersion>
+                    <File:MIMEType>image/jpeg</File:MIMEType>
+                    <IPTC:Keywords>nature</IPTC:Keywords>
+                  </rdf:Description>
+                </rdf:RDF>
+              </premis:objectCharacteristicsExtension>
+            </premis:objectCharacteristics>
+          </premis:object>
+        </mets:xmlData>
+      </mets:mdWrap>
+    </mets:techMD>
+  </mets:amdSec>
+</mets:mets>

--- a/packages/metadata_attacher/src/index.test.ts
+++ b/packages/metadata_attacher/src/index.test.ts
@@ -675,6 +675,57 @@ describe("handler", () => {
 		);
 	});
 
+	test("should extract a single IPTC keyword provided as a string", async () => {
+		const metsContent = await loadMetsFile("single_keyword_mets.xml");
+		mockS3Send.mockResolvedValue({
+			Body: {
+				transformToString: jest.fn().mockResolvedValue(metsContent),
+			},
+		});
+
+		const event = {
+			Records: [
+				{
+					messageId: "1",
+					receiptHandle: "1",
+					body: JSON.stringify({
+						Message: JSON.stringify({
+							Records: [
+								{
+									s3: {
+										bucket: {
+											name: "test-bucket",
+										},
+										object: {
+											key: "access_copies/53f9/8c3d/a29e/4fbf/8a4a/4fd9/991e/313d/1_upload-4a64ba7c-ceac-4547-ac13-c487b2711d5a/METS.4a64ba7c-ceac-4547-ac13-c487b2711d5a.xml",
+										},
+									},
+								},
+							],
+						}),
+					}),
+					attributes: {
+						ApproximateReceiveCount: "1",
+						SentTimestamp: "1",
+						SenderId: "1",
+						ApproximateFirstReceiveTimestamp: "1",
+					},
+					messageAttributes: {},
+					md5OfBody: "1",
+					eventSource: "1",
+					eventSourceARN: "1",
+					awsRegion: "1",
+				},
+			],
+		};
+
+		await handler(event, mock<Context>(), jest.fn());
+
+		const recordMetadata = await getRecordMetadata("1");
+		expect(recordMetadata).toBeDefined();
+		expect(recordMetadata?.tags).toEqual(["nature"]);
+	});
+
 	test("should handle database error gracefully", async () => {
 		const metsContent = await loadMetsFile("sample_mets.xml");
 		mockS3Send.mockResolvedValue({

--- a/packages/metadata_attacher/src/index.ts
+++ b/packages/metadata_attacher/src/index.ts
@@ -127,10 +127,13 @@ const getPhotoMetadata = (
 					rdfMetadata["ExifIFD:DateTimeOriginal"],
 					rdfMetadata["ExifIFD:OffsetTimeOriginal"],
 				);
+	const { "IPTC:Keywords": iptcKeywords } = rdfMetadata;
 	const tags =
-		rdfMetadata["IPTC:Keywords"] === undefined
+		iptcKeywords === undefined
 			? undefined
-			: rdfMetadata["IPTC:Keywords"]["rdf:Bag"]["rdf:li"];
+			: typeof iptcKeywords === "string"
+				? [iptcKeywords]
+				: iptcKeywords["rdf:Bag"]["rdf:li"];
 
 	return {
 		creationTime:

--- a/packages/metadata_attacher/src/models.ts
+++ b/packages/metadata_attacher/src/models.ts
@@ -33,6 +33,7 @@ export interface RdfMetadata {
 	"IPTC:ObjectName": string | undefined;
 	"IPTC:Caption-Abstract": string | undefined;
 	"IPTC:Keywords":
+		| string
 		| {
 				"rdf:Bag": {
 					"rdf:li": string[];

--- a/packages/metadata_attacher/src/validators.ts
+++ b/packages/metadata_attacher/src/validators.ts
@@ -6,11 +6,16 @@ const rdfMetadataSchema = Joi.object({
 	"File:MIMEType": Joi.string().required(),
 	"IPTC:ObjectName": Joi.string().optional().empty(""),
 	"IPTC:Caption-Abstract": Joi.string().optional().empty(""),
-	"IPTC:Keywords": Joi.object({
-		"rdf:Bag": Joi.object({
-			"rdf:li": Joi.array().items(Joi.string()).required(),
-		}).required(),
-	}).optional(),
+	"IPTC:Keywords": Joi.alternatives()
+		.try(
+			Joi.string(),
+			Joi.object({
+				"rdf:Bag": Joi.object({
+					"rdf:li": Joi.array().items(Joi.string()).required(),
+				}).required(),
+			}),
+		)
+		.optional(),
 	"ExifIFD:Title": Joi.string().optional().empty(""),
 	"ExifIFD:UserComment": Joi.string().optional().empty(""),
 	"ExifIFD:Comments": Joi.string().optional().empty(""),


### PR DESCRIPTION
Currently, we expect the IPTC:Keyword field in metadata files to be an object containing potentially multiple keywords. However, in some files it is simply a single keyword expressed as a string. This commit updates the metadata attacher lambda to handle that case.