### PR TITLE
Pin node to 24.16.0

### DIFF
--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -1,6 +1,6 @@
 # Monorepo Dockerfile - must be built from repository root:
 #   docker build -f packages/api/Dockerfile .
-FROM node:24-alpine AS builder
+FROM node:24.16.0-alpine AS builder
 WORKDIR /usr/local/apps/stela/
 
 COPY package.json ./
@@ -15,7 +15,7 @@ RUN npm install
 RUN npm install -ws
 RUN npm run build -ws
 
-FROM node:24-alpine AS final
+FROM node:24.16.0-alpine AS final
 
 ARG AWS_RDS_CERT_BUNDLE
 


### PR DESCRIPTION
We might not need this because Node expects to release a fix to the bug in 24.17 today. If we do need it, we think we should revert it later on the grounds that it is extremely rare for Node to release a breaking bug like this in a minor version