### PR TITLE
Unpin node version

### DIFF
--- a/packages/api/Dockerfile
+++ b/packages/api/Dockerfile
@@ -1,6 +1,6 @@
 # Monorepo Dockerfile - must be built from repository root:
 #   docker build -f packages/api/Dockerfile .
-FROM node:24.16.0-alpine AS builder
+FROM node:24-alpine AS builder
 WORKDIR /usr/local/apps/stela/
 
 COPY package.json ./
@@ -15,7 +15,7 @@ RUN npm install
 RUN npm install -ws
 RUN npm run build -ws
 
-FROM node:24.16.0-alpine AS final
+FROM node:24-alpine AS final
 
 ARG AWS_RDS_CERT_BUNDLE
 


### PR DESCRIPTION
We recently pinned the Node version in our API server's Dockerfile because of a bug in the latest minor version of Node. That bug has since been fixed, so this commit removes the pin.