### PR TITLE
Specify created/updated timestamps in account_archive test fixtures

### DIFF
--- a/packages/api/src/access/fixtures/create_test_account_archives.sql
+++ b/packages/api/src/access/fixtures/create_test_account_archives.sql
@@ -6,7 +6,9 @@ account_archive (
   accessrole,
   position,
   type,
-  status
+  status,
+  createddt,
+  updateddt
 )
 VALUES
 (
@@ -16,7 +18,9 @@ VALUES
   'access.role.owner',
   0,
   'type.account.standard',
-  'status.generic.ok'
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   4,
@@ -25,7 +29,9 @@ VALUES
   'access.role.owner',
   0,
   'type.account.standard',
-  'status.generic.ok'
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   5,
@@ -34,7 +40,9 @@ VALUES
   'access.role.owner',
   0,
   'type.account.standard',
-  'status.generic.ok'
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   6,
@@ -43,7 +51,9 @@ VALUES
   'access.role.manager',
   0,
   'type.account.standard',
-  'status.generic.ok'
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   7,
@@ -52,7 +62,9 @@ VALUES
   'access.role.manager',
   0,
   'type.account.standard',
-  'status.generic.deleted'
+  'status.generic.deleted',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   8,
@@ -61,5 +73,7 @@ VALUES
   'access.role.manager',
   0,
   'type.account.standard',
-  'status.generic.ok'
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 );

--- a/packages/api/src/account/fixtures/create_test_account_archives.sql
+++ b/packages/api/src/account/fixtures/create_test_account_archives.sql
@@ -6,7 +6,9 @@ account_archive (
   accessrole,
   position,
   type,
-  status
+  status,
+  createddt,
+  updateddt
 )
 VALUES
 (
@@ -16,7 +18,9 @@ VALUES
   'access.role.owner',
   0,
   'type.account.standard',
-  'status.generic.ok'
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   5,
@@ -25,7 +29,9 @@ VALUES
   'access.role.viewer',
   0,
   'type.account.standard',
-  'status.generic.ok'
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   8,
@@ -34,7 +40,9 @@ VALUES
   'access.role.owner',
   0,
   'type.account.standard',
-  'status.generic.ok'
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   13,
@@ -43,7 +51,9 @@ VALUES
   'access.role.owner',
   0,
   'type.account.standard',
-  'status.generic.ok'
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   21,
@@ -52,7 +62,9 @@ VALUES
   'access.role.viewer',
   0,
   'type.account.standard',
-  'status.generic.pending'
+  'status.generic.pending',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   34,
@@ -61,5 +73,7 @@ VALUES
   'access.role.curator',
   0,
   'type.account.standard',
-  'status.generic.deleted'
+  'status.generic.deleted',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 );

--- a/packages/api/src/archive/fixtures/create_test_account_archives.sql
+++ b/packages/api/src/archive/fixtures/create_test_account_archives.sql
@@ -6,7 +6,9 @@ account_archive (
   accessrole,
   position,
   type,
-  status
+  status,
+  createddt,
+  updateddt
 )
 VALUES
 (
@@ -16,7 +18,9 @@ VALUES
   'access.role.owner',
   0,
   'type.account.standard',
-  'status.generic.ok'
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   5,
@@ -25,7 +29,9 @@ VALUES
   'access.role.viewer',
   0,
   'type.account.standard',
-  'status.generic.ok'
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   8,
@@ -34,7 +40,9 @@ VALUES
   'access.role.owner',
   0,
   'type.account.standard',
-  'status.generic.ok'
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   13,
@@ -43,7 +51,9 @@ VALUES
   'access.role.owner',
   0,
   'type.account.standard',
-  'status.generic.ok'
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   21,
@@ -52,7 +62,9 @@ VALUES
   'access.role.viewer',
   0,
   'type.account.standard',
-  'status.generic.pending'
+  'status.generic.pending',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   34,
@@ -61,7 +73,9 @@ VALUES
   'access.role.curator',
   0,
   'type.account.standard',
-  'status.generic.deleted'
+  'status.generic.deleted',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   35,
@@ -70,7 +84,9 @@ VALUES
   'access.role.curator',
   0,
   'type.account.standard',
-  'status.generic.deleted'
+  'status.generic.deleted',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   36,
@@ -79,7 +95,9 @@ VALUES
   'access.role.owner',
   0,
   'type.account.standard',
-  'status.generic.ok'
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   37,
@@ -88,5 +106,7 @@ VALUES
   'access.role.owner',
   0,
   'type.account.standard',
-  'status.generic.ok'
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 );

--- a/packages/api/src/directive/fixtures/create_test_account_archives.sql
+++ b/packages/api/src/directive/fixtures/create_test_account_archives.sql
@@ -6,7 +6,9 @@ account_archive (
   accessrole,
   position,
   type,
-  status
+  status,
+  createddt,
+  updateddt
 )
 VALUES
 (
@@ -16,7 +18,9 @@ VALUES
   'access.role.owner',
   0,
   'type.account.standard',
-  'status.generic.ok'
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   5,
@@ -25,7 +29,9 @@ VALUES
   'access.role.viewer',
   0,
   'type.account.standard',
-  'status.generic.ok'
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   8,
@@ -34,7 +40,9 @@ VALUES
   'access.role.owner',
   0,
   'type.account.standard',
-  'status.generic.ok'
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   13,
@@ -43,7 +51,9 @@ VALUES
   'access.role.owner',
   0,
   'type.account.standard',
-  'status.generic.ok'
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   21,
@@ -52,7 +62,9 @@ VALUES
   'access.role.viewer',
   0,
   'type.account.standard',
-  'status.generic.pending'
+  'status.generic.pending',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   34,
@@ -61,5 +73,7 @@ VALUES
   'access.role.curator',
   0,
   'type.account.standard',
-  'status.generic.deleted'
+  'status.generic.deleted',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 );

--- a/packages/api/src/email/fixtures/create_test_account_archives.sql
+++ b/packages/api/src/email/fixtures/create_test_account_archives.sql
@@ -6,7 +6,9 @@ account_archive (
   accessrole,
   position,
   type,
-  status
+  status,
+  createddt,
+  updateddt
 )
 VALUES
 (
@@ -16,7 +18,9 @@ VALUES
   'access.role.owner',
   0,
   'type.account.standard',
-  'status.generic.ok'
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   5,
@@ -25,7 +29,9 @@ VALUES
   'access.role.viewer',
   0,
   'type.account.standard',
-  'status.generic.ok'
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   8,
@@ -34,7 +40,9 @@ VALUES
   'access.role.owner',
   0,
   'type.account.standard',
-  'status.generic.ok'
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   13,
@@ -43,7 +51,9 @@ VALUES
   'access.role.owner',
   0,
   'type.account.standard',
-  'status.generic.ok'
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   21,
@@ -52,7 +62,9 @@ VALUES
   'access.role.viewer',
   0,
   'type.account.standard',
-  'status.generic.pending'
+  'status.generic.pending',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   34,
@@ -61,5 +73,7 @@ VALUES
   'access.role.curator',
   0,
   'type.account.standard',
-  'status.generic.deleted'
+  'status.generic.deleted',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 );

--- a/packages/api/src/folder/fixtures/create_test_account_archives.sql
+++ b/packages/api/src/folder/fixtures/create_test_account_archives.sql
@@ -6,7 +6,9 @@ account_archive (
   accessrole,
   position,
   type,
-  status
+  status,
+  createddt,
+  updateddt
 )
 VALUES
 (
@@ -16,7 +18,9 @@ VALUES
   'access.role.owner',
   0,
   'type.account.standard',
-  'status.generic.ok'
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   5,
@@ -25,7 +29,9 @@ VALUES
   'access.role.viewer',
   0,
   'type.account.standard',
-  'status.generic.ok'
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   8,
@@ -34,7 +40,9 @@ VALUES
   'access.role.owner',
   0,
   'type.account.standard',
-  'status.generic.ok'
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   13,
@@ -43,7 +51,9 @@ VALUES
   'access.role.owner',
   0,
   'type.account.standard',
-  'status.generic.ok'
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   21,
@@ -52,7 +62,9 @@ VALUES
   'access.role.viewer',
   0,
   'type.account.standard',
-  'status.generic.pending'
+  'status.generic.pending',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   34,
@@ -61,7 +73,9 @@ VALUES
   'access.role.curator',
   0,
   'type.account.standard',
-  'status.generic.deleted'
+  'status.generic.deleted',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   35,
@@ -70,7 +84,9 @@ VALUES
   'access.role.owner',
   0,
   'type.account.standard',
-  'status.generic.ok'
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   36,
@@ -79,7 +95,9 @@ VALUES
   'access.role.owner',
   0,
   'type.account.standard',
-  'status.generic.ok'
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   37,
@@ -88,7 +106,9 @@ VALUES
   'access.role.owner',
   0,
   'type.account.standard',
-  'status.generic.deleted'
+  'status.generic.deleted',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   38,
@@ -97,5 +117,7 @@ VALUES
   'access.role.contributor',
   0,
   'type.account.standard',
-  'status.generic.deleted'
+  'status.generic.deleted',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 );

--- a/packages/api/src/record/fixtures/create_test_account_archives.sql
+++ b/packages/api/src/record/fixtures/create_test_account_archives.sql
@@ -6,7 +6,9 @@ account_archive (
   accessrole,
   position,
   type,
-  status
+  status,
+  createddt,
+  updateddt
 )
 VALUES
 (
@@ -16,7 +18,9 @@ VALUES
   'access.role.owner',
   0,
   'type.account.standard',
-  'status.generic.ok'
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   5,
@@ -25,7 +29,9 @@ VALUES
   'access.role.viewer',
   0,
   'type.account.standard',
-  'status.generic.ok'
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   8,
@@ -34,7 +40,9 @@ VALUES
   'access.role.owner',
   0,
   'type.account.standard',
-  'status.generic.ok'
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   13,
@@ -43,7 +51,9 @@ VALUES
   'access.role.owner',
   0,
   'type.account.standard',
-  'status.generic.ok'
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   21,
@@ -52,7 +62,9 @@ VALUES
   'access.role.viewer',
   0,
   'type.account.standard',
-  'status.generic.pending'
+  'status.generic.pending',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   34,
@@ -61,7 +73,9 @@ VALUES
   'access.role.curator',
   0,
   'type.account.standard',
-  'status.generic.deleted'
+  'status.generic.deleted',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   35,
@@ -70,5 +84,7 @@ VALUES
   'access.role.curator',
   0,
   'type.account.standard',
-  'status.generic.ok'
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 );

--- a/packages/api/src/share_link/fixtures/create_test_account_archives.sql
+++ b/packages/api/src/share_link/fixtures/create_test_account_archives.sql
@@ -6,7 +6,9 @@ account_archive (
   accessrole,
   position,
   type,
-  status
+  status,
+  createddt,
+  updateddt
 )
 VALUES
 (
@@ -16,7 +18,9 @@ VALUES
   'access.role.owner',
   0,
   'type.account.standard',
-  'status.generic.ok'
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 ),
 (
   4,
@@ -25,5 +29,7 @@ VALUES
   'access.role.editor',
   0,
   'type.account.standard',
-  'status.generic.ok'
+  'status.generic.ok',
+  CURRENT_TIMESTAMP,
+  CURRENT_TIMESTAMP
 );


### PR DESCRIPTION
We recently updated the database to make the createddt and updateddt columns of account_archive non-nullable. This commit updates the test fixtures of this repo to set those values the tests here continue to work.