### PR TITLE
Fix broken BadRequest import

### DIFF
--- a/packages/api/src/directive/service/update.ts
+++ b/packages/api/src/directive/service/update.ts
@@ -1,4 +1,4 @@
-import createError, { BadRequest } from "http-errors";
+import createError from "http-errors";
 import { logger } from "@stela/logger";
 import { db } from "../../database.js";
 import {
@@ -61,7 +61,7 @@ export const updateDirective = async (
 					throw new createError.BadRequest(
 						"Steward email must have an account",
 					);
-				} else if (err instanceof BadRequest) {
+				} else if (err instanceof createError.BadRequest) {
 					throw err;
 				}
 				logger.error(err);


### PR DESCRIPTION
Currently, we have one file that attempts to import BadRequest directly from http-errors. Because http-errors is a CommonJS module, this doesn't work (though it fails in a way that the Typescript compiler doesn't catch). This commit fixes the problem but just importing createError and accessing BadRequest through that.