### PR TITLE
Add POST /accounts/me/promo-claim endpoint

### DIFF
--- a/packages/api/docs/src/paths/account.yaml
+++ b/packages/api/docs/src/paths/account.yaml
@@ -245,7 +245,6 @@ accounts/me/promo-claim:
     tags:
       - accounts
       - promo
-      - unimplemented
     requestBody:
       content:
         application/json:
@@ -269,11 +268,13 @@ accounts/me/promo-claim:
                   required: [storageGrantInGb]
                   properties:
                     storageGrantInGb:
-                      type: integer
+                      type: number
       "401":
         $ref: "../errors.yaml#/401"
       "403":
         $ref: "../errors.yaml#/403"
+      "404":
+        $ref: "../errors.yaml#/404"
       "400":
         $ref: "../errors.yaml#/400"
       "500":

--- a/packages/api/src/account/controller/claim_promo.test.ts
+++ b/packages/api/src/account/controller/claim_promo.test.ts
@@ -1,0 +1,393 @@
+import request from "supertest";
+import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import type { NextFunction } from "express";
+import createError from "http-errors";
+import type { TinyPg, TinyPgParams } from "tinypg";
+import { logger } from "@stela/logger";
+import { app } from "../../app.js";
+import { db } from "../../database.js";
+import { GB } from "../../constants.js";
+import { verifyUserAuthentication } from "../../middleware/index.js";
+import { mockVerifyUserAuthentication } from "../../../test/middleware_mocks.js";
+
+vi.mock("../../database");
+vi.mock("../../middleware");
+vi.mock("@stela/logger");
+
+const testEmail = "test@permanent.org";
+const testAccountId = "2";
+
+const getAccountSpace = async (
+	accountId: string,
+): Promise<{ spaceLeft: string; spaceTotal: string } | undefined> => {
+	const {
+		rows: [row],
+	} = await db.query<{ spaceLeft: string; spaceTotal: string }>(
+		'SELECT spaceleft "spaceLeft", spacetotal "spaceTotal" FROM account_space WHERE accountid = :accountId',
+		{ accountId },
+	);
+	return row;
+};
+
+const getPromoRemainingUses = async (
+	code: string,
+): Promise<number | undefined> => {
+	const {
+		rows: [row],
+	} = await db.query<{ remainingUses: string }>(
+		'SELECT remaininguses "remainingUses" FROM promo WHERE code = :code',
+		{ code },
+	);
+	return row === undefined ? undefined : +row.remainingUses;
+};
+
+const getAccountPromo = async (
+	accountId: string,
+	promoCode: string,
+): Promise<{ id: string } | undefined> => {
+	const {
+		rows: [row],
+	} = await db.query<{ id: string }>(
+		`SELECT account_promo.account_promoid AS id
+     FROM account_promo
+     INNER JOIN promo ON promo.promoid = account_promo.promoid
+     WHERE account_promo.accountid = :accountId AND promo.code = :promoCode`,
+		{ accountId, promoCode },
+	);
+	return row;
+};
+
+describe("POST /accounts/me/promo-claim", () => {
+	const agent = request(app);
+
+	const setupDatabase = async (): Promise<void> => {
+		await db.sql("account.fixtures.create_test_accounts");
+		await db.sql("account.fixtures.create_test_account_space");
+		await db.sql("account.fixtures.create_test_promos_for_claim");
+	};
+
+	const clearDatabase = async (): Promise<void> => {
+		await db.query(
+			"TRUNCATE account, account_space, ledger_financial, promo, account_promo CASCADE",
+		);
+	};
+
+	const isTinyPg = (value: unknown): value is TinyPg =>
+		value !== null && typeof value === "object" && "sql" in value;
+
+	const mockQueryFailure = (queryNameToFail: string, error: Error): void => {
+		vi.spyOn(db, "sql").mockImplementation(async function (
+			this: TinyPg,
+			name: string,
+			params?: TinyPgParams,
+		) {
+			if (name === queryNameToFail) throw error;
+			const proto: unknown = Object.getPrototypeOf(db);
+			if (!isTinyPg(proto))
+				throw new TypeError("Unexpected db prototype shape");
+			return await proto.sql.call(this, name, params);
+		});
+	};
+
+	beforeEach(async () => {
+		mockVerifyUserAuthentication(
+			testEmail,
+			"6b640c73-4963-47de-a096-4a05ff8dc5f5",
+		);
+		await clearDatabase();
+		await setupDatabase();
+	});
+
+	afterEach(async () => {
+		await clearDatabase();
+		vi.restoreAllMocks();
+	});
+
+	test("should return 200 with the storage grant in GB", async () => {
+		const response = await agent
+			.post("/api/v2/accounts/me/promo-claim")
+			.send({ promoCode: "VALID_PROMO" })
+			.expect(200);
+
+		expect(response.body).toEqual({ data: { storageGrantInGb: 1 } });
+	});
+
+	test("should add storage to the account", async () => {
+		const initialSpace = await getAccountSpace(testAccountId);
+
+		await agent
+			.post("/api/v2/accounts/me/promo-claim")
+			.send({ promoCode: "VALID_PROMO" })
+			.expect(200);
+
+		const updatedSpace = await getAccountSpace(testAccountId);
+		expect(+(updatedSpace?.spaceTotal ?? 0)).toBe(
+			+(initialSpace?.spaceTotal ?? 0) + GB,
+		);
+	});
+
+	test("should create an account_promo record", async () => {
+		await agent
+			.post("/api/v2/accounts/me/promo-claim")
+			.send({ promoCode: "VALID_PROMO" })
+			.expect(200);
+
+		const claim = await getAccountPromo(testAccountId, "VALID_PROMO");
+		expect(claim).toBeDefined();
+	});
+
+	test("should decrement the promo remainingUses", async () => {
+		const initialUses = await getPromoRemainingUses("VALID_PROMO");
+
+		await agent
+			.post("/api/v2/accounts/me/promo-claim")
+			.send({ promoCode: "VALID_PROMO" })
+			.expect(200);
+
+		const updatedUses = await getPromoRemainingUses("VALID_PROMO");
+		expect(updatedUses).toBe((initialUses ?? 0) - 1);
+	});
+
+	test("should create a ledger entry with promo type", async () => {
+		const initialSpace = await getAccountSpace(testAccountId);
+		const initialTotal = parseInt(initialSpace?.spaceTotal ?? "0", 10);
+
+		await agent
+			.post("/api/v2/accounts/me/promo-claim")
+			.send({ promoCode: "VALID_PROMO" })
+			.expect(200);
+
+		const {
+			rows: [ledgerRow],
+		} = await db.query<{
+			spaceDelta: string;
+			toSpaceBefore: string;
+			toSpaceLeft: string;
+			toSpaceTotal: string;
+		}>(
+			`SELECT spacedelta "spaceDelta", tospacebefore "toSpaceBefore", tospaceleft "toSpaceLeft", tospacetotal "toSpaceTotal" FROM ledger_financial
+       WHERE toaccountid = :accountId AND type = 'type.billing.transfer.promo'`,
+			{ accountId: testAccountId },
+		);
+		expect(ledgerRow).toBeDefined();
+		if (ledgerRow === undefined) return;
+		expect(ledgerRow.spaceDelta).toBe(GB.toString());
+		expect(ledgerRow.toSpaceBefore).toBe(initialSpace?.spaceTotal);
+		expect(parseInt(ledgerRow.toSpaceLeft, 10)).toBe(initialTotal + GB);
+		expect(parseInt(ledgerRow.toSpaceTotal, 10)).toBe(initialTotal + GB);
+	});
+
+	test("should return 401 if not authenticated", async () => {
+		vi.mocked(verifyUserAuthentication).mockImplementation(
+			async (_req, _res, next: NextFunction) => {
+				next(new createError.Unauthorized("You aren't logged in"));
+			},
+		);
+		await agent
+			.post("/api/v2/accounts/me/promo-claim")
+			.send({ promoCode: "VALID_PROMO" })
+			.expect(401);
+	});
+
+	test("should return 400 if promoCode is missing", async () => {
+		await agent.post("/api/v2/accounts/me/promo-claim").send({}).expect(400);
+	});
+
+	test("should return 400 if emailFromAuthToken is missing", async () => {
+		mockVerifyUserAuthentication(
+			undefined,
+			"6b640c73-4963-47de-a096-4a05ff8dc5f5",
+		);
+		await agent
+			.post("/api/v2/accounts/me/promo-claim")
+			.send({ promoCode: "VALID_PROMO" })
+			.expect(400);
+	});
+
+	test("should return 400 if userSubjectFromAuthToken is missing", async () => {
+		mockVerifyUserAuthentication(testEmail, undefined);
+		await agent
+			.post("/api/v2/accounts/me/promo-claim")
+			.send({ promoCode: "VALID_PROMO" })
+			.expect(400);
+	});
+
+	test("should return 404 if the caller account can't be found", async () => {
+		mockVerifyUserAuthentication(
+			"test+nonexistent@permanent.org",
+			"6b640c73-4963-47de-a096-4a05ff8dc5f5",
+		);
+		await agent
+			.post("/api/v2/accounts/me/promo-claim")
+			.send({ promoCode: "VALID_PROMO" })
+			.expect(404);
+	});
+
+	test("should return 400 for a nonexistent promo code", async () => {
+		await agent
+			.post("/api/v2/accounts/me/promo-claim")
+			.send({ promoCode: "DOES_NOT_EXIST" })
+			.expect(400);
+	});
+
+	test("should return 400 for an invalid promo code", async () => {
+		await agent
+			.post("/api/v2/accounts/me/promo-claim")
+			.send({ promoCode: "INVALID_PROMO" })
+			.expect(400);
+	});
+
+	test("should return 400 for an expired promo code", async () => {
+		await agent
+			.post("/api/v2/accounts/me/promo-claim")
+			.send({ promoCode: "EXPIRED_PROMO" })
+			.expect(400);
+	});
+
+	test("should return 400 for a promo code with no remaining uses", async () => {
+		await agent
+			.post("/api/v2/accounts/me/promo-claim")
+			.send({ promoCode: "NO_USES_PROMO" })
+			.expect(400);
+	});
+
+	test("should return 400 if the promo code has already been claimed", async () => {
+		await agent
+			.post("/api/v2/accounts/me/promo-claim")
+			.send({ promoCode: "VALID_PROMO" })
+			.expect(200);
+
+		await agent
+			.post("/api/v2/accounts/me/promo-claim")
+			.send({ promoCode: "VALID_PROMO" })
+			.expect(400);
+	});
+
+	test("should return 500 if the transaction fails", async () => {
+		vi.spyOn(db, "transaction").mockRejectedValueOnce(new Error("SQL error"));
+
+		await agent
+			.post("/api/v2/accounts/me/promo-claim")
+			.send({ promoCode: "VALID_PROMO" })
+			.expect(500);
+	});
+
+	describe("individual query failures with transaction rollback", () => {
+		test("should return 500 and log error if get_promo_by_code fails", async () => {
+			const testError = new Error("DB error");
+			mockQueryFailure("promo.queries.get_promo_by_code", testError);
+
+			await agent
+				.post("/api/v2/accounts/me/promo-claim")
+				.send({ promoCode: "VALID_PROMO" })
+				.expect(500);
+
+			expect(logger.error).toHaveBeenCalledWith(testError);
+		});
+
+		test("should return 500 and log error if check_account_promo fails", async () => {
+			const testError = new Error("DB error");
+			mockQueryFailure("promo.queries.check_account_promo", testError);
+
+			await agent
+				.post("/api/v2/accounts/me/promo-claim")
+				.send({ promoCode: "VALID_PROMO" })
+				.expect(500);
+
+			expect(logger.error).toHaveBeenCalledWith(testError);
+		});
+
+		test("should return 500 and log error if decrement_promo_remaining_uses fails", async () => {
+			const testError = new Error("DB error");
+			mockQueryFailure(
+				"promo.queries.decrement_promo_remaining_uses",
+				testError,
+			);
+
+			await agent
+				.post("/api/v2/accounts/me/promo-claim")
+				.send({ promoCode: "VALID_PROMO" })
+				.expect(500);
+
+			expect(logger.error).toHaveBeenCalledWith(testError);
+		});
+
+		test("should return 400 if decrement_promo_remaining_uses returns 0 rows", async () => {
+			vi.spyOn(db, "sql").mockImplementation(async function (
+				this: TinyPg,
+				name: string,
+				params?: TinyPgParams,
+			) {
+				if (name === "promo.queries.decrement_promo_remaining_uses")
+					return { command: "", row_count: 0, rows: [] };
+				const proto: unknown = Object.getPrototypeOf(db);
+				if (!isTinyPg(proto))
+					throw new TypeError("Unexpected db prototype shape");
+				return await proto.sql.call(this, name, params);
+			});
+
+			await agent
+				.post("/api/v2/accounts/me/promo-claim")
+				.send({ promoCode: "VALID_PROMO" })
+				.expect(400);
+		});
+
+		test("should return 500 and roll back decrement if create_account_promo fails", async () => {
+			const initialUses = await getPromoRemainingUses("VALID_PROMO");
+			const testError = new Error("DB error");
+			mockQueryFailure("promo.queries.create_account_promo", testError);
+
+			await agent
+				.post("/api/v2/accounts/me/promo-claim")
+				.send({ promoCode: "VALID_PROMO" })
+				.expect(500);
+
+			expect(logger.error).toHaveBeenCalledWith(testError);
+			const remainingUses = await getPromoRemainingUses("VALID_PROMO");
+			expect(remainingUses).toBe(initialUses);
+			const claim = await getAccountPromo(testAccountId, "VALID_PROMO");
+			expect(claim).toBeUndefined();
+		});
+
+		test("should return 500 and roll back all writes if adjust_account_storage fails", async () => {
+			const initialUses = await getPromoRemainingUses("VALID_PROMO");
+			const initialSpace = await getAccountSpace(testAccountId);
+			const testError = new Error("DB error");
+			mockQueryFailure("storage.queries.adjust_account_storage", testError);
+
+			await agent
+				.post("/api/v2/accounts/me/promo-claim")
+				.send({ promoCode: "VALID_PROMO" })
+				.expect(500);
+
+			expect(logger.error).toHaveBeenCalledWith(testError);
+			const remainingUses = await getPromoRemainingUses("VALID_PROMO");
+			expect(remainingUses).toBe(initialUses);
+			const claim = await getAccountPromo(testAccountId, "VALID_PROMO");
+			expect(claim).toBeUndefined();
+			const space = await getAccountSpace(testAccountId);
+			expect(space?.spaceTotal).toBe(initialSpace?.spaceTotal);
+		});
+
+		test("should return 500 and roll back all writes if adjust_account_storage returns 0 rows", async () => {
+			mockVerifyUserAuthentication(
+				"test+4@permanent.org", // this account has no account_space row, so the adjust storage query will update 0 rows
+				"ea61ff40-f4a2-4f02-848b-a19c2b60728a",
+			);
+			const initialUses = await getPromoRemainingUses("VALID_PROMO");
+			const initialSpace = await getAccountSpace(testAccountId);
+
+			await agent
+				.post("/api/v2/accounts/me/promo-claim")
+				.send({ promoCode: "VALID_PROMO" })
+				.expect(500);
+
+			const remainingUses = await getPromoRemainingUses("VALID_PROMO");
+			expect(remainingUses).toBe(initialUses);
+			const claim = await getAccountPromo(testAccountId, "VALID_PROMO");
+			expect(claim).toBeUndefined();
+			const space = await getAccountSpace(testAccountId);
+			expect(space?.spaceTotal).toBe(initialSpace?.spaceTotal);
+		});
+	});
+});

--- a/packages/api/src/account/controller/controller.ts
+++ b/packages/api/src/account/controller/controller.ts
@@ -23,6 +23,8 @@ import {
 	createStorageAdjustment,
 	getAccounts,
 } from "../service.js";
+import { claimPromo } from "../../promo/service.js";
+import { validateClaimPromoRequest } from "../../promo/validators.js";
 import type { LeaveArchiveRequest } from "../models.js";
 
 export const accountController = Router();
@@ -124,6 +126,19 @@ accountController.post(
 			validatePostMarketingTagsRequest(req.body);
 			const result = await accountService.postMarketingTags(req.body);
 			res.json(result);
+		} catch (err) {
+			next(err);
+		}
+	},
+);
+accountController.post(
+	"/me/promo-claim",
+	verifyUserAuthentication,
+	async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+		try {
+			validateClaimPromoRequest(req.body);
+			const result = await claimPromo(req.body);
+			res.status(HTTP_STATUS.SUCCESSFUL.OK).json({ data: result });
 		} catch (err) {
 			next(err);
 		}

--- a/packages/api/src/account/controller/create_storage_adjustments.test.ts
+++ b/packages/api/src/account/controller/create_storage_adjustments.test.ts
@@ -278,9 +278,10 @@ describe("/account/storage-adjustments", () => {
 		const testError = new Error("test error");
 		const spy = vi.spyOn(db, "sql");
 		when(spy)
-			.calledWith("account.queries.adjust_account_storage", {
+			.calledWith("storage.queries.adjust_account_storage", {
 				accountId: testAccountId,
 				storageAmountInBytes: 5 * GB,
+				ledgerType: "type.billing.transfer.admin_adjustment",
 			})
 			.thenReject(testError);
 

--- a/packages/api/src/account/fixtures/create_test_account_space.sql
+++ b/packages/api/src/account/fixtures/create_test_account_space.sql
@@ -1,0 +1,46 @@
+INSERT INTO
+account_space (
+  accountid,
+  spaceleft,
+  spacetotal,
+  fileleft,
+  filetotal,
+  status,
+  type,
+  createddt,
+  updateddt
+)
+VALUES
+(
+  2,
+  2147483648,
+  2147483648,
+  100000,
+  100000,
+  'status.generic.ok',
+  'type.generic.placeholder',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
+),
+(
+  3,
+  2147483648,
+  2147483648,
+  100000,
+  100000,
+  'status.generic.ok',
+  'type.generic.placeholder',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
+),
+(
+  4,
+  2147483648,
+  2147483648,
+  100000,
+  100000,
+  'status.generic.ok',
+  'type.generic.placeholder',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
+);

--- a/packages/api/src/account/fixtures/create_test_promos_for_claim.sql
+++ b/packages/api/src/account/fixtures/create_test_promos_for_claim.sql
@@ -1,0 +1,56 @@
+INSERT INTO promo (
+  promoid,
+  code,
+  sizeinmb,
+  expiresdt,
+  remaininguses,
+  status,
+  type,
+  createddt,
+  updateddt
+)
+VALUES
+(
+  1,
+  'VALID_PROMO',
+  1024,
+  '2030-12-31',
+  100,
+  'status.promo.valid',
+  'type.generic.ok',
+  '2020-01-01',
+  '2020-01-01'
+),
+(
+  2,
+  'INVALID_PROMO',
+  1024,
+  '2030-12-31',
+  100,
+  'status.promo.invalid',
+  'type.generic.ok',
+  '2020-01-01',
+  '2020-01-01'
+),
+(
+  3,
+  'EXPIRED_PROMO',
+  1024,
+  '2020-01-01',
+  100,
+  'status.promo.valid',
+  'type.generic.ok',
+  '2020-01-01',
+  '2020-01-01'
+),
+(
+  4,
+  'NO_USES_PROMO',
+  1024,
+  '2030-12-31',
+  0,
+  'status.promo.valid',
+  'type.generic.ok',
+  '2020-01-01',
+  '2020-01-01'
+);

--- a/packages/api/src/account/service.ts
+++ b/packages/api/src/account/service.ts
@@ -314,9 +314,10 @@ export const createStorageAdjustment = async (
 			storageTotalInBytes: bigint;
 			adjustmentSizeInBytes: bigint;
 			createdAt: Date;
-		}>("account.queries.adjust_account_storage", {
+		}>("storage.queries.adjust_account_storage", {
 			accountId,
 			storageAmountInBytes: requestBody.storageAmount * GB,
+			ledgerType: "type.billing.transfer.admin_adjustment",
 		})
 		.catch((err: unknown) => {
 			logger.error(err);

--- a/packages/api/src/promo/models.ts
+++ b/packages/api/src/promo/models.ts
@@ -1,3 +1,26 @@
+export interface ClaimPromoRequest {
+	emailFromAuthToken: string;
+	userSubjectFromAuthToken: string;
+	promoCode: string;
+}
+
+export interface ClaimPromoResponse {
+	storageGrantInGb: number;
+}
+
+export interface PromoByCodeRow {
+	id: string;
+	storageInMB: string;
+	expirationTimestamp: Date;
+	remainingUses: string;
+	status: string;
+}
+
+export interface AccountPromoCheckRow {
+	accountId: string;
+	existingClaimId: string | null;
+}
+
 export interface CreatePromoRequest {
 	emailFromAuthToken: string;
 	adminSubjectFromAuthToken: string;
@@ -11,22 +34,22 @@ export interface Promo {
 	id: string;
 	code: string;
 	storageInMB: number;
-	expirationTimestamp: string;
+	expirationTimestamp: Date;
 	remainingUses: number;
 	status: string;
 	type: string;
-	createdAt: string;
-	updatedAt: string;
+	createdAt: Date;
+	updatedAt: Date;
 }
 
 export interface PromoRow {
 	id: string;
 	code: string;
 	storageInMB: string;
-	expirationTimestamp: string;
+	expirationTimestamp: Date;
 	remainingUses: string;
 	status: string;
 	type: string;
-	createdAt: string;
-	updatedAt: string;
+	createdAt: Date;
+	updatedAt: Date;
 }

--- a/packages/api/src/promo/queries/check_account_promo.sql
+++ b/packages/api/src/promo/queries/check_account_promo.sql
@@ -1,0 +1,12 @@
+SELECT
+  account.accountid AS "accountId",
+  account_promo.account_promoid AS "existingClaimId"
+FROM
+  account
+LEFT JOIN
+  account_promo
+  ON
+    account.accountid = account_promo.accountid
+    AND account_promo.promoid = :promoId
+WHERE
+  LOWER(account.primaryemail) = :email

--- a/packages/api/src/promo/queries/create_account_promo.sql
+++ b/packages/api/src/promo/queries/create_account_promo.sql
@@ -1,0 +1,16 @@
+INSERT INTO account_promo (
+  accountid,
+  promoid,
+  status,
+  type,
+  createddt,
+  updateddt
+)
+VALUES (
+  :accountId,
+  :promoId,
+  'status.generic.ok',
+  'type.generic.placeholder',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
+)

--- a/packages/api/src/promo/queries/decrement_promo_remaining_uses.sql
+++ b/packages/api/src/promo/queries/decrement_promo_remaining_uses.sql
@@ -1,0 +1,10 @@
+UPDATE
+  promo
+SET
+  remaininguses = remaininguses - 1,
+  updateddt = CURRENT_TIMESTAMP
+WHERE
+  promoid = :promoId
+  AND remaininguses > 0
+RETURNING
+  promoid AS id

--- a/packages/api/src/promo/queries/get_promo_by_code.sql
+++ b/packages/api/src/promo/queries/get_promo_by_code.sql
@@ -1,0 +1,11 @@
+SELECT
+  promoid AS id,
+  sizeinmb AS "storageInMB",
+  expiresdt AS "expirationTimestamp",
+  remaininguses AS "remainingUses",
+  status
+FROM
+  promo
+WHERE
+  code = :promoCode
+FOR UPDATE

--- a/packages/api/src/promo/service.ts
+++ b/packages/api/src/promo/service.ts
@@ -1,7 +1,116 @@
 import createError from "http-errors";
 import { logger } from "@stela/logger";
 import { db } from "../database.js";
-import type { CreatePromoRequest, Promo, PromoRow } from "./models.js";
+import { KB } from "../constants.js";
+import type {
+	AccountPromoCheckRow,
+	ClaimPromoRequest,
+	ClaimPromoResponse,
+	CreatePromoRequest,
+	Promo,
+	PromoByCodeRow,
+	PromoRow,
+} from "./models.js";
+
+export const claimPromo = async (
+	data: ClaimPromoRequest,
+): Promise<ClaimPromoResponse> =>
+	await db.transaction(async (transactionDb) => {
+		const promoResult = await transactionDb
+			.sql<PromoByCodeRow>("promo.queries.get_promo_by_code", {
+				promoCode: data.promoCode,
+			})
+			.catch((err: unknown) => {
+				logger.error(err);
+				throw new createError.InternalServerError(
+					"Failed to look up promo code",
+				);
+			});
+
+		const {
+			rows: [promo],
+		} = promoResult;
+		if (
+			promo?.status !== "status.promo.valid" ||
+			promo.expirationTimestamp <= new Date() ||
+			+promo.remainingUses <= 0
+		) {
+			throw new createError.BadRequest("Invalid promo code");
+		}
+
+		const accountCheckResult = await transactionDb
+			.sql<AccountPromoCheckRow>("promo.queries.check_account_promo", {
+				email: data.emailFromAuthToken.toLowerCase(),
+				promoId: promo.id,
+			})
+			.catch((err: unknown) => {
+				logger.error(err);
+				throw new createError.InternalServerError(
+					"Failed to check promo claim status",
+				);
+			});
+
+		const {
+			rows: [accountCheck],
+		} = accountCheckResult;
+		if (accountCheck === undefined) {
+			throw new createError.NotFound("Account not found");
+		}
+		if (accountCheck.existingClaimId !== null) {
+			throw new createError.BadRequest(
+				"Promo code has already been claimed by this account",
+			);
+		}
+
+		const decrementResult = await transactionDb
+			.sql("promo.queries.decrement_promo_remaining_uses", {
+				promoId: promo.id,
+			})
+			.catch((err: unknown) => {
+				logger.error(err);
+				throw new createError.InternalServerError("Failed to claim promo code");
+			});
+
+		if (decrementResult.rows.length === 0) {
+			throw new createError.BadRequest("Invalid promo code");
+		}
+
+		await transactionDb
+			.sql("promo.queries.create_account_promo", {
+				accountId: accountCheck.accountId,
+				promoId: promo.id,
+			})
+			.catch((err: unknown) => {
+				logger.error(err);
+				throw new createError.InternalServerError(
+					"Failed to record promo claim",
+				);
+			});
+
+		const adjustmentResult = await transactionDb
+			.sql("storage.queries.adjust_account_storage", {
+				accountId: accountCheck.accountId,
+				storageAmountInBytes: +promo.storageInMB * KB * KB,
+				ledgerType: "type.billing.transfer.promo",
+			})
+			.catch((err: unknown) => {
+				logger.error(err);
+				throw new createError.InternalServerError(
+					"Failed to apply promo storage",
+				);
+			});
+
+		if (adjustmentResult.rows.length === 0) {
+			logger.error(
+				"Storage update query in claimPromo returned 0 rows, meaning no update occurred",
+			);
+			throw new createError.InternalServerError(
+				"Failed to apply promo storage",
+			);
+		}
+
+		return { storageGrantInGb: +promo.storageInMB / KB };
+	});
 
 export const createPromo = async (
 	promoData: CreatePromoRequest,

--- a/packages/api/src/promo/validators.ts
+++ b/packages/api/src/promo/validators.ts
@@ -1,6 +1,26 @@
 import Joi from "joi";
-import type { CreatePromoRequest } from "./models.js";
-import { fieldsFromAdminAuthentication } from "../validators/index.js";
+import type { ClaimPromoRequest, CreatePromoRequest } from "./models.js";
+import {
+	fieldsFromAdminAuthentication,
+	fieldsFromUserAuthentication,
+} from "../validators/index.js";
+
+export const validateClaimPromoRequest: (
+	data: unknown,
+) => asserts data is ClaimPromoRequest = (
+	data: unknown,
+): asserts data is ClaimPromoRequest => {
+	const validation = Joi.object()
+		.keys({
+			...fieldsFromUserAuthentication,
+			promoCode: Joi.string().required(),
+		})
+		.validate(data);
+
+	if (validation.error !== undefined) {
+		throw validation.error;
+	}
+};
 
 const MINIMUM_STORAGE_AWARD = 1;
 const MINIMUM_USES = 1;

--- a/packages/api/src/storage/queries/adjust_account_storage.sql
+++ b/packages/api/src/storage/queries/adjust_account_storage.sql
@@ -38,7 +38,7 @@ ledger_financial (
   updateddt
 )
 SELECT
-  'type.billing.transfer.admin_adjustment' AS type,
+  :ledgerType AS type,
   :storageAmountInBytes,
   0 AS filedelta,
   0 AS fromaccountid,


### PR DESCRIPTION
Users will be able to claim their welcome promo from the dashboard in the Vision 2030 design. To that end, this commit adds a promo-claim endpoint.