### PR TITLE
Per 10309 fix api best practice violations

### DIFF
--- a/packages/api/docs/src/models/item.yaml
+++ b/packages/api/docs/src/models/item.yaml
@@ -1,0 +1,20 @@
+item:
+  oneOf:
+    - allOf:
+      - $ref: "./folder.yaml#/folder"
+      - type: object
+        properties:
+          itemType:
+            type: string
+            enum:
+              - record
+              - folder
+    - allOf:
+      - $ref: "./record.yaml#/record"
+      - type: object
+        properties:
+          itemType:
+            type: string
+            enum:
+              - record
+              - folder

--- a/packages/api/docs/src/models/record.yaml
+++ b/packages/api/docs/src/models/record.yaml
@@ -40,6 +40,7 @@ record:
     Generic Record object
   type: object
   required:
+    - id
     - recordId
     - displayName
     - archiveId
@@ -50,8 +51,11 @@ record:
     - updatedAt
     - archive
   properties:
+    id:
+      type: string
     recordId:
       type: string
+      deprecated: true
     displayName:
       type: string
     archiveId:

--- a/packages/api/docs/src/paths/folder.yaml
+++ b/packages/api/docs/src/paths/folder.yaml
@@ -121,9 +121,7 @@ folders-id-children:
                 items:
                   type: array
                   items:
-                    oneOf:
-                      - $ref: "../models/folder.yaml#/folder"
-                      - $ref: "../models/record.yaml#/record"
+                    $ref: "../models/item.yaml#/item"
                 pagination:
                   $ref: "../models/pagination_metadata.yaml#/pagination"
       "400":

--- a/packages/api/src/folder/controller/get_folder.test.ts
+++ b/packages/api/src/folder/controller/get_folder.test.ts
@@ -197,6 +197,7 @@ describe("GET /folder", () => {
 		expect(folders[0]).toBeDefined();
 		if (folders[0] !== undefined) {
 			expect(folders[0].folderId).toEqual("2");
+			expect(folders[0].id).toEqual("2");
 			expect(folders[0].folderLinkId).toEqual("1");
 			expect(folders[0].archiveNumber).toEqual("0001-0002");
 			expect(folders[0].size).toEqual(0);

--- a/packages/api/src/folder/controller/get_folder_children.test.ts
+++ b/packages/api/src/folder/controller/get_folder_children.test.ts
@@ -69,6 +69,7 @@ describe("GET /folder/{id}/children", () => {
 			expect("folderId" in folder).toBe(true);
 			if ("folderId" in folder) {
 				expect(folder.folderId).toEqual("2");
+				expect(folder.itemType).toEqual("folder");
 				expect(folder.size).toEqual(0);
 				expect(folder.location).toBeDefined();
 				if (folder.location !== undefined) {
@@ -166,6 +167,7 @@ describe("GET /folder/{id}/children", () => {
 			expect("recordId" in record);
 			if ("recordId" in record) {
 				expect(record.recordId).toEqual("8");
+				expect(record.itemType).toEqual("record");
 				expect(record.displayName).toEqual("Public File");
 				expect(record.archiveId).toEqual("1");
 				expect(record.archiveNumber).toEqual("0000-0008");

--- a/packages/api/src/folder/models.ts
+++ b/packages/api/src/folder/models.ts
@@ -3,7 +3,9 @@ import type { Tag } from "../tag/models";
 import type { ArchiveRecord } from "../record/models";
 import type { Location, LocationInput } from "../location/models";
 
-export type FolderChildItem = ArchiveRecord | Folder;
+export type FolderChildItem =
+	| (ArchiveRecord & { itemType: "record" | "folder" })
+	| (Folder & { itemType: "record" | "folder" });
 
 export interface GetFolderChildrenResponse {
 	items: FolderChildItem[];

--- a/packages/api/src/folder/models.ts
+++ b/packages/api/src/folder/models.ts
@@ -18,6 +18,7 @@ export interface GetFolderChildrenResponse {
 
 export interface FolderRow {
 	folderId: string;
+	id: string;
 	archiveNumber: string | null;
 	size: string | null;
 	location?: Location;
@@ -71,6 +72,7 @@ export interface ThumbnailUrls {
 
 export interface Folder {
 	folderId: string;
+	id: string;
 	archiveNumber: string | null;
 	size: number | null;
 	location?: Location;

--- a/packages/api/src/folder/queries/get_folders.sql
+++ b/packages/api/src/folder/queries/get_folders.sql
@@ -213,6 +213,7 @@ account_by_share AS (
 
 SELECT
   folder.folderid AS "folderId",
+  folder.folderid AS id,
   folder.archivenbr AS "archiveNumber",
   folder_size.allfilesizedeep AS size,
   aggregated_shares.folder_shares AS shares,

--- a/packages/api/src/folder/service.ts
+++ b/packages/api/src/folder/service.ts
@@ -177,7 +177,7 @@ export const getFolderChildren = async (
 					? folders.find((folder) => folder.folderId === row.id)
 					: records.find((record) => record.recordId === row.id);
 			if (child !== undefined) {
-				accumulator.push(child);
+				accumulator.push({ ...child, itemType: row.item_type });
 			}
 			return accumulator;
 		},

--- a/packages/api/src/record/controller/get_records.test.ts
+++ b/packages/api/src/record/controller/get_records.test.ts
@@ -268,6 +268,7 @@ describe("GET /records", () => {
 		expect(records.length).toEqual(1);
 		if (record !== undefined) {
 			expect(record).toMatchObject({
+				id: "10008",
 				recordId: "10008",
 				displayName: "Public File",
 				archiveId: "1",

--- a/packages/api/src/record/models.ts
+++ b/packages/api/src/record/models.ts
@@ -4,6 +4,7 @@ import type { Tag } from "../tag/models";
 import type { Location, LocationInput } from "../location/models";
 
 export interface ArchiveRecord {
+	id: string;
 	recordId: string;
 	archiveId: string;
 	displayName: string;
@@ -53,6 +54,7 @@ export interface ArchiveRecord {
 }
 
 export interface ArchiveRecordRow {
+	id: string;
 	recordId: string;
 	archiveId: string;
 	displayName: string;

--- a/packages/api/src/record/queries/get_records.sql
+++ b/packages/api/src/record/queries/get_records.sql
@@ -179,6 +179,7 @@ aggregated_ancestor_unrestricted_share_tokens AS (
 )
 
 SELECT DISTINCT ON (record.recordid)
+  record.recordid AS id,
   record.recordid AS "recordId",
   record.displayname AS "displayName",
   record.archiveid AS "archiveId",


### PR DESCRIPTION
This does two small changes to bring our API closer to compliance with our standards
- add an `id` field to record objects (to replace the stuttering `recordId`, though that's retained for now)
- add an `itemType` field to the items returned by GET /folders/{id}/children (which isn't strictly about following the standard but will make the API more friendly to callers

I'm working on other things as part of this ticket as well, but they're bigger changes so I decided to put up this PR separately.