### PR TITLE
Add timezone field to record and folder locations

### DIFF
--- a/packages/api/docs/src/models/location.yaml
+++ b/packages/api/docs/src/models/location.yaml
@@ -26,6 +26,8 @@ location:
     precision:
       type: string
       enum: [approximate, uncertain, unknown]
+    timezone:
+      type: string
     streetNumber:
       type: string
       deprecated: true
@@ -78,3 +80,5 @@ locationInput:
     precision:
       type: string
       enum: [approximate, uncertain, unknown]
+    timezone:
+      type: string

--- a/packages/api/src/folder/controller/get_folder_legacy.test.ts
+++ b/packages/api/src/folder/controller/get_folder_legacy.test.ts
@@ -221,6 +221,7 @@ describe("GET /folder (deprecated alias, no pagination)", () => {
 				expect(folders[0].location.county).toEqual("Ile-de-France");
 				expect(folders[0].location.countryCode).toEqual("FR");
 				expect(folders[0].location.displayName).toEqual("Jean Valjean's House");
+				expect(folders[0].location.timezone).toEqual("Europe/Paris");
 			}
 			expect(folders[0].parentFolder?.id).toEqual("10");
 			expect(folders[0].parentFolder?.folderLinkId).toEqual("10");

--- a/packages/api/src/folder/controller/patch_folder.test.ts
+++ b/packages/api/src/folder/controller/patch_folder.test.ts
@@ -6,6 +6,7 @@ import { db } from "../../database";
 import { loadFixtures, clearDatabase } from "./utils_test";
 import { mockVerifyUserAuthentication } from "../../../test/middleware_mocks";
 import { mockSqlCall } from "../../../test/mock_sql";
+import type { Folder } from "../models";
 
 vi.mock("../../database");
 vi.mock("../../middleware");
@@ -165,6 +166,8 @@ describe("patch folder", () => {
 				displayTime: undefined,
 				setDisplayTimeToNull: false,
 				locationId: null,
+				timezone: undefined,
+				setTimezoneToNull: false,
 			},
 			{ reject: testError },
 		);
@@ -213,6 +216,8 @@ describe("patch folder", () => {
 				displayTime: undefined,
 				setDisplayTimeToNull: false,
 				locationId: null,
+				timezone: undefined,
+				setTimezoneToNull: false,
 			},
 			{ resolve: { rows: [] } },
 		);
@@ -269,7 +274,7 @@ describe("patch folder", () => {
 
 	describe("nested location updates", () => {
 		test("expect a nested location to update the existing location row", async () => {
-			await agent
+			const response = await agent
 				.patch("/api/v2/folders/2")
 				.send({
 					location: {
@@ -279,6 +284,7 @@ describe("patch folder", () => {
 						latitude: 45.764,
 						longitude: 4.8357,
 						precision: "approximate",
+						timezone: "Europe/Lyon",
 					},
 				})
 				.expect(200);
@@ -300,6 +306,10 @@ describe("patch folder", () => {
 				longitude: 4.8357,
 				locationprecision: "approximate",
 			});
+			const {
+				body: { data: folder },
+			} = response as { body: { data: Folder } };
+			expect(folder.location?.timezone).toEqual("Europe/Lyon");
 		});
 
 		test("expect a nested location partial update to preserve untouched fields", async () => {
@@ -318,7 +328,7 @@ describe("patch folder", () => {
 		});
 
 		test("expect a nested location to create a new location when folder has none", async () => {
-			await agent
+			const response = await agent
 				.patch("/api/v2/folders/1")
 				.send({
 					location: {
@@ -328,6 +338,7 @@ describe("patch folder", () => {
 						latitude: 43.2965,
 						longitude: 5.3698,
 						precision: "approximate",
+						timezone: "Europe/Marseille",
 					},
 				})
 				.expect(200);
@@ -349,6 +360,10 @@ describe("patch folder", () => {
 				city: "Marseille",
 				country: "France",
 			});
+			const {
+				body: { data: folder },
+			} = response as { body: { data: Folder } };
+			expect(folder.location?.timezone).toEqual("Europe/Marseille");
 		});
 
 		test("expect 400 error if location is an empty object", async () => {
@@ -445,6 +460,17 @@ describe("patch folder", () => {
 				"SELECT locality FROM locn WHERE locnid = 1",
 			);
 			expect(locationResult.rows[0]).toEqual({ locality: "Marseille" });
+		});
+
+		test("expect location.timezone to be set to null if explicitly null in the request", async () => {
+			await agent
+				.patch("/api/v2/folders/2")
+				.send({ location: { timezone: null } })
+				.expect(200);
+			const updatedFolder = await db.query(
+				"SELECT timezone FROM folder WHERE folderid = 2",
+			);
+			expect(updatedFolder.rows[0]).toEqual({ timezone: null });
 		});
 	});
 

--- a/packages/api/src/folder/fixtures/create_test_folders.sql
+++ b/packages/api/src/folder/fixtures/create_test_folders.sql
@@ -23,7 +23,8 @@ folder (
   displaytimelowerbound,
   imageratio,
   sort,
-  view
+  view,
+  timezone
 )
 VALUES
 (
@@ -36,6 +37,7 @@ VALUES
   'status.generic.ok',
   CURRENT_TIMESTAMP - '2 days'::interval,
   'type.folder.public',
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -76,7 +78,8 @@ VALUES
   '2025-01-01',
   1.00,
   'sort.alphabetical_asc',
-  'folder.view.grid'
+  'folder.view.grid',
+  'Europe/Paris'
 ),
 (
   3,
@@ -88,6 +91,7 @@ VALUES
   'status.generic.ok',
   CURRENT_TIMESTAMP,
   'type.folder.private',
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -114,6 +118,7 @@ VALUES
   'status.generic.deleted',
   CURRENT_TIMESTAMP,
   'type.folder.private',
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -154,6 +159,7 @@ VALUES
   NULL,
   NULL,
   NULL,
+  NULL,
   NULL
 ),
 (
@@ -166,6 +172,7 @@ VALUES
   'status.generic.ok',
   CURRENT_TIMESTAMP + '1 day'::interval,
   'type.folder.private',
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -206,6 +213,7 @@ VALUES
   NULL,
   NULL,
   NULL,
+  NULL,
   NULL
 ),
 (
@@ -218,6 +226,7 @@ VALUES
   'status.generic.deleted',
   '2020-01-01 00:00:00',
   'type.folder.private',
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -258,6 +267,7 @@ VALUES
   NULL,
   NULL,
   NULL,
+  NULL,
   NULL
 ),
 (
@@ -284,6 +294,7 @@ VALUES
   NULL,
   NULL,
   'sort.alphabetical_asc',
+  NULL,
   NULL
 ),
 (
@@ -310,6 +321,7 @@ VALUES
   NULL,
   NULL,
   NULL,
+  NULL,
   NULL
 ),
 (
@@ -322,6 +334,7 @@ VALUES
   'status.generic.ok',
   CURRENT_TIMESTAMP,
   'type.folder.private',
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -362,6 +375,7 @@ VALUES
   NULL,
   NULL,
   NULL,
+  NULL,
   NULL
 ),
 (
@@ -374,6 +388,7 @@ VALUES
   'status.generic.ok',
   CURRENT_TIMESTAMP,
   'type.folder.root.root',
+  NULL,
   NULL,
   NULL,
   NULL,
@@ -414,6 +429,7 @@ VALUES
   '2025-01-01',
   NULL,
   NULL,
+  NULL,
   NULL
 ),
 (
@@ -438,6 +454,7 @@ VALUES
   NULL,
   NULL,
   '2020-01-01',
+  NULL,
   NULL,
   NULL,
   NULL

--- a/packages/api/src/folder/queries/get_folders.sql
+++ b/packages/api/src/folder/queries/get_folders.sql
@@ -286,7 +286,9 @@ all_folders AS (
       'countryCode',
       locn.countrycode,
       'displayName',
-      locn.displayname
+      locn.displayname,
+      'timezone',
+      folder.timezone
     ) AS location,
     CASE
       WHEN folder_link.parentfolderid IS NOT NULL

--- a/packages/api/src/folder/queries/update_folder.sql
+++ b/packages/api/src/folder/queries/update_folder.sql
@@ -13,6 +13,10 @@ SET
     WHEN :setDisplayTimeToNull THEN NULL
     ELSE COALESCE(:displayTime, displaytime)
   END,
+  timezone = CASE
+    WHEN :setTimezoneToNull THEN NULL
+    ELSE COALESCE(:timezone, timezone)
+  END,
   locnid = COALESCE(:locationId::bigint, locnid),
   updateddt = CURRENT_TIMESTAMP
 WHERE

--- a/packages/api/src/folder/service.ts
+++ b/packages/api/src/folder/service.ts
@@ -330,6 +330,8 @@ export const patchFolder = async (
 				setDisplayEndDateToNull: folderData.displayEndDate === null,
 				displayTime: folderData.displayTime,
 				setDisplayTimeToNull: folderData.displayTime === null,
+				timezone: folderData.location?.timezone,
+				setTimezoneToNull: folderData.location?.timezone === null,
 				locationId,
 			})
 			.catch((err: unknown) => {

--- a/packages/api/src/location/models.ts
+++ b/packages/api/src/location/models.ts
@@ -11,6 +11,7 @@ export interface LocationInput {
 	longitude?: number;
 	altitudeMeters?: number;
 	precision?: LocationPrecision;
+	timezone?: string | null;
 }
 
 export interface Location extends LocationInput {

--- a/packages/api/src/location/validators.ts
+++ b/packages/api/src/location/validators.ts
@@ -19,5 +19,6 @@ export const locationInputSchema = Joi.object()
 		precision: Joi.string()
 			.valid("approximate", "uncertain", "unknown")
 			.optional(),
+		timezone: Joi.string().optional().allow(null),
 	})
 	.min(1);

--- a/packages/api/src/record/controller/copy_record.test.ts
+++ b/packages/api/src/record/controller/copy_record.test.ts
@@ -142,6 +142,17 @@ describe("POST /record/{recordId}/copies", () => {
 		expect(record.displayName).toEqual("Public File");
 	});
 
+	test("expect copied record to retain the original record's timezone", async () => {
+		const response = await agent
+			.post("/api/v2/records/10008/copies")
+			.send({ destinationFolderId: "34" })
+			.expect(200);
+		const {
+			body: { data: record },
+		} = response as { body: { data: ArchiveRecord } };
+		expect(record.location.timezone).toEqual("Europe/Paris");
+	});
+
 	test("expect 403 if copying to public workspace without manager role", async () => {
 		// test+1@permanent.org is viewer in archive 1, which is below manager.
 		// Folder 1 is type.folder.public in archive 1 and requires manager role.

--- a/packages/api/src/record/controller/get_record_legacy.test.ts
+++ b/packages/api/src/record/controller/get_record_legacy.test.ts
@@ -321,6 +321,7 @@ describe("GET /record (deprecated alias, no pagination)", () => {
 					county: "Ile-de-France",
 					countryCode: "FR",
 					displayName: "Jean Valjean's House",
+					timezone: "Europe/Paris",
 				},
 				files: [
 					{

--- a/packages/api/src/record/controller/update_record.test.ts
+++ b/packages/api/src/record/controller/update_record.test.ts
@@ -260,6 +260,8 @@ describe("PATCH /records", () => {
 				setDescriptionToNull: false,
 				displayTime: undefined,
 				setDisplayTimeToNull: false,
+				timezone: undefined,
+				setTimezoneToNull: false,
 			})
 			.thenReject(testError);
 
@@ -320,6 +322,8 @@ describe("PATCH /records", () => {
 				setDescriptionToNull: false,
 				displayTime: undefined,
 				setDisplayTimeToNull: false,
+				timezone: undefined,
+				setTimezoneToNull: false,
 			})
 			.thenDo(vi.fn().mockResolvedValue({ rows: [] }));
 
@@ -416,7 +420,7 @@ describe("PATCH /records", () => {
 	});
 
 	test("expect a nested location to update the existing location row", async () => {
-		await agent
+		const response = await agent
 			.patch("/api/v2/records/10008")
 			.send({
 				location: {
@@ -426,6 +430,7 @@ describe("PATCH /records", () => {
 					latitude: 45.764,
 					longitude: 4.8357,
 					precision: "approximate",
+					timezone: "Europe/Lyon",
 				},
 			})
 			.expect(200);
@@ -447,6 +452,11 @@ describe("PATCH /records", () => {
 			longitude: 4.8357,
 			locationprecision: "approximate",
 		});
+
+		const {
+			body: { data: record },
+		} = response as { body: { data: ArchiveRecord } };
+		expect(record.location.timezone).toEqual("Europe/Lyon");
 	});
 
 	test("expect a nested location partial update to preserve untouched fields", async () => {
@@ -465,7 +475,7 @@ describe("PATCH /records", () => {
 	});
 
 	test("expect a nested location to create a new location when record has none", async () => {
-		await agent
+		const response = await agent
 			.patch("/api/v2/records/10001")
 			.send({
 				location: {
@@ -475,6 +485,7 @@ describe("PATCH /records", () => {
 					latitude: 43.2965,
 					longitude: 5.3698,
 					precision: "approximate",
+					timezone: "Europe/Marseille",
 				},
 			})
 			.expect(200);
@@ -496,6 +507,11 @@ describe("PATCH /records", () => {
 			city: "Marseille",
 			country: "France",
 		});
+
+		const {
+			body: { data: record },
+		} = response as { body: { data: ArchiveRecord } };
+		expect(record.location.timezone).toEqual("Europe/Marseille");
 	});
 
 	test("expect 400 error if location and locationId are both provided", async () => {
@@ -544,5 +560,16 @@ describe("PATCH /records", () => {
 			.expect(500);
 
 		expect(logger.error).toHaveBeenCalledWith(testError);
+	});
+
+	test("expect location.timezone to be set to null if explicitly null in the request", async () => {
+		await agent
+			.patch("/api/v2/records/10008")
+			.send({ location: { timezone: null } })
+			.expect(200);
+		const updatedRecord = await db.query(
+			"SELECT timezone FROM record WHERE recordid = 10008",
+		);
+		expect(updatedRecord.rows[0]).toEqual({ timezone: null });
 	});
 });

--- a/packages/api/src/record/fixtures/create_complete_test_record.sql
+++ b/packages/api/src/record/fixtures/create_complete_test_record.sql
@@ -25,7 +25,8 @@ record (
   updateddt,
   alttext,
   locnid,
-  displaytime
+  displaytime,
+  timezone
 )
 VALUES
 (
@@ -54,5 +55,6 @@ VALUES
   '2023-06-21T00:00:00.000Z',
   'An image',
   1,
-  '1985-04-12T23:20:30Z'
+  '1985-04-12T23:20:30Z',
+  'Europe/Paris'
 );

--- a/packages/api/src/record/queries/copy_record.sql
+++ b/packages/api/src/record/queries/copy_record.sql
@@ -152,7 +152,8 @@ new_record AS (
     updateddt,
     uploadpayeraccountid,
     alttext,
-    displaytime
+    displaytime,
+    timezone
   )
   SELECT
     :destinationArchiveId AS archiveid,
@@ -220,7 +221,8 @@ new_record AS (
       (SELECT copier_account.accountid FROM copier_account)
     ) AS uploadpayeraccountid,
     alttext,
-    displaytime
+    displaytime,
+    timezone
   FROM
     record
   WHERE

--- a/packages/api/src/record/queries/get_records.sql
+++ b/packages/api/src/record/queries/get_records.sql
@@ -278,7 +278,9 @@ all_records AS (
       'countryCode',
       locn.countrycode,
       'displayName',
-      locn.displayname
+      locn.displayname,
+      'timezone',
+      record.timezone
     ) AS location,
     JSON_BUILD_OBJECT(
       'id',

--- a/packages/api/src/record/queries/update_record.sql
+++ b/packages/api/src/record/queries/update_record.sql
@@ -14,6 +14,10 @@ SET
     WHEN :setDisplayTimeToNull THEN NULL
     ELSE COALESCE(:displayTime, displaytime)
   END,
+  timezone = CASE
+    WHEN :setTimezoneToNull THEN NULL
+    ELSE COALESCE(:timezone, timezone)
+  END,
   updateddt = CURRENT_TIMESTAMP
 WHERE
   recordid = :recordId

--- a/packages/api/src/record/service.ts
+++ b/packages/api/src/record/service.ts
@@ -205,6 +205,8 @@ export const patchRecord = async (
 				setDescriptionToNull: recordData.description === null,
 				displayTime: recordData.displayTime,
 				setDisplayTimeToNull: recordData.displayTime === null,
+				timezone: recordData.location?.timezone,
+				setTimezoneToNull: recordData.location?.timezone === null,
 			})
 			.catch((err: unknown) => {
 				logger.error(err);


### PR DESCRIPTION
The displayTime field of a record or folder tracks the offset associated with that time, but not a specific timezone. This commit adds a timezone field to record and folder locations, since we treat timezone as location metadata (offset is all you need to know to express time accurately; a timezone is a place).