### PR TITLE
Remove deprecated storageGiftInMB field from transfer ownership calls

### DIFF
--- a/packages/api/src/legacy_client.test.ts
+++ b/packages/api/src/legacy_client.test.ts
@@ -37,7 +37,6 @@ describe("transferArchiveOwnership", () => {
 			archiveSlug,
 			message: testMessage,
 			isLegacyAction: true,
-			storageGiftInMB: 1024,
 		});
 
 		expect(fetch).toHaveBeenCalledWith("/archive/transferOwnership", {
@@ -50,7 +49,6 @@ describe("transferArchiveOwnership", () => {
 			body: JSON.stringify({
 				recipientEmail: testEmail,
 				archiveNbr: archiveSlug,
-				storageGiftInMB: 1024,
 				isLegacyAction: true,
 				message: testMessage,
 			}),
@@ -75,7 +73,6 @@ describe("transferArchiveOwnership", () => {
 			body: JSON.stringify({
 				recipientEmail: testEmail,
 				archiveNbr: archiveSlug,
-				storageGiftInMB: 0,
 				isLegacyAction: false,
 				message: null,
 			}),

--- a/packages/api/src/legacy_client.ts
+++ b/packages/api/src/legacy_client.ts
@@ -8,7 +8,6 @@ const transferArchiveOwnership = async (request: {
 	archiveSlug: string;
 	message?: string;
 	isLegacyAction?: boolean;
-	storageGiftInMB?: number;
 }): Promise<Response> => {
 	const response = await fetch(`${hostUrl}/archive/transferOwnership`, {
 		method: "POST",
@@ -20,7 +19,6 @@ const transferArchiveOwnership = async (request: {
 		body: JSON.stringify({
 			recipientEmail: request.recipientEmail,
 			archiveNbr: request.archiveSlug,
-			storageGiftInMB: request.storageGiftInMB ?? 0,
 			isLegacyAction: request.isLegacyAction ?? false,
 			message: request.message ?? null,
 		}),


### PR DESCRIPTION
The legacy /archive/transferOwnership endpoint has a storageGiftInMB field, which was historically used to send storage alongside archive ownership transfers. This feature is deprecated, and nothing uses it any longer. Thus this commit removes it from the stela APIs client for the legacy API.