### PR TITLE
Implement POST /accounts/me/marketings_tags endpoint

### DIFF
--- a/packages/api/docs/src/paths/account.yaml
+++ b/packages/api/docs/src/paths/account.yaml
@@ -190,6 +190,7 @@ accounts/me/marketing-tags:
             properties:
               tags:
                 type: array
+                minItems: 1
                 items:
                   type: string
     responses:

--- a/packages/api/src/account/controller/controller.ts
+++ b/packages/api/src/account/controller/controller.ts
@@ -9,6 +9,7 @@ import {
 } from "../../middleware/index.js";
 import {
 	validateUpdateTagsRequest,
+	validatePostMarketingTagsRequest,
 	validateBodyFromAuthentication,
 	validateBodyFromAdminAuthentication,
 	validateLeaveArchiveParams,
@@ -97,6 +98,19 @@ accountController.delete(
 			await accountService.leaveArchive(data);
 
 			res.status(HTTP_STATUS.SUCCESSFUL.NO_CONTENT).send();
+		} catch (err) {
+			next(err);
+		}
+	},
+);
+accountController.post(
+	"/me/marketing-tags",
+	verifyUserAuthentication,
+	async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+		try {
+			validatePostMarketingTagsRequest(req.body);
+			const result = await accountService.postMarketingTags(req.body);
+			res.json(result);
 		} catch (err) {
 			next(err);
 		}

--- a/packages/api/src/account/controller/get_marketing_tags.test.ts
+++ b/packages/api/src/account/controller/get_marketing_tags.test.ts
@@ -31,6 +31,7 @@ describe("getMarketingTags", () => {
 				{ id: 1, name: "tag1", date_added: "2024-01-01" },
 				{ id: 2, name: "tag2", date_added: "2024-01-02" },
 			],
+			total_items: 2,
 		});
 
 		const response = await agent
@@ -47,6 +48,7 @@ describe("getMarketingTags", () => {
 	test("should return an empty list when the account has no tags", async () => {
 		vi.mocked(MailchimpMarketing.lists.getListMemberTags).mockResolvedValue({
 			tags: [],
+			total_items: 0,
 		});
 
 		const response = await agent

--- a/packages/api/src/account/controller/post_marketing_tags.test.ts
+++ b/packages/api/src/account/controller/post_marketing_tags.test.ts
@@ -1,0 +1,160 @@
+import request from "supertest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { Md5 } from "ts-md5";
+import { app } from "../../app.js";
+import { MailchimpMarketing } from "../../mailchimp.js";
+import { mockVerifyUserAuthentication } from "../../../test/middleware_mocks.js";
+
+vi.mock("../../mailchimp", () => ({
+	MailchimpMarketing: {
+		lists: {
+			updateListMemberTags: vi.fn(),
+			getListMemberTags: vi.fn(),
+		},
+	},
+}));
+vi.mock("../../middleware");
+
+describe("postMarketingTags", () => {
+	const agent = request.agent(app);
+	const testEmail = "test@permanent.org";
+	const testUserSubject = "b5461dc2-1eb0-450e-b710-fef7b2cafe1e";
+	const listId = process.env["MAILCHIMP_COMMUNITY_LIST_ID"] ?? "";
+	const subscriberHash = Md5.hashStr(testEmail);
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockVerifyUserAuthentication(testEmail, testUserSubject);
+	});
+
+	test("should add tags and return the current tag list", async () => {
+		vi.mocked(MailchimpMarketing.lists.updateListMemberTags).mockResolvedValue(
+			null,
+		);
+		vi.mocked(MailchimpMarketing.lists.getListMemberTags).mockResolvedValue({
+			tags: [
+				{ id: 1, name: "tag1", date_added: "2024-01-01 00:00:00" },
+				{ id: 2, name: "tag2", date_added: "2024-01-01 00:00:00" },
+			],
+			total_items: 2,
+		});
+
+		const response = await agent
+			.post("/api/v2/accounts/me/marketing-tags")
+			.send({
+				emailFromAuthToken: testEmail,
+				userSubjectFromAuthToken: testUserSubject,
+				tags: ["tag1", "tag2"],
+			})
+			.expect(200);
+
+		expect(MailchimpMarketing.lists.updateListMemberTags).toHaveBeenCalledWith(
+			listId,
+			subscriberHash,
+			{
+				tags: [
+					{ name: "tag1", status: "active" },
+					{ name: "tag2", status: "active" },
+				],
+			},
+		);
+		expect(MailchimpMarketing.lists.getListMemberTags).toHaveBeenCalledWith(
+			listId,
+			subscriberHash,
+		);
+		expect(response.body).toEqual({ items: ["tag1", "tag2"] });
+	});
+
+	test("should return a 400 error if the caller tries to add 0 tags", async () => {
+		await agent
+			.post("/api/v2/accounts/me/marketing-tags")
+			.send({
+				emailFromAuthToken: testEmail,
+				userSubjectFromAuthToken: testUserSubject,
+				tags: [],
+			})
+			.expect(400);
+	});
+
+	test("should return an error if updateListMemberTags fails", async () => {
+		vi.mocked(MailchimpMarketing.lists.updateListMemberTags).mockRejectedValue({
+			status: 500,
+		});
+
+		await agent
+			.post("/api/v2/accounts/me/marketing-tags")
+			.send({
+				emailFromAuthToken: testEmail,
+				userSubjectFromAuthToken: testUserSubject,
+				tags: ["tag1"],
+			})
+			.expect(500);
+
+		expect(MailchimpMarketing.lists.getListMemberTags).not.toHaveBeenCalled();
+	});
+
+	test("should return an error if getListMemberTags fails", async () => {
+		vi.mocked(MailchimpMarketing.lists.updateListMemberTags).mockResolvedValue(
+			null,
+		);
+		vi.mocked(MailchimpMarketing.lists.getListMemberTags).mockRejectedValue({
+			status: 404,
+			response: {
+				body: {
+					detail: "Member not found",
+					status: 404,
+					type: "",
+					title: "",
+					instance: "",
+				},
+			},
+		});
+
+		await agent
+			.post("/api/v2/accounts/me/marketing-tags")
+			.send({
+				emailFromAuthToken: testEmail,
+				userSubjectFromAuthToken: testUserSubject,
+				tags: ["tag1"],
+			})
+			.expect(404);
+	});
+
+	test("should default to a 500 error if the error from Mailchimp has no status", async () => {
+		vi.mocked(MailchimpMarketing.lists.updateListMemberTags).mockRejectedValue({
+			error: "Out of cheese - redo from start",
+		});
+
+		await agent
+			.post("/api/v2/accounts/me/marketing-tags")
+			.send({
+				emailFromAuthToken: testEmail,
+				userSubjectFromAuthToken: testUserSubject,
+				tags: ["tag1"],
+			})
+			.expect(500);
+
+		expect(MailchimpMarketing.lists.getListMemberTags).not.toHaveBeenCalled();
+	});
+
+	test("should return a bad request error if tags is missing", async () => {
+		await agent
+			.post("/api/v2/accounts/me/marketing-tags")
+			.send({
+				emailFromAuthToken: testEmail,
+				userSubjectFromAuthToken: testUserSubject,
+			})
+			.expect(400);
+	});
+
+	test("should return a bad request error if tags contains non-strings", async () => {
+		await agent
+			.post("/api/v2/accounts/me/marketing-tags")
+			.send({
+				emailFromAuthToken: testEmail,
+				userSubjectFromAuthToken: testUserSubject,
+				tags: [1, 2, 3],
+			})
+			.expect(400);
+	});
+});

--- a/packages/api/src/account/controller/update_tags.test.ts
+++ b/packages/api/src/account/controller/update_tags.test.ts
@@ -57,12 +57,45 @@ describe("updateTags", () => {
 	});
 
 	test("should throw an error if MailChimp call fails", async () => {
-		vi.mocked(MailchimpMarketing.lists.updateListMemberTags).mockResolvedValue({
-			detail: "Out of Cheese - Redo from Start",
+		vi.mocked(MailchimpMarketing.lists.updateListMemberTags).mockRejectedValue({
 			status: 500,
-			type: "",
-			title: "",
-			instance: "",
+			response: {
+				body: {
+					detail: "Out of Cheese - Redo from Start",
+					status: 500,
+					type: "",
+					title: "",
+					instance: "",
+				},
+			},
+		});
+		await agent
+			.put("/api/v2/accounts/tags")
+			.send({
+				emailFromAuthToken: "test@permanent.org",
+				addTags: ["tag1", "tag2"],
+				removeTags: ["tag3", "tag4"],
+			})
+			.expect(500);
+	});
+
+	test("should use the error's status even if the received error response is empty", async () => {
+		vi.mocked(MailchimpMarketing.lists.updateListMemberTags).mockRejectedValue({
+			status: 418,
+		});
+		await agent
+			.put("/api/v2/accounts/tags")
+			.send({
+				emailFromAuthToken: "test@permanent.org",
+				addTags: ["tag1", "tag2"],
+				removeTags: ["tag3", "tag4"],
+			})
+			.expect(418);
+	});
+
+	test("should default to a 500 error if the error from Mailchimp has no status", async () => {
+		vi.mocked(MailchimpMarketing.lists.updateListMemberTags).mockRejectedValue({
+			error: "Out of cheese - redo from start",
 		});
 		await agent
 			.put("/api/v2/accounts/tags")

--- a/packages/api/src/account/models.ts
+++ b/packages/api/src/account/models.ts
@@ -105,6 +105,12 @@ export interface GetMarketingTagsResponse {
 	items: string[];
 }
 
+export interface PostMarketingTagsRequest {
+	emailFromAuthToken: string;
+	userSubjectFromAuthToken: string;
+	tags: string[];
+}
+
 export interface SignupDetails {
 	token: string;
 }

--- a/packages/api/src/account/service.ts
+++ b/packages/api/src/account/service.ts
@@ -1,8 +1,8 @@
 import { Md5 } from "ts-md5";
 import createError from "http-errors";
 import { HTTP_STATUS } from "@pdc/http-status-codes";
-import { logger } from "@stela/logger";
 import type { ErrorResponse } from "@mailchimp/mailchimp_marketing";
+import { logger } from "@stela/logger";
 
 import { db } from "../database.js";
 import { MailchimpMarketing } from "../mailchimp.js";
@@ -13,6 +13,7 @@ import type { CreateEventRequest } from "../event/models.js";
 import {
 	type UpdateTagsRequest,
 	type GetMarketingTagsResponse,
+	type PostMarketingTagsRequest,
 	type SignupDetails,
 	type GetAccountArchiveResult,
 	type LeaveArchiveRequest,
@@ -85,6 +86,18 @@ const accountRowToAccount = (row: AccountRow): Account => ({
 	type: prettifyAccountType(row.type),
 });
 
+interface MailchimpApiError {
+	status: number;
+	response?: {
+		body: ErrorResponse;
+	};
+}
+
+const isMailchimpApiError = (err: unknown): err is MailchimpApiError =>
+	err instanceof Object &&
+	"status" in err &&
+	typeof (err as { status: unknown }).status === "number";
+
 export const getAccounts = async (
 	query: GetAccountsQuery,
 ): Promise<GetAccountsResponse> => {
@@ -143,28 +156,52 @@ const updateTags = async (requestBody: UpdateTagsRequest): Promise<void> => {
 			),
 		);
 
-	const response = await MailchimpMarketing.lists.updateListMemberTags(
-		process.env["MAILCHIMP_COMMUNITY_LIST_ID"] ?? "",
-		Md5.hashStr(requestBody.emailFromAuthToken),
-		{ tags },
-	);
-
-	if (response !== null) {
-		throw createError(response.status, response.detail);
+	try {
+		await MailchimpMarketing.lists.updateListMemberTags(
+			process.env["MAILCHIMP_COMMUNITY_LIST_ID"] ?? "",
+			Md5.hashStr(requestBody.emailFromAuthToken),
+			{ tags },
+		);
+	} catch (err) {
+		if (isMailchimpApiError(err)) {
+			throw err.response === undefined
+				? createError(err.status)
+				: createError(err.status, err.response.body.detail);
+		}
+		throw err;
 	}
 };
 
-interface MailchimpApiError {
-	status: number;
-	response?: {
-		body: ErrorResponse;
-	};
-}
+const postMarketingTags = async (
+	requestBody: PostMarketingTagsRequest,
+): Promise<{ items: string[] }> => {
+	const subscriberHash = Md5.hashStr(requestBody.emailFromAuthToken);
+	const listId = process.env["MAILCHIMP_COMMUNITY_LIST_ID"] ?? "";
 
-const isMailchimpApiError = (err: unknown): err is MailchimpApiError =>
-	err instanceof Object &&
-	"status" in err &&
-	typeof (err as { status: unknown }).status === "number";
+	try {
+		await MailchimpMarketing.lists.updateListMemberTags(
+			listId,
+			subscriberHash,
+			{
+				tags: requestBody.tags.map((tag) => ({ name: tag, status: "active" })),
+			},
+		);
+
+		const tagsResponse = await MailchimpMarketing.lists.getListMemberTags(
+			listId,
+			subscriberHash,
+		);
+
+		return { items: tagsResponse.tags.map((tag) => tag.name) };
+	} catch (err) {
+		if (isMailchimpApiError(err)) {
+			throw err.response === undefined
+				? createError(err.status)
+				: createError(err.status, err.response.body.detail);
+		}
+		throw err;
+	}
+};
 
 const getMarketingTags = async (requestBody: {
 	emailFromAuthToken: string;
@@ -298,6 +335,7 @@ export const accountService = {
 	leaveArchive,
 	updateTags,
 	getMarketingTags,
+	postMarketingTags,
 	getAccountArchive,
 };
 

--- a/packages/api/src/account/validators.ts
+++ b/packages/api/src/account/validators.ts
@@ -1,6 +1,7 @@
 import Joi from "joi";
 import type {
 	CreateStorageAdjustmentRequest,
+	PostMarketingTagsRequest,
 	UpdateTagsRequest,
 	GetAccountsQuery,
 } from "./models.js";
@@ -108,6 +109,22 @@ export const validateGetAccountsQuery: (
 				.optional(),
 		})
 		.xor("accountIds", "accountEmails")
+		.validate(data);
+	if (validation.error !== undefined) {
+		throw validation.error;
+	}
+};
+
+export const validatePostMarketingTagsRequest: (
+	data: unknown,
+) => asserts data is PostMarketingTagsRequest = (
+	data: unknown,
+): asserts data is PostMarketingTagsRequest => {
+	const validation = Joi.object()
+		.keys({
+			...fieldsFromUserAuthentication,
+			tags: Joi.array().items(Joi.string()).min(1).required(),
+		})
 		.validate(data);
 	if (validation.error !== undefined) {
 		throw validation.error;

--- a/packages/api/src/types/mailchimp_marketing.d.ts
+++ b/packages/api/src/types/mailchimp_marketing.d.ts
@@ -13,18 +13,20 @@ declare module "@mailchimp/mailchimp_marketing" {
 		instance: string;
 	}
 
+	export interface MemberTagsResponse {
+		tags: Array<{ id: number; name: string; date_added: string }>;
+		total_items: number;
+	}
+
 	export namespace lists {
 		export function updateListMemberTags(
 			listId: string,
 			subscriberHash: string,
 			body: { tags: Array<{ name: string; status: "active" | "inactive" }> },
-		): Promise<ErrorResponse | null>;
-
+		): Promise<null>;
 		export function getListMemberTags(
 			listId: string,
 			subscriberHash: string,
-		): Promise<{
-			tags: Array<{ id: number; name: string; date_added: string }>;
-		}>;
+		): Promise<MemberTagsResponse>;
 	}
 }


### PR DESCRIPTION
In the Vision 2030 dashboard, we want to have a widget where users can express their goals for their use of Permanent. We store these are Mailchimp tags, so this commit adds an endpoint to store the user's selections in Mailchimp.