### PR TITLE
Add GET /accounts/me endpoint

### DIFF
--- a/.sqlfluff
+++ b/.sqlfluff
@@ -14,7 +14,7 @@ param_style = colon
 spacing_within = touch:inline
 
 [sqlfluff:rules:references.keywords]
-ignore_words = name, owner, type, trigger, shares, location, action, version, position, precision
+ignore_words = name, owner, type, trigger, shares, location, action, version, position, precision, settings
 
 [sqlfluff:rules:capitalisation.functions]
 extended_capitalisation_policy = upper

--- a/packages/api/docs/src/models/account.yaml
+++ b/packages/api/docs/src/models/account.yaml
@@ -40,7 +40,7 @@ notificationTypesEnabled:
 account:
   description: An object representing a user account on permanent.org
   type: object
-  required: [id, primaryEmail, fullName, address, settings]
+  required: [id, primaryEmail, fullName, address, settings, archiveMemberships, createdAt, updatedAt, status, type, primaryPhone, defaultArchiveId]
   properties:
     id:
       type: string
@@ -55,6 +55,7 @@ account:
     primaryPhone:
       type: object
       required: [number, verified]
+      nullable: true
       properties:
         number:
           type: string
@@ -64,6 +65,7 @@ account:
       type: string
     defaultArchiveId:
       type: string
+      nullable: true
     address:
       type: object
       properties:

--- a/packages/api/docs/src/paths/account.yaml
+++ b/packages/api/docs/src/paths/account.yaml
@@ -157,7 +157,6 @@ accounts/me:
       - bearerHttpAuthentication: []
     tags:
       - accounts
-      - unimplemented
     responses:
       "200":
         description: >

--- a/packages/api/src/account/controller/controller.ts
+++ b/packages/api/src/account/controller/controller.ts
@@ -81,6 +81,19 @@ accountController.get(
 		}
 	},
 );
+accountController.get(
+	"/me",
+	verifyUserAuthentication,
+	async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+		try {
+			validateBodyFromAuthentication(req.body);
+			const account = await accountService.getMe(req.body.emailFromAuthToken);
+			res.status(HTTP_STATUS.SUCCESSFUL.OK).json({ data: account });
+		} catch (err) {
+			next(err);
+		}
+	},
+);
 accountController.delete(
 	"/archive/:archiveId",
 	verifyUserAuthentication,

--- a/packages/api/src/account/controller/get_accounts_me.test.ts
+++ b/packages/api/src/account/controller/get_accounts_me.test.ts
@@ -1,0 +1,268 @@
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { logger } from "@stela/logger";
+import { app } from "../../app.js";
+import { db } from "../../database.js";
+import { verifyUserAuthentication } from "../../middleware/index.js";
+import { mockVerifyUserAuthentication } from "../../../test/middleware_mocks.js";
+import type { Account } from "../models.js";
+
+vi.mock("../../database");
+vi.mock("../../middleware");
+vi.mock("@stela/logger");
+
+const setupDatabase = async (): Promise<void> => {
+	await db.sql("account.fixtures.create_test_accounts");
+	await db.sql("account.fixtures.create_test_archives");
+	await db.sql("account.fixtures.create_test_account_archives");
+	await db.sql("account.fixtures.create_test_profile_items");
+};
+
+const clearDatabase = async (): Promise<void> => {
+	await db.query(
+		"TRUNCATE profile_item, account_archive, archive, account CASCADE",
+	);
+};
+
+describe("GET /accounts/me", () => {
+	const agent = request(app);
+
+	beforeEach(async () => {
+		mockVerifyUserAuthentication(
+			"test@permanent.org",
+			"13bb917e-7c75-4971-a8ee-b22e82432888",
+		);
+		await clearDatabase();
+		await setupDatabase();
+	});
+
+	afterEach(async () => {
+		await clearDatabase();
+		vi.clearAllMocks();
+	});
+
+	test("should call verifyUserAuthentication", async () => {
+		await agent.get("/api/v2/accounts/me");
+		expect(verifyUserAuthentication).toHaveBeenCalled();
+	});
+
+	test("should return 400 if email from auth token is missing", async () => {
+		mockVerifyUserAuthentication(
+			undefined,
+			"13bb917e-7c75-4971-a8ee-b22e82432888",
+		);
+		await agent.get("/api/v2/accounts/me").expect(400);
+	});
+
+	test("should return 400 if user subject from auth token is missing", async () => {
+		mockVerifyUserAuthentication("test@permanent.org");
+		await agent.get("/api/v2/accounts/me").expect(400);
+	});
+
+	test("should return 200 with the authenticated account", async () => {
+		const response = await agent.get("/api/v2/accounts/me").expect(200);
+
+		const {
+			body: { data: account },
+		} = response as { body: { data: Account } };
+		expect(account.id).toBe("2");
+		expect(account.primaryEmail.address).toBe("test@permanent.org");
+		expect(account.primaryEmail.verified).toBe(false);
+		expect(account.fullName).toBe("Jack Rando");
+		expect(account.address).toEqual({
+			lineOne: null,
+			lineTwo: null,
+			city: null,
+			state: null,
+			zip: null,
+			country: null,
+		});
+		expect(account.settings.hideChecklist).toBe(false);
+		expect(account.settings.allowSftpDeletion).toBe(false);
+		expect(account.settings.notificationsEnabled).toEqual({});
+		expect(account.type).toEqual("standard");
+		expect(account.status).toEqual("ok");
+		expect(account.createdAt).toEqual("2026-06-01T00:00:00.000Z");
+		expect(account.updatedAt).toEqual("2026-07-01T00:00:00.000Z");
+	});
+
+	test("should return archiveMemberships for the authenticated account", async () => {
+		const response = await agent.get("/api/v2/accounts/me").expect(200);
+
+		const {
+			body: { data: account },
+		} = response as { body: { data: Account } };
+		expect(account.archiveMemberships).toBeDefined();
+		expect(account.archiveMemberships).toHaveLength(1);
+		if (account.archiveMemberships[0] !== undefined) {
+			const {
+				archiveMemberships: [membership],
+			} = account;
+			expect(membership.id).toBe("3");
+			expect(membership.accountId).toBe("2");
+			expect(membership.accessRole).toBe("owner");
+			expect(membership.status).toBe("ok");
+			expect(membership.archive.id).toBe("1");
+			expect(membership.archive.name).toBe("Test Archive 1");
+			expect(membership.archive.thumbnailUrls).toEqual({
+				width200: null,
+				width500: null,
+				width1000: null,
+				width2000: null,
+			});
+		}
+	});
+
+	test("should return 404 if the authenticated account does not exist", async () => {
+		mockVerifyUserAuthentication(
+			"nonexistent@permanent.org",
+			"13bb917e-7c75-4971-a8ee-b22e82432888",
+		);
+		await agent.get("/api/v2/accounts/me").expect(404);
+	});
+
+	test("should return 404 for a deleted account", async () => {
+		await db.query(`
+			INSERT INTO account (accountid, primaryemail, status, notificationpreferences, type)
+			VALUES (99, 'deleted@permanent.org', 'status.generic.deleted', '{}', 'type.account.standard')
+		`);
+		mockVerifyUserAuthentication(
+			"deleted@permanent.org",
+			"13bb917e-7c75-4971-a8ee-b22e82432888",
+		);
+		await agent.get("/api/v2/accounts/me").expect(404);
+	});
+
+	test("should exclude memberships to deleted archives", async () => {
+		// account 2 has account_archive id=13 pointing to archive 4 (status.generic.deleted)
+		const response = await agent.get("/api/v2/accounts/me").expect(200);
+		const {
+			body: { data: account },
+		} = response as { body: { data: Account } };
+		const archiveIds = account.archiveMemberships.map((m) => m.archive.id);
+		expect(archiveIds).not.toContain("4");
+	});
+
+	test("should exclude memberships with non-ok status", async () => {
+		// account 2 has account_archive id=21 to archive 3 with status.generic.pending
+		const response = await agent.get("/api/v2/accounts/me").expect(200);
+		const {
+			body: { data: account },
+		} = response as { body: { data: Account } };
+		const archiveIds = account.archiveMemberships.map((m) => m.archive.id);
+		expect(archiveIds).not.toContain("3");
+	});
+
+	test("should return all active memberships for an account with multiple archives", async () => {
+		// account 3 (test+1) has ok memberships to archive 1 (viewer) and archive 2 (owner)
+		mockVerifyUserAuthentication(
+			"test+1@permanent.org",
+			"553f3cb8-b753-43ce-83af-4443a404741b",
+		);
+		const response = await agent.get("/api/v2/accounts/me").expect(200);
+		const {
+			body: { data: account },
+		} = response as { body: { data: Account } };
+		expect(account.archiveMemberships).toHaveLength(2);
+	});
+
+	test("should return null archive name when no basic profile item exists", async () => {
+		// account 3 has a membership to archive 2, which has no profile_item row
+		mockVerifyUserAuthentication(
+			"test+1@permanent.org",
+			"553f3cb8-b753-43ce-83af-4443a404741b",
+		);
+		const response = await agent.get("/api/v2/accounts/me").expect(200);
+		const {
+			body: { data: account },
+		} = response as { body: { data: Account } };
+		const archive2Membership = account.archiveMemberships.find(
+			(m) => m.archive.id === "2",
+		);
+		expect(archive2Membership).toBeDefined();
+		expect(archive2Membership?.archive.name).toBeNull();
+	});
+
+	test("should map non-owner access roles correctly", async () => {
+		// account 3 has access.role.viewer to archive 1
+		mockVerifyUserAuthentication(
+			"test+1@permanent.org",
+			"553f3cb8-b753-43ce-83af-4443a404741b",
+		);
+		const response = await agent.get("/api/v2/accounts/me").expect(200);
+		const {
+			body: { data: account },
+		} = response as { body: { data: Account } };
+		const archive1Membership = account.archiveMemberships.find(
+			(m) => m.archive.id === "1",
+		);
+		expect(archive1Membership?.accessRole).toBe("viewer");
+	});
+
+	test("should return empty archiveMemberships array for an account with no active memberships", async () => {
+		// account 4 (test+2@permanent.org) has one account_archive with deleted status, so no active memberships
+		mockVerifyUserAuthentication(
+			"test+2@permanent.org",
+			"13bb917e-7c75-4971-a8ee-b22e82432888",
+		);
+		const response = await agent.get("/api/v2/accounts/me").expect(200);
+		const {
+			body: { data: account },
+		} = response as { body: { data: Account } };
+		expect(account.archiveMemberships).toEqual([]);
+	});
+
+	test("should return 404 for accounts with invited status", async () => {
+		// account 5 (test+3@permanent.org) has status.generic.invited; the query filters on status.auth.ok
+		mockVerifyUserAuthentication(
+			"test+3@permanent.org",
+			"13bb917e-7c75-4971-a8ee-b22e82432888",
+		);
+		await agent.get("/api/v2/accounts/me").expect(404);
+	});
+
+	test("should return verified: true when the account email is verified", async () => {
+		await db.query(
+			"UPDATE account SET emailstatus = 'status.auth.ok' WHERE accountid = 2",
+		);
+		const response = await agent.get("/api/v2/accounts/me").expect(200);
+		const {
+			body: { data: account },
+		} = response as { body: { data: Account } };
+		expect(account.primaryEmail.verified).toBe(true);
+	});
+
+	test("should match lowercase email from the call to uppercase emails in the database", async () => {
+		// account 6 is stored as TEST+4@permanent.org; query with lowercase
+		mockVerifyUserAuthentication(
+			"test+4@permanent.org",
+			"13bb917e-7c75-4971-a8ee-b22e82432888",
+		);
+		const response = await agent.get("/api/v2/accounts/me").expect(200);
+		const {
+			body: { data: account },
+		} = response as { body: { data: Account } };
+		expect(account.id).toBe("6");
+	});
+
+	test("should match uppercase email from the call to lowercase emails in the database", async () => {
+		mockVerifyUserAuthentication(
+			"TEST@permanent.org",
+			"13bb917e-7c75-4971-a8ee-b22e82432888",
+		);
+		const response = await agent.get("/api/v2/accounts/me").expect(200);
+		const {
+			body: { data: account },
+		} = response as { body: { data: Account } };
+		expect(account.id).toBe("2");
+	});
+
+	test("should log error and return 500 if account database query fails", async () => {
+		const testError = new Error("test error");
+		vi.spyOn(db, "sql").mockRejectedValueOnce(testError);
+
+		await agent.get("/api/v2/accounts/me").expect(500);
+
+		expect(logger.error).toHaveBeenCalledWith(testError);
+	});
+});

--- a/packages/api/src/account/fixtures/create_test_accounts.sql
+++ b/packages/api/src/account/fixtures/create_test_accounts.sql
@@ -6,7 +6,9 @@ account (
   notificationpreferences,
   type,
   fullname,
-  subject
+  subject,
+  createddt,
+  updateddt
 )
 VALUES
 (
@@ -16,7 +18,9 @@ VALUES
   '{}',
   'type.account.standard',
   'Jack Rando',
-  null
+  null,
+  '2026-06-01',
+  '2026-07-01'
 ),
 (
   3,
@@ -25,7 +29,9 @@ VALUES
   '{}',
   'type.account.standard',
   'John Rando',
-  '553f3cb8-b753-43ce-83af-4443a404741b'
+  '553f3cb8-b753-43ce-83af-4443a404741b',
+  null,
+  null
 ),
 (
   4,
@@ -34,6 +40,8 @@ VALUES
   '{}',
   'type.account.standard',
   'Jane Rando',
+  null,
+  null,
   null
 ),
 (
@@ -43,6 +51,8 @@ VALUES
   '{}',
   'type.account.standard',
   'Jenny Rando',
+  null,
+  null,
   null
 ),
 (
@@ -52,5 +62,7 @@ VALUES
   '{}',
   'type.account.standard',
   'Jenny Rando',
+  null,
+  null,
   null
 );

--- a/packages/api/src/account/fixtures/create_test_profile_items.sql
+++ b/packages/api/src/account/fixtures/create_test_profile_items.sql
@@ -1,0 +1,18 @@
+INSERT INTO
+profile_item (
+  profile_itemid,
+  archiveid,
+  fieldnameui,
+  string1,
+  status,
+  type
+)
+VALUES
+(
+  1,
+  1,
+  'profile.basic',
+  'Test Archive 1',
+  'status.generic.ok',
+  'type.profile_item.basic'
+);

--- a/packages/api/src/account/models.ts
+++ b/packages/api/src/account/models.ts
@@ -1,3 +1,5 @@
+import type { ArchiveMembershipRole } from "../access/models.js";
+
 interface NotificationTypePreference {
 	apps?: { confirmations?: boolean };
 	share?: {
@@ -19,10 +21,23 @@ interface NotificationTypePreference {
 	};
 }
 
-interface RawNotificationPreferences {
-	textPreference?: NotificationTypePreference;
-	emailPreference?: NotificationTypePreference;
-	inAppPreference?: NotificationTypePreference;
+export interface ArchiveSummary {
+	id: string;
+	name: string | null;
+	thumbnailUrls: {
+		width200: string | null;
+		width500: string | null;
+		width1000: string | null;
+		width2000: string | null;
+	};
+}
+
+export interface ArchiveMembership {
+	id: string;
+	accountId: string;
+	archive: ArchiveSummary;
+	accessRole: ArchiveMembershipRole;
+	status: "ok" | "pending";
 }
 
 export interface Account {
@@ -31,12 +46,12 @@ export interface Account {
 		address: string;
 		verified: boolean;
 	};
-	primaryPhone?: {
+	primaryPhone: {
 		number: string;
 		verified: boolean;
-	};
+	} | null;
 	fullName: string | null;
-	defaultArchiveId?: string;
+	defaultArchiveId: string | null;
 	address: {
 		lineOne: string | null;
 		lineTwo: string | null;
@@ -56,27 +71,13 @@ export interface Account {
 	};
 	status: PrettyAccountStatus;
 	type: PrettyAccountType;
+	archiveMemberships: ArchiveMembership[];
+	createdAt: string;
+	updatedAt: string;
 }
 
-export interface AccountRow {
-	id: string;
-	primaryEmailAddress: string;
-	emailStatus: string | null;
-	primaryPhoneNumber: string | null;
-	phoneStatus: string | null;
-	fullName: string | null;
-	defaultArchiveId: string | null;
-	addressLineOne: string | null;
-	addressLineTwo: string | null;
-	city: string | null;
-	state: string | null;
-	zip: string | null;
-	country: string | null;
-	hideChecklist: boolean;
-	allowSftpDeletion: boolean;
-	notificationPreferences: RawNotificationPreferences;
-	status: AccountStatus;
-	type: AccountType;
+export interface AccountRow extends Account {
+	totalPages: number;
 }
 
 export interface GetAccountsQuery {
@@ -139,16 +140,6 @@ export interface StorageAdjustment {
 	newStorageTotal: number;
 	adjustmentAmount: number;
 	createdAt: Date;
-}
-
-export enum AccountStatus {
-	Ok = "status.auth.ok",
-	Invited = "status.generic.invited",
-}
-
-export enum AccountType {
-	Standard = "type.account.standard",
-	Test = "type.account.test",
 }
 
 export enum PrettyAccountStatus {

--- a/packages/api/src/account/queries/get_accounts.sql
+++ b/packages/api/src/account/queries/get_accounts.sql
@@ -1,46 +1,142 @@
+WITH aggregated_memberships AS (
+  SELECT
+    account_archive.accountid,
+    ARRAY_AGG(
+      JSONB_BUILD_OBJECT(
+        'id', account_archive.account_archiveid::text,
+        'accountId', account_archive.accountid::text,
+        'accessRole',
+        CASE account_archive.accessrole
+          WHEN 'access.role.owner' THEN 'owner'
+          WHEN 'access.role.manager' THEN 'manager'
+          WHEN 'access.role.curator' THEN 'curator'
+          WHEN 'access.role.editor' THEN 'editor'
+          WHEN 'access.role.contributor' THEN 'contributor'
+          WHEN 'access.role.viewer' THEN 'viewer'
+        END,
+        'status', CASE account_archive.status
+          WHEN 'status.generic.ok' THEN 'ok'
+          WHEN 'status.generic.pending' THEN 'pending'
+          WHEN 'status.generic.deleted' THEN 'deleted'
+        END,
+        'archive', JSONB_BUILD_OBJECT(
+          'id', archive.archiveid::text,
+          'name', basic_profile_item.string1,
+          'thumbnailUrls', JSONB_BUILD_OBJECT(
+            'width200', archive.thumburl200,
+            'width500', archive.thumburl500,
+            'width1000', archive.thumburl1000,
+            'width2000', archive.thumburl2000
+          )
+        )
+      )
+    ) AS memberships
+  FROM
+    account_archive
+  INNER JOIN
+    archive
+    ON
+      account_archive.archiveid = archive.archiveid
+      AND archive.status != 'status.generic.deleted'
+  LEFT JOIN
+    profile_item AS basic_profile_item
+    ON
+      archive.archiveid = basic_profile_item.archiveid
+      AND basic_profile_item.fieldnameui = 'profile.basic'
+      AND basic_profile_item.status != 'status.generic.deleted'
+  WHERE
+    account_archive.status = 'status.generic.ok'
+    AND account_archive.accountid IN (
+      SELECT account.accountid
+      FROM account
+      WHERE
+        ((
+          :filterByIds = true
+          AND account.accountid::text = ANY(:accountIds::text[])
+        )
+        OR (
+          :filterByIds = false
+          AND LOWER(account.primaryemail) = ANY(:accountEmails::text[])
+        ))
+        AND account.status = 'status.auth.ok'
+        AND account.accountid > COALESCE(:cursor, 0)
+    )
+  GROUP BY
+    account_archive.accountid
+)
 SELECT
   account.accountid::text AS id,
-  account.primaryemail AS "primaryEmailAddress",
-  account.emailstatus AS "emailStatus",
-  account.primaryphone AS "primaryPhoneNumber",
-  account.phonestatus AS "phoneStatus",
   account.fullname AS "fullName",
   account.defaultarchiveid::text AS "defaultArchiveId",
-  account.address AS "addressLineOne",
-  account.address2 AS "addressLineTwo",
-  account.city,
-  account.state,
-  account.zip,
-  account.country,
-  account.hidechecklist AS "hideChecklist",
-  account.allowsftpdeletion AS "allowSftpDeletion",
-  account.notificationpreferences AS "notificationPreferences",
-  account.status,
-  account.type,
+  account.createddt AS "createdAt",
+  account.updateddt AS "updatedAt",
+  JSONB_BUILD_OBJECT(
+    'address', account.primaryemail,
+    'verified', COALESCE(account.emailstatus = 'status.auth.ok', false)
+  ) AS "primaryEmail",
+  CASE
+    WHEN account.primaryphone IS NOT null
+      THEN JSONB_BUILD_OBJECT(
+        'number', account.primaryphone,
+        'verified', COALESCE(account.phonestatus = 'status.auth.ok', false)
+      )
+  END AS "primaryPhone",
+  JSONB_BUILD_OBJECT(
+    'lineOne', account.address,
+    'lineTwo', account.address2,
+    'city', account.city,
+    'state', account.state,
+    'zip', account.zip,
+    'country', account.country
+  ) AS address,
+  JSONB_BUILD_OBJECT(
+    'hideChecklist', account.hidechecklist,
+    'allowSftpDeletion', account.allowsftpdeletion,
+    'notificationsEnabled', JSONB_STRIP_NULLS(JSONB_BUILD_OBJECT(
+      'sms', account.notificationpreferences -> 'textPreference',
+      'email', account.notificationpreferences -> 'emailPreference',
+      'inApp', account.notificationpreferences -> 'inAppPreference'
+    ))
+  ) AS settings,
+  CASE account.status
+    WHEN 'status.auth.ok' THEN 'ok'
+    WHEN 'status.generic.invited' THEN 'invited'
+  END AS status,
+  CASE account.type
+    WHEN 'type.account.standard' THEN 'standard'
+    WHEN 'type.account.test' THEN 'test'
+  END AS type,
+  COALESCE(
+    aggregated_memberships.memberships,
+    ARRAY[]::jsonb[]
+  ) AS "archiveMemberships",
   CEILING((
     SELECT COUNT(account_for_count.accountid) FROM account AS account_for_count
     WHERE
-      (
-        :filterByIds = TRUE
+      ((
+        :filterByIds = true
         AND account_for_count.accountid::text = ANY(:accountIds::text[])
       )
       OR (
-        :filterByIds = FALSE
+        :filterByIds = false
         AND LOWER(account_for_count.primaryemail) = ANY(:accountEmails::text[])
-      )
+      ))
+      AND account_for_count.status = 'status.auth.ok'
   ) / :pageSize) AS "totalPages"
 FROM
   account
+LEFT JOIN
+  aggregated_memberships ON account.accountid = aggregated_memberships.accountid
 WHERE
   ((
-    :filterByIds = TRUE
+    :filterByIds = true
     AND account.accountid::text = ANY(:accountIds::text[])
   )
   OR (
-    :filterByIds = FALSE
+    :filterByIds = false
     AND LOWER(account.primaryemail) = ANY(:accountEmails::text[])
   ))
   AND account.accountid > COALESCE(:cursor, 0)
-  AND account.status != 'status.generic.deleted'
+  AND account.status = 'status.auth.ok'
 ORDER BY account.accountid ASC
 LIMIT :pageSize;

--- a/packages/api/src/account/service.ts
+++ b/packages/api/src/account/service.ts
@@ -10,81 +10,25 @@ import { ACCESS_ROLE, EVENT_ACTION, EVENT_ENTITY, GB } from "../constants.js";
 import { createEvent } from "../event/service.js";
 import type { CreateEventRequest } from "../event/models.js";
 
-import {
-	type UpdateTagsRequest,
-	type GetMarketingTagsResponse,
-	type PostMarketingTagsRequest,
-	type SignupDetails,
-	type GetAccountArchiveResult,
-	type LeaveArchiveRequest,
-	type CreateStorageAdjustmentRequest,
-	type StorageAdjustment,
-	type Account,
-	type AccountRow,
-	type GetAccountsQuery,
-	type GetAccountsResponse,
-	AccountType,
-	PrettyAccountType,
-	AccountStatus,
-	PrettyAccountStatus,
+import type {
+	UpdateTagsRequest,
+	GetMarketingTagsResponse,
+	SignupDetails,
+	GetAccountArchiveResult,
+	LeaveArchiveRequest,
+	CreateStorageAdjustmentRequest,
+	StorageAdjustment,
+	Account,
+	AccountRow,
+	GetAccountsQuery,
+	GetAccountsResponse,
+	PostMarketingTagsRequest,
 } from "./models.js";
 
-const prettifyAccountType = (accountType: AccountType): PrettyAccountType => {
-	switch (accountType) {
-		case AccountType.Standard:
-			return PrettyAccountType.Standard;
-		case AccountType.Test:
-			return PrettyAccountType.Test;
-	}
+const accountRowToAccount = (row: AccountRow): Account => {
+	const { totalPages: _, ...account } = row;
+	return account;
 };
-
-const prettifyAccountStatus = (
-	accountStatus: AccountStatus,
-): PrettyAccountStatus => {
-	switch (accountStatus) {
-		case AccountStatus.Ok:
-			return PrettyAccountStatus.Ok;
-		case AccountStatus.Invited:
-			return PrettyAccountStatus.Invited;
-	}
-};
-
-const accountRowToAccount = (row: AccountRow): Account => ({
-	id: row.id,
-	primaryEmail: {
-		address: row.primaryEmailAddress,
-		verified: row.emailStatus === "status.auth.ok",
-	},
-	...(row.primaryPhoneNumber !== null && {
-		primaryPhone: {
-			number: row.primaryPhoneNumber,
-			verified: row.phoneStatus === "status.auth.ok",
-		},
-	}),
-	fullName: row.fullName,
-	...(row.defaultArchiveId !== null && {
-		defaultArchiveId: row.defaultArchiveId,
-	}),
-	address: {
-		lineOne: row.addressLineOne,
-		lineTwo: row.addressLineTwo,
-		city: row.city,
-		state: row.state,
-		zip: row.zip,
-		country: row.country,
-	},
-	settings: {
-		hideChecklist: row.hideChecklist,
-		allowSftpDeletion: row.allowSftpDeletion,
-		notificationsEnabled: {
-			sms: row.notificationPreferences.textPreference,
-			email: row.notificationPreferences.emailPreference,
-			inApp: row.notificationPreferences.inAppPreference,
-		},
-	},
-	status: prettifyAccountStatus(row.status),
-	type: prettifyAccountType(row.type),
-});
 
 interface MailchimpApiError {
 	status: number;
@@ -114,7 +58,7 @@ export const getAccounts = async (
 			: [query.accountEmails.toLowerCase()];
 
 	const result = await db
-		.sql<AccountRow & { totalPages: number }>("account.queries.get_accounts", {
+		.sql<AccountRow>("account.queries.get_accounts", {
 			filterByIds,
 			accountIds,
 			accountEmails,
@@ -330,6 +274,27 @@ const getAccountArchive = async (
 	return accountArchiveResult.rows[0];
 };
 
+const getMe = async (email: string): Promise<Account> => {
+	const result = await db
+		.sql<AccountRow>("account.queries.get_accounts", {
+			filterByIds: false,
+			accountEmails: [email.toLowerCase()],
+			accountIds: [],
+			pageSize: 1,
+			cursor: undefined,
+		})
+		.catch((err: unknown) => {
+			logger.error(err);
+			throw new createError.InternalServerError("Failed to retrieve account");
+		});
+
+	if (result.rows[0] === undefined) {
+		throw new createError.NotFound("Account not found");
+	}
+
+	return accountRowToAccount(result.rows[0]);
+};
+
 export const accountService = {
 	getSignupDetails,
 	leaveArchive,
@@ -337,6 +302,7 @@ export const accountService = {
 	getMarketingTags,
 	postMarketingTags,
 	getAccountArchive,
+	getMe,
 };
 
 export const createStorageAdjustment = async (


### PR DESCRIPTION
The 2030 dashboard will require various information about the logged in user's account. To serve those use cases, this commit adds a GET /accounts/me endpoint that returns that account, including its archive memberships.