### PR TITLE
Add GET /accounts/me/marketing-tags endpoint

### DIFF
--- a/packages/api/docs/src/paths/account.yaml
+++ b/packages/api/docs/src/paths/account.yaml
@@ -181,7 +181,6 @@ accounts/me/marketing-tags:
       - bearerHttpAuthentication: []
     tags:
       - accounts
-      - unimplemented
     requestBody:
       content:
         application/json:

--- a/packages/api/src/account/controller/controller.ts
+++ b/packages/api/src/account/controller/controller.ts
@@ -53,6 +53,19 @@ accountController.put(
 	},
 );
 accountController.get(
+	"/me/marketing-tags",
+	verifyUserAuthentication,
+	async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+		try {
+			validateBodyFromAuthentication(req.body);
+			const result = await accountService.getMarketingTags(req.body);
+			res.status(HTTP_STATUS.SUCCESSFUL.OK).json(result);
+		} catch (err) {
+			next(err);
+		}
+	},
+);
+accountController.get(
 	"/signup",
 	verifyUserAuthentication,
 	async (req: Request, res: Response, next: NextFunction): Promise<void> => {

--- a/packages/api/src/account/controller/get_marketing_tags.test.ts
+++ b/packages/api/src/account/controller/get_marketing_tags.test.ts
@@ -1,0 +1,117 @@
+import request from "supertest";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import { Md5 } from "ts-md5";
+import { app } from "../../app.js";
+import { MailchimpMarketing } from "../../mailchimp.js";
+import { mockVerifyUserAuthentication } from "../../../test/middleware_mocks.js";
+
+vi.mock("../../mailchimp", () => ({
+	MailchimpMarketing: {
+		lists: {
+			getListMemberTags: vi.fn(),
+		},
+	},
+}));
+vi.mock("../../middleware");
+
+describe("getMarketingTags", () => {
+	const agent = request.agent(app);
+
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockVerifyUserAuthentication(
+			"test@permanent.org",
+			"b5461dc2-1eb0-450e-b710-fef7b2cafe1e",
+		);
+	});
+
+	test("should return a list of tag names for the authenticated account", async () => {
+		vi.mocked(MailchimpMarketing.lists.getListMemberTags).mockResolvedValue({
+			tags: [
+				{ id: 1, name: "tag1", date_added: "2024-01-01" },
+				{ id: 2, name: "tag2", date_added: "2024-01-02" },
+			],
+		});
+
+		const response = await agent
+			.get("/api/v2/accounts/me/marketing-tags")
+			.expect(200);
+
+		expect(response.body).toStrictEqual({ items: ["tag1", "tag2"] });
+		expect(MailchimpMarketing.lists.getListMemberTags).toHaveBeenCalledWith(
+			process.env["MAILCHIMP_COMMUNITY_LIST_ID"] ?? "",
+			Md5.hashStr("test@permanent.org"),
+		);
+	});
+
+	test("should return an empty list when the account has no tags", async () => {
+		vi.mocked(MailchimpMarketing.lists.getListMemberTags).mockResolvedValue({
+			tags: [],
+		});
+
+		const response = await agent
+			.get("/api/v2/accounts/me/marketing-tags")
+			.expect(200);
+
+		expect(response.body).toStrictEqual({ items: [] });
+	});
+
+	test("should return an empty list when the account does not exist in Mailchimp", async () => {
+		vi.mocked(MailchimpMarketing.lists.getListMemberTags).mockRejectedValue({
+			status: 404,
+			response: {
+				body: {
+					type: "https://mailchimp.com/developer/marketing/docs/errors/",
+					title: "Resource Not Found",
+					status: 404,
+					detail: "The requested resource could not be found.",
+					instance: "",
+				},
+			},
+		});
+
+		const response = await agent
+			.get("/api/v2/accounts/me/marketing-tags")
+			.expect(200);
+
+		expect(response.body).toStrictEqual({ items: [] });
+	});
+
+	test("should throw an error if the Mailchimp call fails", async () => {
+		vi.mocked(MailchimpMarketing.lists.getListMemberTags).mockRejectedValue({
+			status: 500,
+			response: {
+				body: {
+					type: "",
+					title: "Internal Server Error",
+					status: 500,
+					detail: "Out of Cheese - Redo from Start",
+					instance: "",
+				},
+			},
+		});
+
+		await agent.get("/api/v2/accounts/me/marketing-tags").expect(500);
+	});
+
+	test("should propagate the status code from an error even if a lacks a response object", async () => {
+		vi.mocked(MailchimpMarketing.lists.getListMemberTags).mockRejectedValue({
+			status: 418,
+		});
+
+		await agent.get("/api/v2/accounts/me/marketing-tags").expect(418);
+	});
+
+	test("should default to a 500 error if an error from Mailchimp has no status code", async () => {
+		vi.mocked(MailchimpMarketing.lists.getListMemberTags).mockRejectedValue({
+			error: "Out of cheese - redo from start",
+		});
+
+		await agent.get("/api/v2/accounts/me/marketing-tags").expect(500);
+	});
+
+	test("should return a bad request error if authentication fields are missing", async () => {
+		mockVerifyUserAuthentication("test@permanent.org");
+		await agent.get("/api/v2/accounts/me/marketing-tags").expect(400);
+	});
+});

--- a/packages/api/src/account/models.ts
+++ b/packages/api/src/account/models.ts
@@ -101,6 +101,10 @@ export interface UpdateTagsRequest {
 	removeTags?: string[];
 }
 
+export interface GetMarketingTagsResponse {
+	items: string[];
+}
+
 export interface SignupDetails {
 	token: string;
 }

--- a/packages/api/src/account/service.ts
+++ b/packages/api/src/account/service.ts
@@ -1,6 +1,8 @@
 import { Md5 } from "ts-md5";
 import createError from "http-errors";
+import { HTTP_STATUS } from "@pdc/http-status-codes";
 import { logger } from "@stela/logger";
+import type { ErrorResponse } from "@mailchimp/mailchimp_marketing";
 
 import { db } from "../database.js";
 import { MailchimpMarketing } from "../mailchimp.js";
@@ -10,6 +12,7 @@ import type { CreateEventRequest } from "../event/models.js";
 
 import {
 	type UpdateTagsRequest,
+	type GetMarketingTagsResponse,
 	type SignupDetails,
 	type GetAccountArchiveResult,
 	type LeaveArchiveRequest,
@@ -151,6 +154,41 @@ const updateTags = async (requestBody: UpdateTagsRequest): Promise<void> => {
 	}
 };
 
+interface MailchimpApiError {
+	status: number;
+	response?: {
+		body: ErrorResponse;
+	};
+}
+
+const isMailchimpApiError = (err: unknown): err is MailchimpApiError =>
+	err instanceof Object &&
+	"status" in err &&
+	typeof (err as { status: unknown }).status === "number";
+
+const getMarketingTags = async (requestBody: {
+	emailFromAuthToken: string;
+	userSubjectFromAuthToken: string;
+}): Promise<GetMarketingTagsResponse> => {
+	try {
+		const response = await MailchimpMarketing.lists.getListMemberTags(
+			process.env["MAILCHIMP_COMMUNITY_LIST_ID"] ?? "",
+			Md5.hashStr(requestBody.emailFromAuthToken),
+		);
+		return { items: response.tags.map((tag) => tag.name) };
+	} catch (err) {
+		if (isMailchimpApiError(err)) {
+			if (err.status === HTTP_STATUS.CLIENT_ERROR.NOT_FOUND.valueOf()) {
+				return { items: [] };
+			}
+			throw err.response === undefined
+				? createError(err.status)
+				: createError(err.status, err.response.body.detail);
+		}
+		throw err;
+	}
+};
+
 const getSignupDetails = async (
 	accountEmail: string,
 ): Promise<SignupDetails> => {
@@ -259,6 +297,7 @@ export const accountService = {
 	getSignupDetails,
 	leaveArchive,
 	updateTags,
+	getMarketingTags,
 	getAccountArchive,
 };
 

--- a/packages/api/src/types/mailchimp_marketing.d.ts
+++ b/packages/api/src/types/mailchimp_marketing.d.ts
@@ -19,5 +19,12 @@ declare module "@mailchimp/mailchimp_marketing" {
 			subscriberHash: string,
 			body: { tags: Array<{ name: string; status: "active" | "inactive" }> },
 		): Promise<ErrorResponse | null>;
+
+		export function getListMemberTags(
+			listId: string,
+			subscriberHash: string,
+		): Promise<{
+			tags: Array<{ id: number; name: string; date_added: string }>;
+		}>;
 	}
 }


### PR DESCRIPTION
The Vision 2030 dashboard design contains the possibility of displaying a users selected goals on the dashboard. To support this, this commit adds a GET /accounts/me/marketing-tags endpoint, which will retrieve those values from Mailchimp.