### PR TITLE
Update queries to use the new name of the record EDTF column

### DIFF
--- a/packages/api/src/record/controller/update_record.test.ts
+++ b/packages/api/src/record/controller/update_record.test.ts
@@ -191,13 +191,13 @@ describe("PATCH /records", () => {
 			.expect(200);
 
 		const result = await db.query(
-			"SELECT originalfilecreationtime FROM record WHERE recordId = :recordId",
+			"SELECT displaytime FROM record WHERE recordId = :recordId",
 			{
 				recordId: 10001,
 			},
 		);
 
-		expect(result.rows[0]).toEqual({ originalfilecreationtime: "2001-21~" });
+		expect(result.rows[0]).toEqual({ displaytime: "2001-21~" });
 	});
 
 	test("expect display time is updated when set to null", async () => {
@@ -207,13 +207,13 @@ describe("PATCH /records", () => {
 			.expect(200);
 
 		const result = await db.query(
-			"SELECT originalfilecreationtime FROM record WHERE recordId = :recordId",
+			"SELECT displaytime FROM record WHERE recordId = :recordId",
 			{
 				recordId: 10008,
 			},
 		);
 
-		expect(result.rows[0]).toEqual({ originalfilecreationtime: null });
+		expect(result.rows[0]).toEqual({ displaytime: null });
 	});
 
 	test("expect to log error and return 500 if database permissions query fails", async () => {

--- a/packages/api/src/record/fixtures/create_complete_test_record.sql
+++ b/packages/api/src/record/fixtures/create_complete_test_record.sql
@@ -25,7 +25,7 @@ record (
   updateddt,
   alttext,
   locnid,
-  originalfilecreationtime
+  displaytime
 )
 VALUES
 (

--- a/packages/api/src/record/queries/copy_record.sql
+++ b/packages/api/src/record/queries/copy_record.sql
@@ -152,7 +152,7 @@ new_record AS (
     updateddt,
     uploadpayeraccountid,
     alttext,
-    originalfilecreationtime
+    displaytime
   )
   SELECT
     :destinationArchiveId AS archiveid,
@@ -220,7 +220,7 @@ new_record AS (
       (SELECT copier_account.accountid FROM copier_account)
     ) AS uploadpayeraccountid,
     alttext,
-    originalfilecreationtime
+    displaytime
   FROM
     record
   WHERE

--- a/packages/api/src/record/queries/get_records.sql
+++ b/packages/api/src/record/queries/get_records.sql
@@ -191,7 +191,7 @@ SELECT DISTINCT ON (record.recordid)
   record.uploadpayeraccountid AS "uploadPayerAccountId",
   record.size,
   record.displaydt AS "displayDate",
-  record.originalfilecreationtime AS "displayTime",
+  record.displaytime AS "displayTime",
   record.derivedcreateddt AS "fileCreatedAt",
   record.imageratio AS "imageRatio",
   record.thumburl200 AS "thumbUrl200",

--- a/packages/api/src/record/queries/update_record.sql
+++ b/packages/api/src/record/queries/update_record.sql
@@ -10,9 +10,9 @@ SET
     WHEN :setDescriptionToNull THEN NULL
     ELSE COALESCE(:description, description)
   END,
-  originalfilecreationtime = CASE
+  displaytime = CASE
     WHEN :setDisplayTimeToNull THEN NULL
-    ELSE COALESCE(:displayTime, originalfilecreationtime)
+    ELSE COALESCE(:displayTime, displaytime)
   END,
   updateddt = CURRENT_TIMESTAMP
 WHERE

--- a/packages/metadata_attacher/src/index.test.ts
+++ b/packages/metadata_attacher/src/index.test.ts
@@ -43,7 +43,7 @@ describe("handler", () => {
 				displayName: string;
 				description: string | null;
 				derivedTimestamp: Date | null;
-				originalFileCreationTime: string | null;
+				displayTime: string | null;
 				tags: string[];
 				altText: string | null;
 		  }
@@ -53,7 +53,7 @@ describe("handler", () => {
 			displayName: string;
 			description: string | null;
 			derivedTimestamp: Date | null;
-			originalFileCreationTime: string | null;
+			displayTime: string | null;
 			tags: string[];
 			altText: string | null;
 		}>(
@@ -62,7 +62,7 @@ describe("handler", () => {
 				record.displayname AS "displayName",
 				record.description,
 				record.deriveddt AS "derivedTimestamp",
-				record.originalfilecreationtime AS "originalFileCreationTime",
+				record.displaytime AS "displayTime",
 				array_remove(array_agg(tag.name), NULL) AS "tags",
 				alttext AS "altText"
 			FROM
@@ -201,9 +201,7 @@ describe("handler", () => {
 		expect(recordMetadata?.derivedTimestamp).toEqual(
 			new Date("2023-06-15T21:30:00.000Z"),
 		);
-		expect(recordMetadata?.originalFileCreationTime).toEqual(
-			"2023-06-15T21:30:00Z",
-		);
+		expect(recordMetadata?.displayTime).toEqual("2023-06-15T21:30:00Z");
 		expect(recordMetadata?.tags.sort()).toEqual(
 			["nature", "landscape", "sunset"].sort(),
 		);
@@ -614,7 +612,7 @@ describe("handler", () => {
 			"This is a test image description",
 		);
 		expect(recordMetadata?.derivedTimestamp).toEqual(null);
-		expect(recordMetadata?.originalFileCreationTime).toEqual(null);
+		expect(recordMetadata?.displayTime).toEqual(null);
 		expect(recordMetadata?.tags.sort()).toEqual(
 			["nature", "landscape", "sunset"].sort(),
 		);
@@ -670,9 +668,7 @@ describe("handler", () => {
 		const recordMetadata = await getRecordMetadata("1");
 		expect(recordMetadata).toBeDefined();
 		expect(recordMetadata?.derivedTimestamp).toEqual(null);
-		expect(recordMetadata?.originalFileCreationTime).toEqual(
-			"2023-06-15T21:30:00",
-		);
+		expect(recordMetadata?.displayTime).toEqual("2023-06-15T21:30:00");
 	});
 
 	test("should extract a single IPTC keyword provided as a string", async () => {
@@ -831,9 +827,7 @@ describe("handler", () => {
 		expect(recordMetadata?.derivedTimestamp).toEqual(
 			new Date("2024-03-15T10:30:00.000Z"),
 		);
-		expect(recordMetadata?.originalFileCreationTime).toEqual(
-			"2024-03-15T10:30:00Z",
-		);
+		expect(recordMetadata?.displayTime).toEqual("2024-03-15T10:30:00Z");
 		expect(recordMetadata?.displayName).toEqual("test_file.jpg");
 		expect(recordMetadata?.description).toEqual(null);
 		expect(recordMetadata?.tags.length).toEqual(0);
@@ -893,9 +887,7 @@ describe("handler", () => {
 		expect(recordMetadata?.derivedTimestamp).toEqual(
 			new Date("2023-08-20T14:15:30.000Z"),
 		);
-		expect(recordMetadata?.originalFileCreationTime).toEqual(
-			"2023-08-20T14:15:30Z",
-		);
+		expect(recordMetadata?.displayTime).toEqual("2023-08-20T14:15:30Z");
 		expect(recordMetadata?.displayName).toEqual("test_file.jpg");
 		expect(recordMetadata?.description).toEqual(null);
 		expect(recordMetadata?.tags.length).toEqual(0);
@@ -955,9 +947,7 @@ describe("handler", () => {
 		expect(recordMetadata?.derivedTimestamp).toEqual(
 			new Date("2024-05-20T08:45:00.000Z"),
 		);
-		expect(recordMetadata?.originalFileCreationTime).toEqual(
-			"2024-05-20T08:45:00Z",
-		);
+		expect(recordMetadata?.displayTime).toEqual("2024-05-20T08:45:00Z");
 		expect(recordMetadata?.displayName).toEqual("test_file.jpg");
 		expect(recordMetadata?.description).toEqual(null);
 		expect(recordMetadata?.tags.length).toEqual(0);
@@ -1066,7 +1056,7 @@ describe("handler", () => {
 		const recordMetadata = await getRecordMetadata("1");
 		expect(recordMetadata).toBeDefined();
 		expect(recordMetadata?.derivedTimestamp).toEqual(null);
-		expect(recordMetadata?.originalFileCreationTime).toEqual(null);
+		expect(recordMetadata?.displayTime).toEqual(null);
 		expect(recordMetadata?.displayName).toEqual("test_file.jpg");
 		expect(recordMetadata?.description).toEqual(null);
 		expect(recordMetadata?.tags.length).toEqual(0);

--- a/packages/metadata_attacher/src/queries/update_metadata.sql
+++ b/packages/metadata_attacher/src/queries/update_metadata.sql
@@ -72,7 +72,7 @@ SET
 		END,
 	description = COALESCE(description, :descriptionFromEmbeddedMetadata),
 	deriveddt = COALESCE(deriveddt, :timestampFromEmbeddedMetadata),
-	originalfilecreationtime = COALESCE(originalfilecreationtime, :timeFromEmbeddedMetadata),
+	displaytime = COALESCE(displaytime, :timeFromEmbeddedMetadata),
 	alttext = COALESCE(alttext, :altTextFromEmbeddedMetadata)
 WHERE
 	record.recordid = (SELECT recordid FROM record_to_update);


### PR DESCRIPTION
We are renaming record.originalfilecreationtime to record.displaytime, which better reflects its actual meaning. In light of that, this commit updates all stela queries that touch that column to use the new name.