### PR TITLE
Update Kubernetes to 1.34

### DIFF
--- a/terraform/prod_cluster/eks-cluster.tf
+++ b/terraform/prod_cluster/eks-cluster.tf
@@ -3,7 +3,7 @@ module "eks" {
   version = "21.2.0"
 
   name               = local.cluster_name
-  kubernetes_version = "1.33"
+  kubernetes_version = "1.34"
 
   vpc_id                 = var.vpc_id
   subnet_ids             = var.subnet_ids

--- a/terraform/test_cluster/eks-cluster.tf
+++ b/terraform/test_cluster/eks-cluster.tf
@@ -3,7 +3,7 @@ module "eks" {
   version = "21.2.0"
 
   name               = local.cluster_name
-  kubernetes_version = "1.33"
+  kubernetes_version = "1.34"
 
   vpc_id                 = var.vpc_id
   subnet_ids             = var.subnet_ids


### PR DESCRIPTION
Kubernetes 1.33 will soon pass out of standard AWS support, so this commit updates our clusters to 1.34.