### PR TITLE
Add documentation for planned dashboard 2030 endpoints

### DIFF
--- a/packages/api/docs/src/api.yaml
+++ b/packages/api/docs/src/api.yaml
@@ -44,6 +44,12 @@ paths:
     $ref: "./paths/mfa_management.yaml#/mfa-method-with-id"
   /accounts:
     $ref: "./paths/account.yaml#/account"
+  /accounts/me:
+    $ref: "./paths/account.yaml#/accounts~1me"
+  /accounts/me/marketing-tags:
+    $ref: "./paths/account.yaml#/accounts~1me~1marketing-tags"
+  /accounts/me/promo-claim:
+    $ref: "./paths/account.yaml#/accounts~1me~1promo-claim"
   /accounts/{id}/storage-adjustments:
     $ref: "./paths/account.yaml#/storage-adjustment"
   /share-links:
@@ -72,6 +78,8 @@ paths:
     $ref: "./paths/archive.yaml#/archives~1{id}"
   /archives/{id}/folders/shared:
     $ref: "./paths/archive.yaml#/archives-id-folders-shared"
+  /archive-memberships/{id}:
+    $ref: "./paths/archive_membership.yaml#/archive-memberships~1{id}"
   /applications:
     $ref: "./paths/application.yaml#/applications"
   /applications/{id}:

--- a/packages/api/docs/src/models/account.yaml
+++ b/packages/api/docs/src/models/account.yaml
@@ -106,3 +106,13 @@ account:
               $ref: "#/notificationTypesEnabled"
             inApp:
               $ref: "#/notificationTypesEnabled"
+    archiveMemberships:
+      type: array
+      items:
+        $ref: "./archive_membership.yaml#/archiveMembership"
+    createdAt:
+      type: string
+      format: date-time
+    updatedAt:
+      type: string
+      format: date-time

--- a/packages/api/docs/src/models/archive.yaml
+++ b/packages/api/docs/src/models/archive.yaml
@@ -2,6 +2,7 @@ archive:
   description: Archive object
   type: object
   required:
+    - id
     - archiveId
     - rootFolderId
     - name
@@ -13,8 +14,11 @@ archive:
     - createdAt
     - updatedAt
   properties:
+    id:
+      type: string
     archiveId:
       type: string
+      deprecated: true
     rootFolderId:
       type: string
     description:
@@ -60,8 +64,13 @@ archive:
       $ref: "./archive_membership_role.yaml#/archiveMembershipRole"
     status:
       type: string
+      enum:
+        - ok
+        - orphaned
+        - deleted
+        - generate-avatar
     type:
-      type: string
+      $ref: "./archive_type.yaml#/archiveType"
     createdAt:
       type: string
       format: date-time
@@ -73,3 +82,26 @@ archive:
       enum:
         - chronological
         - reverse_chronological
+archiveSummary:
+  description: A minimal, summary version of an archive object
+  type: object
+  required:
+    - id
+    - name
+    - thumbnailUrls
+  properties:
+    id:
+      type: string
+    name:
+      type: string
+    thumbnailUrls:
+      type: object
+      properties:
+        width200:
+          type: string
+        width500:
+          type: string
+        width1000:
+          type: string
+        width2000:
+          type: string

--- a/packages/api/docs/src/models/archive_membership.yaml
+++ b/packages/api/docs/src/models/archive_membership.yaml
@@ -1,0 +1,18 @@
+archiveMembership:
+  description: A membership relation granting an account some level of access to an archive
+  type: object
+  required: [id, accountId, archive, accessRole, status]
+  properties:
+    id:
+      type: string
+    accountId:
+      type: string
+    archive:
+      $ref: "./archive.yaml#/archiveSummary"
+    accessRole:
+      $ref: "./archive_membership_role.yaml#/archiveMembershipRole"
+    status:
+      type: string
+      enum:
+        - ok
+        - pending

--- a/packages/api/docs/src/models/archive_type.yaml
+++ b/packages/api/docs/src/models/archive_type.yaml
@@ -1,0 +1,6 @@
+archiveType:
+  type: string
+  enum:
+    - person
+    - group
+    - organization

--- a/packages/api/docs/src/models/folder.yaml
+++ b/packages/api/docs/src/models/folder.yaml
@@ -43,7 +43,7 @@ folder:
     shares:
       type: array
       items:
-        $ref: "../models/share.yaml#/share"
+        $ref: "../models/share.yaml#/shareSummary"
     pendingShares:
       nullable: true
       type: array

--- a/packages/api/docs/src/models/share.yaml
+++ b/packages/api/docs/src/models/share.yaml
@@ -1,6 +1,6 @@
-share:
+shareSummary:
   description: >
-    Share Object
+    Share Object Summary
   type: object
   properties:
     id:

--- a/packages/api/docs/src/paths/account.yaml
+++ b/packages/api/docs/src/paths/account.yaml
@@ -149,3 +149,133 @@ storage-adjustment:
         $ref: "../errors.yaml#/404"
       "500":
         $ref: "../errors.yaml#/500"
+accounts/me:
+  get:
+    summary: Get the currently authenticated account.
+    operationId: get-accounts-me
+    security:
+      - bearerHttpAuthentication: []
+    tags:
+      - accounts
+      - unimplemented
+    responses:
+      "200":
+        description: >
+          The account authenticated by the bearer token.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                data:
+                  $ref: "../models/account.yaml#/account"
+      "401":
+        $ref: "../errors.yaml#/401"
+      "500":
+        $ref: "../errors.yaml#/500"
+accounts/me/marketing-tags:
+  post:
+    summary: Add marketing tags to the authenticated account
+    operationId: post-accounts-me-marketing-tags
+    security:
+      - bearerHttpAuthentication: []
+    tags:
+      - accounts
+      - unimplemented
+    requestBody:
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [tags]
+            properties:
+              tags:
+                type: array
+                items:
+                  type: string
+    responses:
+      "200":
+        description: >
+          The marketing tags of the account authenticated by the bearer token.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                items:
+                  type: array
+                  items:
+                    type: string
+      "401":
+        $ref: "../errors.yaml#/401"
+      "400":
+        $ref: "../errors.yaml#/400"
+      "500":
+        $ref: "../errors.yaml#/500"
+  get:
+    summary: Get the marketing tags of the authenticated account
+    operationId: get-accounts-me-marketing-tags
+    security:
+      - bearerHttpAuthentication: []
+    tags:
+      - accounts
+      - unimplemented
+    responses:
+      "200":
+        description: >
+          The marketing tags of the account authenticated by the bearer token.
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                items:
+                  type: array
+                  items:
+                    type: string
+      "401":
+        $ref: "../errors.yaml#/401"
+      "500":
+        $ref: "../errors.yaml#/500"
+accounts/me/promo-claim:
+  post:
+    summary: Claim a promo code for the authenticated account
+    operationId: post-accounts-me-promo-claim
+    security:
+      - bearerHttpAuthentication: []
+    tags:
+      - accounts
+      - promo
+      - unimplemented
+    requestBody:
+      content:
+        application/json:
+          schema:
+            type: object
+            required: [promoCode]
+            properties:
+              promoCode:
+                type: string
+    responses:
+      "200":
+        description: >
+          The amount of storage granted by the promo code in GB
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                data:
+                  type: object
+                  required: [storageGrantInGb]
+                  properties:
+                    storageGrantInGb:
+                      type: integer
+      "401":
+        $ref: "../errors.yaml#/401"
+      "403":
+        $ref: "../errors.yaml#/403"
+      "400":
+        $ref: "../errors.yaml#/400"
+      "500":
+        $ref: "../errors.yaml#/500"

--- a/packages/api/docs/src/paths/archive.yaml
+++ b/packages/api/docs/src/paths/archive.yaml
@@ -67,15 +67,69 @@ archives:
         $ref: "../errors.yaml#/401"
       "500":
         $ref: "../errors.yaml#/500"
+  post:
+    summary: Create an archive
+    security:
+      - bearerHttpAuthentication: []
+    tags:
+      - archives
+      - unimplemented
+    operationId: post-archives
+    requestBody:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              name:
+                type: string
+              type:
+                $ref: "../models/archive_type.yaml#/archiveType"
+    responses:
+      "200":
+        description: The created archive
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                data:
+                  $ref: "../models/archive.yaml#/archive"
+      "400":
+        $ref: "../errors.yaml#/400"
+      "500":
+        $ref: "../errors.yaml#/500"
 archives/{id}:
+  parameters:
+    - name: id
+      in: path
+      required: true
+      schema:
+        type: string
+  get:
+    summary: Get an archive
+    security:
+      - bearerHttpAuthentication: []
+    tags:
+      - archives
+      - unimplemented
+    operationId: get-archives-id
+    responses:
+      "200":
+        description: The requested archive
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                data:
+                  $ref: "../models/archive.yaml#/archive"
+      "400":
+        $ref: "../errors.yaml#/400"
+      "500":
+        $ref: "../errors.yaml#/500"
   patch:
     summary: Update an archive
-    parameters:
-      - name: id
-        in: path
-        required: true
-        schema:
-          type: integer
     security:
       - bearerHttpAuthentication: []
     tags:

--- a/packages/api/docs/src/paths/archive_membership.yaml
+++ b/packages/api/docs/src/paths/archive_membership.yaml
@@ -1,0 +1,50 @@
+archive-memberships/{id}:
+  parameters:
+    - name: id
+      in: path
+      required: true
+      schema:
+        type: string
+  patch:
+    summary: Update an archive membership
+    description: |
+      Updateable fields of an archive membership are accessRole and status.
+      accessRole can only be updated by a Manager or Owner of the archive involved
+      in the membership. status can only be set to "ok" by the account involved in
+      the membership. It can be set to "deleted" by either that account or a Manager
+      or Owner of the archive.
+    security:
+      - bearerHttpAuthentication: []
+    tags:
+      - archive-membership
+      - unimplemented
+    operationId: patch-archive-membership
+    requestBody:
+      content:
+        application/json:
+          schema:
+            type: object
+            properties:
+              accessRole:
+                $ref: "../models/archive_membership_role.yaml#/archiveMembershipRole"
+              status:
+                type: string
+                enum:
+                  - ok
+                  - deleted
+    responses:
+      "200":
+        description: The updated archive membership
+        content:
+          application/json:
+            schema:
+              type: object
+              properties:
+                data:
+                  $ref: "../models/archive_membership.yaml#/archiveMembership"
+      "400":
+        $ref: "../errors.yaml#/400"
+      "401":
+        $ref: "../errors.yaml#/401"
+      "500":
+        $ref: "../errors.yaml#/500"


### PR DESCRIPTION
This commit adds the specifications for the new and updated endpoints required to implement the dashboard from our Vision 2030 designs. These endpoints are
- GET /accounts/me
- GET /accounts/me/marketing-tags
- POST /accounts/me/marketing-tags
- POST /archives
- GET /archives/{id}
- PATCH /archive-memberships/{id}
- POST /accounts/me/promo-claim