### PR TITLE
Optimize API tests

### DIFF
--- a/packages/api/src/access/permission.test.ts
+++ b/packages/api/src/access/permission.test.ts
@@ -1,5 +1,13 @@
 import createError from "http-errors";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+	vi,
+} from "vitest";
 import {
 	getArchiveAccessRole,
 	getRecordAccessRole,
@@ -8,17 +16,20 @@ import {
 } from "./permission.js";
 import { AccessRole } from "./models.js";
 import { db } from "../database.js";
+import { runFixtures } from "../../test/run_fixtures.js";
 
 vi.mock("../database");
 
 const loadFixtures = async (): Promise<void> => {
-	await db.sql("access.fixtures.create_test_accounts");
-	await db.sql("access.fixtures.create_test_archives");
-	await db.sql("access.fixtures.create_test_account_archives");
-	await db.sql("access.fixtures.create_test_records");
-	await db.sql("access.fixtures.create_test_folders");
-	await db.sql("access.fixtures.create_test_folder_links");
-	await db.sql("access.fixtures.create_test_accesses");
+	await runFixtures(db, [
+		"access.fixtures.create_test_accounts",
+		"access.fixtures.create_test_archives",
+		"access.fixtures.create_test_account_archives",
+		"access.fixtures.create_test_records",
+		"access.fixtures.create_test_folders",
+		"access.fixtures.create_test_folder_links",
+		"access.fixtures.create_test_accesses",
+	]);
 };
 
 const clearDatabase = async (): Promise<void> => {
@@ -35,6 +46,9 @@ describe("getArchiveAccessRole", () => {
 
 	afterEach(async () => {
 		vi.restoreAllMocks();
+	});
+
+	afterAll(async () => {
 		await clearDatabase();
 	});
 
@@ -99,6 +113,9 @@ describe("getRecordAccessRole", () => {
 
 	afterEach(async () => {
 		vi.restoreAllMocks();
+	});
+
+	afterAll(async () => {
 		await clearDatabase();
 	});
 
@@ -223,7 +240,7 @@ describe("getFolderAccessRole", () => {
 		await loadFixtures();
 	});
 
-	afterEach(async () => {
+	afterAll(async () => {
 		await clearDatabase();
 	});
 
@@ -317,6 +334,9 @@ describe("isItemPublic", () => {
 
 	afterEach(async () => {
 		vi.restoreAllMocks();
+	});
+
+	afterAll(async () => {
 		await clearDatabase();
 	});
 	test("should return true for a public record", async () => {

--- a/packages/api/src/account/controller/claim_promo.test.ts
+++ b/packages/api/src/account/controller/claim_promo.test.ts
@@ -1,5 +1,13 @@
 import request from "supertest";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+	vi,
+} from "vitest";
 import type { NextFunction } from "express";
 import createError from "http-errors";
 import type { TinyPg, TinyPgParams } from "tinypg";
@@ -9,6 +17,7 @@ import { db } from "../../database.js";
 import { GB } from "../../constants.js";
 import { verifyUserAuthentication } from "../../middleware/index.js";
 import { mockVerifyUserAuthentication } from "../../../test/middleware_mocks.js";
+import { runFixtures } from "../../../test/run_fixtures.js";
 
 vi.mock("../../database");
 vi.mock("../../middleware");
@@ -61,9 +70,11 @@ describe("POST /accounts/me/promo-claim", () => {
 	const agent = request(app);
 
 	const setupDatabase = async (): Promise<void> => {
-		await db.sql("account.fixtures.create_test_accounts");
-		await db.sql("account.fixtures.create_test_account_space");
-		await db.sql("account.fixtures.create_test_promos_for_claim");
+		await runFixtures(db, [
+			"account.fixtures.create_test_accounts",
+			"account.fixtures.create_test_account_space",
+			"account.fixtures.create_test_promos_for_claim",
+		]);
 	};
 
 	const clearDatabase = async (): Promise<void> => {
@@ -99,8 +110,11 @@ describe("POST /accounts/me/promo-claim", () => {
 	});
 
 	afterEach(async () => {
-		await clearDatabase();
 		vi.restoreAllMocks();
+	});
+
+	afterAll(async () => {
+		await clearDatabase();
 	});
 
 	test("should return 200 with the storage grant in GB", async () => {

--- a/packages/api/src/account/controller/create_storage_adjustments.test.ts
+++ b/packages/api/src/account/controller/create_storage_adjustments.test.ts
@@ -1,5 +1,13 @@
 import request from "supertest";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+	vi,
+} from "vitest";
 import { when } from "vitest-when";
 import { logger } from "@stela/logger";
 import { app } from "../../app.js";
@@ -8,6 +16,7 @@ import { GB } from "../../constants.js";
 import { verifyAdminAuthentication } from "../../middleware/index.js";
 import type { StorageAdjustment } from "../models.js";
 import { mockVerifyAdminAuthentication } from "../../../test/middleware_mocks.js";
+import { runFixtures } from "../../../test/run_fixtures.js";
 
 vi.mock("../../database");
 vi.mock("../../middleware");
@@ -34,9 +43,11 @@ describe("/account/storage-adjustments", () => {
 	const agent = request(app);
 
 	const setupDatabase = async (): Promise<void> => {
-		await db.sql("storage.fixtures.create_test_accounts");
-		await db.sql("storage.fixtures.create_test_account_space");
-		await db.sql("storage.fixtures.create_test_emails");
+		await runFixtures(db, [
+			"storage.fixtures.create_test_accounts",
+			"storage.fixtures.create_test_account_space",
+			"storage.fixtures.create_test_emails",
+		]);
 	};
 
 	const clearDatabase = async (): Promise<void> => {
@@ -55,8 +66,11 @@ describe("/account/storage-adjustments", () => {
 	});
 
 	afterEach(async () => {
-		await clearDatabase();
 		vi.resetAllMocks();
+	});
+
+	afterAll(async () => {
+		await clearDatabase();
 	});
 
 	test("should call verifyAdminAuthentication", async () => {

--- a/packages/api/src/account/controller/get_accounts.test.ts
+++ b/packages/api/src/account/controller/get_accounts.test.ts
@@ -1,5 +1,13 @@
 import request from "supertest";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+	vi,
+} from "vitest";
 import { logger } from "@stela/logger";
 import { app } from "../../app.js";
 import { db } from "../../database.js";
@@ -32,8 +40,11 @@ describe("GET /account", () => {
 	});
 
 	afterEach(async () => {
-		await clearDatabase();
 		vi.clearAllMocks();
+	});
+
+	afterAll(async () => {
+		await clearDatabase();
 	});
 
 	test("should call verifyAdminAuthentication", async () => {

--- a/packages/api/src/account/controller/get_accounts_me.test.ts
+++ b/packages/api/src/account/controller/get_accounts_me.test.ts
@@ -1,21 +1,32 @@
 import request from "supertest";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+	vi,
+} from "vitest";
 import { logger } from "@stela/logger";
 import { app } from "../../app.js";
 import { db } from "../../database.js";
 import { verifyUserAuthentication } from "../../middleware/index.js";
 import { mockVerifyUserAuthentication } from "../../../test/middleware_mocks.js";
 import type { Account } from "../models.js";
+import { runFixtures } from "../../../test/run_fixtures.js";
 
 vi.mock("../../database");
 vi.mock("../../middleware");
 vi.mock("@stela/logger");
 
 const setupDatabase = async (): Promise<void> => {
-	await db.sql("account.fixtures.create_test_accounts");
-	await db.sql("account.fixtures.create_test_archives");
-	await db.sql("account.fixtures.create_test_account_archives");
-	await db.sql("account.fixtures.create_test_profile_items");
+	await runFixtures(db, [
+		"account.fixtures.create_test_accounts",
+		"account.fixtures.create_test_archives",
+		"account.fixtures.create_test_account_archives",
+		"account.fixtures.create_test_profile_items",
+	]);
 };
 
 const clearDatabase = async (): Promise<void> => {
@@ -37,8 +48,11 @@ describe("GET /accounts/me", () => {
 	});
 
 	afterEach(async () => {
-		await clearDatabase();
 		vi.clearAllMocks();
+	});
+
+	afterAll(async () => {
+		await clearDatabase();
 	});
 
 	test("should call verifyUserAuthentication", async () => {

--- a/packages/api/src/account/controller/get_signup_details.test.ts
+++ b/packages/api/src/account/controller/get_signup_details.test.ts
@@ -1,18 +1,29 @@
 import request from "supertest";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+	vi,
+} from "vitest";
 import { logger } from "@stela/logger";
 import { app } from "../../app.js";
 import { db } from "../../database.js";
 import type { SignupDetails } from "../models.js";
 import { mockVerifyUserAuthentication } from "../../../test/middleware_mocks.js";
+import { runFixtures } from "../../../test/run_fixtures.js";
 
 vi.mock("../../database");
 vi.mock("../../middleware");
 vi.mock("@stela/logger");
 
 const loadFixtures = async (): Promise<void> => {
-	await db.sql("account.fixtures.create_test_accounts");
-	await db.sql("account.fixtures.create_test_invites");
+	await runFixtures(db, [
+		"account.fixtures.create_test_accounts",
+		"account.fixtures.create_test_invites",
+	]);
 };
 
 const clearDatabase = async (): Promise<void> => {
@@ -30,6 +41,9 @@ describe("getSignupDetails", () => {
 	});
 	afterEach(async () => {
 		vi.clearAllMocks();
+	});
+
+	afterAll(async () => {
 		await clearDatabase();
 	});
 

--- a/packages/api/src/account/controller/leave_archive.test.ts
+++ b/packages/api/src/account/controller/leave_archive.test.ts
@@ -6,6 +6,7 @@ import { db } from "../../database.js";
 import { EVENT_ACTION, EVENT_ACTOR, EVENT_ENTITY } from "../../constants.js";
 import { app } from "../../app.js";
 import { createEvent } from "../../event/service.js";
+import { runFixtures } from "../../../test/run_fixtures.js";
 import {
 	mockVerifyUserAuthentication,
 	mockExtractIp,
@@ -16,9 +17,11 @@ vi.mock("../../middleware");
 vi.mock("../../event/service");
 
 const loadFixtures = async (): Promise<void> => {
-	await db.sql("account.fixtures.create_test_accounts");
-	await db.sql("account.fixtures.create_test_archives");
-	await db.sql("account.fixtures.create_test_account_archives");
+	await runFixtures(db, [
+		"account.fixtures.create_test_accounts",
+		"account.fixtures.create_test_archives",
+		"account.fixtures.create_test_account_archives",
+	]);
 };
 
 const clearDatabase = async (): Promise<void> => {

--- a/packages/api/src/account/service.test.ts
+++ b/packages/api/src/account/service.test.ts
@@ -1,15 +1,18 @@
 import { InternalServerError } from "http-errors";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
 import { db } from "../database.js";
 import { accountService } from "./service.js";
+import { runFixtures } from "../../test/run_fixtures.js";
 
 vi.mock("../database");
 
 const loadFixtures = async (): Promise<void> => {
-	await db.sql("account.fixtures.create_test_accounts");
-	await db.sql("account.fixtures.create_test_invites");
-	await db.sql("account.fixtures.create_test_archives");
-	await db.sql("account.fixtures.create_test_account_archives");
+	await runFixtures(db, [
+		"account.fixtures.create_test_accounts",
+		"account.fixtures.create_test_invites",
+		"account.fixtures.create_test_archives",
+		"account.fixtures.create_test_account_archives",
+	]);
 };
 
 const clearDatabase = async (): Promise<void> => {
@@ -22,7 +25,7 @@ describe("getAccountArchive", () => {
 		await loadFixtures();
 	});
 
-	afterEach(async () => {
+	afterAll(async () => {
 		await clearDatabase();
 	});
 

--- a/packages/api/src/admin/controller.test.ts
+++ b/packages/api/src/admin/controller.test.ts
@@ -1,5 +1,13 @@
 import request from "supertest";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+	vi,
+} from "vitest";
 import type { NextFunction } from "express";
 import createError from "http-errors";
 import { logger } from "@stela/logger";
@@ -8,6 +16,7 @@ import { db } from "../database.js";
 import { lowPriorityTopicArn, publisherClient } from "@stela/publisher-utils";
 import { verifyAdminAuthentication } from "../middleware/index.js";
 import { mockVerifyAdminAuthentication } from "../../test/middleware_mocks.js";
+import { runFixtures } from "../../test/run_fixtures.js";
 
 vi.mock("../database");
 vi.mock("@stela/logger");
@@ -34,7 +43,7 @@ describe("recalculateFolderThumbnails", () => {
 		await loadFixtures();
 	});
 
-	afterEach(async () => {
+	afterAll(async () => {
 		await clearDatabase();
 	});
 
@@ -134,7 +143,7 @@ describe("set_null_subjects", () => {
 		await loadFixtures();
 	});
 
-	afterEach(async () => {
+	afterAll(async () => {
 		await clearDatabase();
 	});
 
@@ -369,11 +378,13 @@ describe("/record/:recordId/recalculate_thumbnail", () => {
 	const agent = request(app);
 
 	const loadFixtures = async (): Promise<void> => {
-		await db.sql("admin.fixtures.create_test_accounts");
-		await db.sql("admin.fixtures.create_test_archives");
-		await db.sql("admin.fixtures.create_test_records");
-		await db.sql("admin.fixtures.create_test_folders");
-		await db.sql("admin.fixtures.create_test_folder_links");
+		await runFixtures(db, [
+			"admin.fixtures.create_test_accounts",
+			"admin.fixtures.create_test_archives",
+			"admin.fixtures.create_test_records",
+			"admin.fixtures.create_test_folders",
+			"admin.fixtures.create_test_folder_links",
+		]);
 	};
 
 	const clearDatabase = async (): Promise<void> => {
@@ -392,7 +403,7 @@ describe("/record/:recordId/recalculate_thumbnail", () => {
 		await loadFixtures();
 	});
 
-	afterEach(async () => {
+	afterAll(async () => {
 		await clearDatabase();
 	});
 
@@ -476,11 +487,13 @@ describe("/folder/delete-orphaned-folders", () => {
 	const agent = request(app);
 
 	const loadFixtures = async (): Promise<void> => {
-		await db.sql("admin.fixtures.create_test_accounts");
-		await db.sql("admin.fixtures.create_test_archives");
-		await db.sql("admin.fixtures.create_test_folders");
-		await db.sql("admin.fixtures.create_test_records");
-		await db.sql("admin.fixtures.create_test_folder_links");
+		await runFixtures(db, [
+			"admin.fixtures.create_test_accounts",
+			"admin.fixtures.create_test_archives",
+			"admin.fixtures.create_test_folders",
+			"admin.fixtures.create_test_records",
+			"admin.fixtures.create_test_folder_links",
+		]);
 	};
 
 	beforeEach(async () => {

--- a/packages/api/src/archive/controller/backfill_ledger.test.ts
+++ b/packages/api/src/archive/controller/backfill_ledger.test.ts
@@ -8,6 +8,7 @@ import { verifyAdminAuthentication } from "../../middleware/index.js";
 import { db } from "../../database.js";
 import { publisherClient } from "@stela/publisher-utils";
 import { mockVerifyAdminAuthentication } from "../../../test/middleware_mocks.js";
+import { runFixtures } from "../../../test/run_fixtures.js";
 
 vi.mock("../../database");
 vi.mock("../../middleware");
@@ -15,9 +16,11 @@ vi.mock("@stela/publisher-utils");
 vi.mock("@stela/logger");
 
 const loadFixtures = async (): Promise<void> => {
-	await db.sql("archive.fixtures.create_test_accounts");
-	await db.sql("archive.fixtures.create_test_archives");
-	await db.sql("archive.fixtures.create_test_records");
+	await runFixtures(db, [
+		"archive.fixtures.create_test_accounts",
+		"archive.fixtures.create_test_archives",
+		"archive.fixtures.create_test_records",
+	]);
 };
 
 const clearDatabase = async (): Promise<void> => {

--- a/packages/api/src/archive/controller/get_featured.test.ts
+++ b/packages/api/src/archive/controller/get_featured.test.ts
@@ -4,16 +4,19 @@ import { logger } from "@stela/logger";
 import { app } from "../../app.js";
 import { db } from "../../database.js";
 import type { FeaturedArchive } from "../models.js";
+import { runFixtures } from "../../../test/run_fixtures.js";
 
 vi.mock("../../database");
 vi.mock("@stela/logger");
 
 const loadFixtures = async (): Promise<void> => {
-	await db.sql("archive.fixtures.create_test_accounts");
-	await db.sql("archive.fixtures.create_test_archives");
-	await db.sql("archive.fixtures.create_test_featured_archives");
-	await db.sql("archive.fixtures.create_test_folders");
-	await db.sql("archive.fixtures.create_test_profile_items");
+	await runFixtures(db, [
+		"archive.fixtures.create_test_accounts",
+		"archive.fixtures.create_test_archives",
+		"archive.fixtures.create_test_featured_archives",
+		"archive.fixtures.create_test_folders",
+		"archive.fixtures.create_test_profile_items",
+	]);
 };
 
 const clearDatabase = async (): Promise<void> => {

--- a/packages/api/src/archive/controller/get_payer_account_storage.test.ts
+++ b/packages/api/src/archive/controller/get_payer_account_storage.test.ts
@@ -1,20 +1,31 @@
 import request from "supertest";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+	vi,
+} from "vitest";
 import { logger } from "@stela/logger";
 import { app } from "../../app.js";
 import { db } from "../../database.js";
 import { GB } from "../../constants.js";
 import { mockVerifyUserAuthentication } from "../../../test/middleware_mocks.js";
+import { runFixtures } from "../../../test/run_fixtures.js";
 
 vi.mock("../../database");
 vi.mock("../../middleware");
 vi.mock("@stela/logger");
 
 const loadFixtures = async (): Promise<void> => {
-	await db.sql("archive.fixtures.create_test_accounts");
-	await db.sql("archive.fixtures.create_test_archives");
-	await db.sql("archive.fixtures.create_test_account_archives");
-	await db.sql("archive.fixtures.create_test_account_space");
+	await runFixtures(db, [
+		"archive.fixtures.create_test_accounts",
+		"archive.fixtures.create_test_archives",
+		"archive.fixtures.create_test_account_archives",
+		"archive.fixtures.create_test_account_space",
+	]);
 };
 
 const clearDatabase = async (): Promise<void> => {
@@ -34,8 +45,11 @@ describe("getPayerAccountStorage", () => {
 		await loadFixtures();
 	});
 	afterEach(async () => {
-		await clearDatabase();
 		vi.clearAllMocks();
+	});
+
+	afterAll(async () => {
+		await clearDatabase();
 	});
 
 	test("should return payer account storage", async () => {

--- a/packages/api/src/archive/controller/get_public_tags.test.ts
+++ b/packages/api/src/archive/controller/get_public_tags.test.ts
@@ -1,19 +1,30 @@
 import request from "supertest";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+	vi,
+} from "vitest";
 import { logger } from "@stela/logger";
 import { app } from "../../app.js";
 import { db } from "../../database.js";
+import { runFixtures } from "../../../test/run_fixtures.js";
 
 vi.mock("../../database");
 vi.mock("@stela/logger");
 
 const loadFixtures = async (): Promise<void> => {
-	await db.sql("archive.fixtures.create_test_accounts");
-	await db.sql("archive.fixtures.create_test_archives");
-	await db.sql("archive.fixtures.create_test_records");
-	await db.sql("archive.fixtures.create_test_folders");
-	await db.sql("archive.fixtures.create_test_tags");
-	await db.sql("archive.fixtures.create_test_tag_links");
+	await runFixtures(db, [
+		"archive.fixtures.create_test_accounts",
+		"archive.fixtures.create_test_archives",
+		"archive.fixtures.create_test_records",
+		"archive.fixtures.create_test_folders",
+		"archive.fixtures.create_test_tags",
+		"archive.fixtures.create_test_tag_links",
+	]);
 };
 
 const clearDatabase = async (): Promise<void> => {
@@ -29,8 +40,11 @@ describe("getPublicTags", () => {
 		await loadFixtures();
 	});
 	afterEach(async () => {
-		await clearDatabase();
 		vi.clearAllMocks();
+	});
+
+	afterAll(async () => {
+		await clearDatabase();
 	});
 
 	test("should return public tags and not private or deleted tags", async () => {

--- a/packages/api/src/archive/controller/get_shared_folders.test.ts
+++ b/packages/api/src/archive/controller/get_shared_folders.test.ts
@@ -8,18 +8,21 @@ import { verifyUserAuthentication } from "../../middleware/index.js";
 import { db } from "../../database.js";
 import type { GetSharedFoldersResponse } from "../models.js";
 import { mockVerifyUserAuthentication } from "../../../test/middleware_mocks.js";
+import { runFixtures } from "../../../test/run_fixtures.js";
 
 vi.mock("../../database");
 vi.mock("../../middleware");
 vi.mock("@stela/logger");
 
 const loadFixtures = async (): Promise<void> => {
-	await db.sql("archive.fixtures.create_test_accounts");
-	await db.sql("archive.fixtures.create_test_archives");
-	await db.sql("archive.fixtures.create_test_account_archives");
-	await db.sql("archive.fixtures.create_test_folders");
-	await db.sql("archive.fixtures.create_test_folder_links");
-	await db.sql("archive.fixtures.create_test_shares");
+	await runFixtures(db, [
+		"archive.fixtures.create_test_accounts",
+		"archive.fixtures.create_test_archives",
+		"archive.fixtures.create_test_account_archives",
+		"archive.fixtures.create_test_folders",
+		"archive.fixtures.create_test_folder_links",
+		"archive.fixtures.create_test_shares",
+	]);
 };
 
 const clearDatabase = async (): Promise<void> => {

--- a/packages/api/src/archive/controller/make_featured.test.ts
+++ b/packages/api/src/archive/controller/make_featured.test.ts
@@ -4,14 +4,17 @@ import { logger } from "@stela/logger";
 import { app } from "../../app.js";
 import { db } from "../../database.js";
 import { mockVerifyAdminAuthentication } from "../../../test/middleware_mocks.js";
+import { runFixtures } from "../../../test/run_fixtures.js";
 
 vi.mock("../../database");
 vi.mock("../../middleware");
 vi.mock("@stela/logger");
 
 const loadFixtures = async (): Promise<void> => {
-	await db.sql("archive.fixtures.create_test_accounts");
-	await db.sql("archive.fixtures.create_test_archives");
+	await runFixtures(db, [
+		"archive.fixtures.create_test_accounts",
+		"archive.fixtures.create_test_archives",
+	]);
 };
 
 const clearDatabase = async (): Promise<void> => {

--- a/packages/api/src/archive/controller/search_archives.test.ts
+++ b/packages/api/src/archive/controller/search_archives.test.ts
@@ -4,6 +4,7 @@ import { logger } from "@stela/logger";
 import { app } from "../../app.js";
 import { db } from "../../database.js";
 import { ArchiveMembershipRole, type Archive } from "../models.js";
+import { runFixtures } from "../../../test/run_fixtures.js";
 import {
 	mockExtractUserIsAdminFromAuthToken,
 	mockExtractUserEmailFromAuthToken,
@@ -14,12 +15,14 @@ vi.mock("@stela/logger");
 vi.mock("../../middleware");
 
 const loadFixtures = async (): Promise<void> => {
-	await db.sql("archive.fixtures.create_test_accounts");
-	await db.sql("archive.fixtures.create_test_archives");
-	await db.sql("archive.fixtures.create_test_folders");
-	await db.sql("archive.fixtures.create_test_text_data");
-	await db.sql("archive.fixtures.create_test_profile_items");
-	await db.sql("archive.fixtures.create_test_account_archives");
+	await runFixtures(db, [
+		"archive.fixtures.create_test_accounts",
+		"archive.fixtures.create_test_archives",
+		"archive.fixtures.create_test_folders",
+		"archive.fixtures.create_test_text_data",
+		"archive.fixtures.create_test_profile_items",
+		"archive.fixtures.create_test_account_archives",
+	]);
 };
 
 const clearDatabase = async (): Promise<void> => {

--- a/packages/api/src/archive/controller/unfeature.test.ts
+++ b/packages/api/src/archive/controller/unfeature.test.ts
@@ -5,17 +5,20 @@ import { app } from "../../app.js";
 import { db } from "../../database.js";
 import { archiveService } from "../service/index.js";
 import { mockVerifyAdminAuthentication } from "../../../test/middleware_mocks.js";
+import { runFixtures } from "../../../test/run_fixtures.js";
 
 vi.mock("../../database");
 vi.mock("../../middleware");
 vi.mock("@stela/logger");
 
 const loadFixtures = async (): Promise<void> => {
-	await db.sql("archive.fixtures.create_test_accounts");
-	await db.sql("archive.fixtures.create_test_archives");
-	await db.sql("archive.fixtures.create_test_featured_archives");
-	await db.sql("archive.fixtures.create_test_folders");
-	await db.sql("archive.fixtures.create_test_profile_items");
+	await runFixtures(db, [
+		"archive.fixtures.create_test_accounts",
+		"archive.fixtures.create_test_archives",
+		"archive.fixtures.create_test_featured_archives",
+		"archive.fixtures.create_test_folders",
+		"archive.fixtures.create_test_profile_items",
+	]);
 };
 
 const clearDatabase = async (): Promise<void> => {

--- a/packages/api/src/archive/controller/update_archive.test.ts
+++ b/packages/api/src/archive/controller/update_archive.test.ts
@@ -5,18 +5,21 @@ import { app } from "../../app.js";
 import { db } from "../../database.js";
 import { mockVerifyUserAuthentication } from "../../../test/middleware_mocks.js";
 import type { Archive } from "../models.js";
+import { runFixtures } from "../../../test/run_fixtures.js";
 
 vi.mock("../../database");
 vi.mock("../../middleware");
 vi.mock("@stela/logger");
 
 const loadFixtures = async (): Promise<void> => {
-	await db.sql("archive.fixtures.create_test_accounts");
-	await db.sql("archive.fixtures.create_test_archives");
-	await db.sql("archive.fixtures.create_test_account_archives");
-	await db.sql("archive.fixtures.create_test_profile_items");
-	await db.sql("archive.fixtures.create_test_text_data");
-	await db.sql("archive.fixtures.create_test_folders");
+	await runFixtures(db, [
+		"archive.fixtures.create_test_accounts",
+		"archive.fixtures.create_test_archives",
+		"archive.fixtures.create_test_account_archives",
+		"archive.fixtures.create_test_profile_items",
+		"archive.fixtures.create_test_text_data",
+		"archive.fixtures.create_test_folders",
+	]);
 };
 
 const clearDatabase = async (): Promise<void> => {

--- a/packages/api/src/directive/controller.test.ts
+++ b/packages/api/src/directive/controller.test.ts
@@ -1,5 +1,13 @@
 import request from "supertest";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+	vi,
+} from "vitest";
 import { when } from "vitest-when";
 import { logger } from "@stela/logger";
 import { app } from "../app.js";
@@ -7,6 +15,7 @@ import { db } from "../database.js";
 import { sendArchiveStewardNotification } from "../email/index.js";
 import type { Directive, DirectiveTrigger } from "./model.js";
 import { legacyClient } from "../legacy_client.js";
+import { runFixtures } from "../../test/run_fixtures.js";
 import {
 	mockVerifyUserAuthentication,
 	mockVerifyAdminAuthentication,
@@ -28,11 +37,13 @@ describe("GET /directive/archive/:archiveId", () => {
 	const testEmail = "test@permanent.org";
 
 	const loadFixtures = async (): Promise<void> => {
-		await db.sql("directive.fixtures.create_test_accounts");
-		await db.sql("directive.fixtures.create_test_archives");
-		await db.sql("directive.fixtures.create_test_account_archives");
-		await db.sql("directive.fixtures.create_test_directives");
-		await db.sql("directive.fixtures.create_test_directive_triggers");
+		await runFixtures(db, [
+			"directive.fixtures.create_test_accounts",
+			"directive.fixtures.create_test_archives",
+			"directive.fixtures.create_test_account_archives",
+			"directive.fixtures.create_test_directives",
+			"directive.fixtures.create_test_directive_triggers",
+		]);
 	};
 
 	const clearDatabase = async (): Promise<void> => {
@@ -50,7 +61,8 @@ describe("GET /directive/archive/:archiveId", () => {
 		await clearDatabase();
 		await loadFixtures();
 	});
-	afterEach(async () => {
+
+	afterAll(async () => {
 		await clearDatabase();
 	});
 
@@ -109,9 +121,11 @@ describe("POST /directive", () => {
 	const stewardEmail = "test+1@permanent.org";
 
 	const loadFixtures = async (): Promise<void> => {
-		await db.sql("directive.fixtures.create_test_accounts");
-		await db.sql("directive.fixtures.create_test_archives");
-		await db.sql("directive.fixtures.create_test_account_archives");
+		await runFixtures(db, [
+			"directive.fixtures.create_test_accounts",
+			"directive.fixtures.create_test_archives",
+			"directive.fixtures.create_test_account_archives",
+		]);
 	};
 
 	const clearDatabase = async (): Promise<void> => {
@@ -130,8 +144,11 @@ describe("POST /directive", () => {
 		await loadFixtures();
 	});
 	afterEach(async () => {
-		await clearDatabase();
 		vi.resetAllMocks();
+	});
+
+	afterAll(async () => {
+		await clearDatabase();
 	});
 
 	test("should successfully create a directive and trigger", async () => {
@@ -343,11 +360,13 @@ describe("PUT /directive/:directiveId", () => {
 	const testNote = "test note";
 
 	const loadFixtures = async (): Promise<void> => {
-		await db.sql("directive.fixtures.create_test_accounts");
-		await db.sql("directive.fixtures.create_test_archives");
-		await db.sql("directive.fixtures.create_test_account_archives");
-		await db.sql("directive.fixtures.create_test_directives");
-		await db.sql("directive.fixtures.create_test_directive_triggers");
+		await runFixtures(db, [
+			"directive.fixtures.create_test_accounts",
+			"directive.fixtures.create_test_archives",
+			"directive.fixtures.create_test_account_archives",
+			"directive.fixtures.create_test_directives",
+			"directive.fixtures.create_test_directive_triggers",
+		]);
 	};
 
 	const clearDatabase = async (): Promise<void> => {
@@ -365,8 +384,11 @@ describe("PUT /directive/:directiveId", () => {
 		await loadFixtures();
 	});
 	afterEach(async () => {
-		await clearDatabase();
 		vi.resetAllMocks();
+	});
+
+	afterAll(async () => {
+		await clearDatabase();
 	});
 
 	test("should successfully update steward account and note", async () => {
@@ -638,11 +660,13 @@ describe("POST /trigger/account/:accountId", () => {
 	const testDirectiveId = "39b2a5fa-3508-4030-91b6-21dc6ec7a1ab";
 
 	const loadFixtures = async (): Promise<void> => {
-		await db.sql("directive.fixtures.create_test_accounts");
-		await db.sql("directive.fixtures.create_test_archives");
-		await db.sql("directive.fixtures.create_test_account_archives");
-		await db.sql("directive.fixtures.create_test_directives");
-		await db.sql("directive.fixtures.create_test_directive_triggers");
+		await runFixtures(db, [
+			"directive.fixtures.create_test_accounts",
+			"directive.fixtures.create_test_archives",
+			"directive.fixtures.create_test_account_archives",
+			"directive.fixtures.create_test_directives",
+			"directive.fixtures.create_test_directive_triggers",
+		]);
 	};
 
 	const clearDatabase = async (): Promise<void> => {
@@ -662,7 +686,8 @@ describe("POST /trigger/account/:accountId", () => {
 			"373f94fb-88f0-4acb-9638-9d554ec51520",
 		);
 	});
-	afterEach(async () => {
+
+	afterAll(async () => {
 		await clearDatabase();
 	});
 

--- a/packages/api/src/directive/service/utils.test.ts
+++ b/packages/api/src/directive/service/utils.test.ts
@@ -1,7 +1,8 @@
 import { NotFound } from "http-errors";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import { afterAll, beforeEach, describe, expect, test, vi } from "vitest";
 import { db } from "../../database.js";
 import { confirmArchiveOwnership } from "./utils.js";
+import { runFixtures } from "../../../test/run_fixtures.js";
 
 vi.mock("../../database");
 
@@ -9,9 +10,11 @@ const testArchiveId = "1";
 const testEmail = "test@permanent.org";
 
 const loadFixtures = async (): Promise<void> => {
-	await db.sql("directive.fixtures.create_test_accounts");
-	await db.sql("directive.fixtures.create_test_archives");
-	await db.sql("directive.fixtures.create_test_account_archives");
+	await runFixtures(db, [
+		"directive.fixtures.create_test_accounts",
+		"directive.fixtures.create_test_archives",
+		"directive.fixtures.create_test_account_archives",
+	]);
 };
 
 const clearDatabase = async (): Promise<void> => {
@@ -23,7 +26,8 @@ describe("confirmArchiveOwnership", () => {
 		await clearDatabase();
 		await loadFixtures();
 	});
-	afterEach(async () => {
+
+	afterAll(async () => {
 		await clearDatabase();
 	});
 

--- a/packages/api/src/email/service.test.ts
+++ b/packages/api/src/email/service.test.ts
@@ -1,5 +1,13 @@
 import type { MessagesSendSuccessResponse } from "@mailchimp/mailchimp_transactional";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+	vi,
+} from "vitest";
 import {
 	sendLegacyContactNotification,
 	sendArchiveStewardNotification,
@@ -9,6 +17,7 @@ import {
 } from "./service.js";
 import { MailchimpTransactional } from "../mailchimp.js";
 import { db } from "../database.js";
+import { runFixtures } from "../../test/run_fixtures.js";
 
 vi.mock("../database");
 vi.mock("../mailchimp", () => ({
@@ -23,12 +32,14 @@ const testLegacyContactId = "0cb0738c-5607-42d0-8014-8666a8d6ba13";
 const testDirectiveId = "39b2a5fa-3508-4030-91b6-21dc6ec7a1ab";
 
 const loadFixtures = async (): Promise<void> => {
-	await db.sql("email.fixtures.create_test_accounts");
-	await db.sql("email.fixtures.create_test_legacy_contacts");
-	await db.sql("email.fixtures.create_test_archives");
-	await db.sql("email.fixtures.create_test_account_archives");
-	await db.sql("email.fixtures.create_test_directives");
-	await db.sql("email.fixtures.create_test_profile_items");
+	await runFixtures(db, [
+		"email.fixtures.create_test_accounts",
+		"email.fixtures.create_test_legacy_contacts",
+		"email.fixtures.create_test_archives",
+		"email.fixtures.create_test_account_archives",
+		"email.fixtures.create_test_directives",
+		"email.fixtures.create_test_profile_items",
+	]);
 };
 
 const clearDatabase = async (): Promise<void> => {
@@ -44,8 +55,11 @@ describe("sendLegacyContactNotification", () => {
 	});
 
 	afterEach(async () => {
-		await clearDatabase();
 		vi.clearAllMocks();
+	});
+
+	afterAll(async () => {
+		await clearDatabase();
 	});
 
 	test("should send legacy contact notification successfully", async () => {
@@ -105,8 +119,11 @@ describe("sendArchiveNotification", () => {
 	});
 
 	afterEach(async () => {
-		await clearDatabase();
 		vi.clearAllMocks();
+	});
+
+	afterAll(async () => {
+		await clearDatabase();
 	});
 
 	test("should send archive steward notification successfully", async () => {
@@ -293,8 +310,11 @@ describe("sendInvitationNotification", () => {
 	});
 
 	afterEach(async () => {
-		await clearDatabase();
 		vi.clearAllMocks();
+	});
+
+	afterAll(async () => {
+		await clearDatabase();
 	});
 
 	test("send invite email should call mailchimp successfully", async () => {
@@ -376,8 +396,11 @@ describe("sendGiftNotification", () => {
 	});
 
 	afterEach(async () => {
-		await clearDatabase();
 		vi.clearAllMocks();
+	});
+
+	afterAll(async () => {
+		await clearDatabase();
 	});
 
 	test("send gift email should call mailchimp successfully", async () => {

--- a/packages/api/src/event/controller.test.ts
+++ b/packages/api/src/event/controller.test.ts
@@ -1,5 +1,13 @@
 import request from "supertest";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+	vi,
+} from "vitest";
 import type { NextFunction } from "express";
 import createError from "http-errors";
 import { db } from "../database.js";
@@ -9,6 +17,7 @@ import {
 	verifyUserOrAdminOrDelegatedCallAuthentication,
 } from "../middleware/index.js";
 import type { ChecklistItem } from "./models.js";
+import { runFixtures } from "../../test/run_fixtures.js";
 import {
 	mockVerifyUserOrAdminOrDelegatedCallAuthentication,
 	mockVerifyUserAuthentication,
@@ -481,8 +490,10 @@ describe("GET /event/checklist", () => {
 	};
 
 	const loadFixtures = async (): Promise<void> => {
-		await db.sql("event.fixtures.create_test_accounts");
-		await db.sql("event.fixtures.create_test_events");
+		await runFixtures(db, [
+			"event.fixtures.create_test_accounts",
+			"event.fixtures.create_test_events",
+		]);
 	};
 
 	const clearDatabase = async (): Promise<void> => {
@@ -498,6 +509,9 @@ describe("GET /event/checklist", () => {
 	afterEach(async () => {
 		vi.restoreAllMocks();
 		vi.clearAllMocks();
+	});
+
+	afterAll(async () => {
 		await clearDatabase();
 	});
 

--- a/packages/api/src/feature_flag/controller.test.ts
+++ b/packages/api/src/feature_flag/controller.test.ts
@@ -1,5 +1,13 @@
 import request from "supertest";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+	vi,
+} from "vitest";
 import type { NextFunction } from "express";
 import { logger } from "@stela/logger";
 import createError from "http-errors";
@@ -42,6 +50,9 @@ describe("GET /feature-flags", () => {
 
 	afterEach(async () => {
 		vi.restoreAllMocks();
+	});
+
+	afterAll(async () => {
 		await clearDatabase();
 	});
 
@@ -121,6 +132,9 @@ describe("POST /feature-flag", () => {
 	afterEach(async () => {
 		vi.restoreAllMocks();
 		vi.clearAllMocks();
+	});
+
+	afterAll(async () => {
 		await clearDatabase();
 	});
 
@@ -258,6 +272,9 @@ describe("PUT /feature-flag/:featureFlagId", () => {
 	afterEach(async () => {
 		vi.restoreAllMocks();
 		vi.clearAllMocks();
+	});
+
+	afterAll(async () => {
 		await clearDatabase();
 	});
 
@@ -396,6 +413,9 @@ describe("DELETE /feature-flag/:featureFlagId", () => {
 	afterEach(async () => {
 		vi.restoreAllMocks();
 		vi.clearAllMocks();
+	});
+
+	afterAll(async () => {
 		await clearDatabase();
 	});
 

--- a/packages/api/src/folder/controller/get_folder_share_links.test.ts
+++ b/packages/api/src/folder/controller/get_folder_share_links.test.ts
@@ -1,5 +1,13 @@
 import type { NextFunction } from "express";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+	vi,
+} from "vitest";
 import request from "supertest";
 import { logger } from "@stela/logger";
 import createError from "http-errors";
@@ -27,9 +35,12 @@ describe("GET /folder/{id}/share_links", () => {
 	});
 
 	afterEach(async () => {
-		await clearDatabase();
 		vi.restoreAllMocks();
 		vi.clearAllMocks();
+	});
+
+	afterAll(async () => {
+		await clearDatabase();
 	});
 
 	test("expect to return share links for a folder", async () => {

--- a/packages/api/src/folder/controller/patch_folder.test.ts
+++ b/packages/api/src/folder/controller/patch_folder.test.ts
@@ -1,5 +1,13 @@
 import { logger } from "@stela/logger";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+	vi,
+} from "vitest";
 import request from "supertest";
 import { app } from "../../app.js";
 import { db } from "../../database.js";
@@ -25,9 +33,12 @@ describe("patch folder", () => {
 	});
 
 	afterEach(async () => {
-		await clearDatabase();
 		vi.restoreAllMocks();
 		vi.resetAllMocks();
+	});
+
+	afterAll(async () => {
+		await clearDatabase();
 	});
 
 	test("expect an empty query to cause a 400 error", async () => {

--- a/packages/api/src/folder/controller/utils_test.ts
+++ b/packages/api/src/folder/controller/utils_test.ts
@@ -1,23 +1,26 @@
 import { db } from "../../database.js";
+import { runFixtures } from "../../../test/run_fixtures.js";
 
 export const loadFixtures = async (): Promise<void> => {
-	await db.sql("folder.fixtures.create_test_accounts");
-	await db.sql("folder.fixtures.create_test_archives");
-	await db.sql("folder.fixtures.create_test_account_archives");
-	await db.sql("folder.fixtures.create_test_locations");
-	await db.sql("folder.fixtures.create_test_folders");
-	await db.sql("folder.fixtures.create_test_records");
-	await db.sql("folder.fixtures.create_test_files");
-	await db.sql("folder.fixtures.create_test_record_files");
-	await db.sql("folder.fixtures.create_test_folder_links");
-	await db.sql("folder.fixtures.create_test_shareby_urls");
-	await db.sql("folder.fixtures.create_test_accesses");
-	await db.sql("folder.fixtures.create_test_folder_sizes");
-	await db.sql("folder.fixtures.create_test_shares");
-	await db.sql("folder.fixtures.create_test_profile_items");
-	await db.sql("folder.fixtures.create_test_tags");
-	await db.sql("folder.fixtures.create_test_tag_links");
-	await db.sql("folder.fixtures.create_test_invite_shares");
+	await runFixtures(db, [
+		"folder.fixtures.create_test_accounts",
+		"folder.fixtures.create_test_archives",
+		"folder.fixtures.create_test_account_archives",
+		"folder.fixtures.create_test_locations",
+		"folder.fixtures.create_test_folders",
+		"folder.fixtures.create_test_records",
+		"folder.fixtures.create_test_files",
+		"folder.fixtures.create_test_record_files",
+		"folder.fixtures.create_test_folder_links",
+		"folder.fixtures.create_test_shareby_urls",
+		"folder.fixtures.create_test_accesses",
+		"folder.fixtures.create_test_folder_sizes",
+		"folder.fixtures.create_test_shares",
+		"folder.fixtures.create_test_profile_items",
+		"folder.fixtures.create_test_tags",
+		"folder.fixtures.create_test_tag_links",
+		"folder.fixtures.create_test_invite_shares",
+	]);
 };
 
 export const clearDatabase = async (): Promise<void> => {

--- a/packages/api/src/idpuser/controller.test.ts
+++ b/packages/api/src/idpuser/controller.test.ts
@@ -1,5 +1,13 @@
 import request from "supertest";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+	vi,
+} from "vitest";
 import createError from "http-errors";
 import type { NextFunction } from "express";
 import { app } from "../app.js";
@@ -345,8 +353,11 @@ describe("POST /idpuser/enable-two-factor", () => {
 	});
 
 	afterEach(async () => {
-		await clearDatabase();
 		vi.restoreAllMocks();
+	});
+
+	afterAll(async () => {
+		await clearDatabase();
 	});
 
 	test("should return a 401 status if the caller is not authenticated", async () => {

--- a/packages/api/src/legacy_contact/controller.test.ts
+++ b/packages/api/src/legacy_contact/controller.test.ts
@@ -1,11 +1,20 @@
 import request from "supertest";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+	vi,
+} from "vitest";
 import { logger } from "@stela/logger";
 import { app } from "../app.js";
 import { db } from "../database.js";
 import { sendLegacyContactNotification } from "../email/index.js";
 import type { LegacyContact } from "./model.js";
 import { mockVerifyUserAuthentication } from "../../test/middleware_mocks.js";
+import { runFixtures } from "../../test/run_fixtures.js";
 
 vi.mock("@stela/logger");
 vi.mock("../database");
@@ -16,8 +25,10 @@ vi.mock("../email", () => ({
 
 describe("GET /legacy-contact", () => {
 	const loadFixtures = async (): Promise<void> => {
-		await db.sql("legacy_contact.fixtures.create_test_accounts");
-		await db.sql("legacy_contact.fixtures.create_test_legacy_contacts");
+		await runFixtures(db, [
+			"legacy_contact.fixtures.create_test_accounts",
+			"legacy_contact.fixtures.create_test_legacy_contacts",
+		]);
 	};
 
 	const clearDatabase = async (): Promise<void> => {
@@ -33,7 +44,8 @@ describe("GET /legacy-contact", () => {
 		await clearDatabase();
 		await loadFixtures();
 	});
-	afterEach(async () => {
+
+	afterAll(async () => {
 		await clearDatabase();
 	});
 
@@ -86,8 +98,11 @@ describe("POST /legacy-contact", () => {
 		await loadFixtures();
 	});
 	afterEach(async () => {
-		await clearDatabase();
 		vi.clearAllMocks();
+	});
+
+	afterAll(async () => {
+		await clearDatabase();
 	});
 
 	test("should successfully create a legacy contact", async () => {
@@ -170,8 +185,10 @@ describe("PUT /legacy-contact/:legacyContactId", () => {
 	const agent = request(app);
 
 	const loadFixtures = async (): Promise<void> => {
-		await db.sql("legacy_contact.fixtures.create_test_accounts");
-		await db.sql("legacy_contact.fixtures.create_test_legacy_contacts");
+		await runFixtures(db, [
+			"legacy_contact.fixtures.create_test_accounts",
+			"legacy_contact.fixtures.create_test_legacy_contacts",
+		]);
 	};
 
 	const clearDatabase = async (): Promise<void> => {
@@ -189,8 +206,11 @@ describe("PUT /legacy-contact/:legacyContactId", () => {
 		await loadFixtures();
 	});
 	afterEach(async () => {
-		await clearDatabase();
 		vi.clearAllMocks();
+	});
+
+	afterAll(async () => {
+		await clearDatabase();
 	});
 
 	test("should update a legacy contact's name and email", async () => {

--- a/packages/api/src/promo/controller.test.ts
+++ b/packages/api/src/promo/controller.test.ts
@@ -1,5 +1,13 @@
 import request from "supertest";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+	vi,
+} from "vitest";
 import type { NextFunction } from "express";
 import createError from "http-errors";
 import { logger } from "@stela/logger";
@@ -35,6 +43,9 @@ describe("POST /promo", () => {
 	afterEach(async () => {
 		vi.restoreAllMocks();
 		vi.clearAllMocks();
+	});
+
+	afterAll(async () => {
 		await clearDatabase();
 	});
 

--- a/packages/api/src/record/controller/copy_record.test.ts
+++ b/packages/api/src/record/controller/copy_record.test.ts
@@ -1,5 +1,13 @@
 import request from "supertest";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+	vi,
+} from "vitest";
 import type { NextFunction } from "express";
 import { when } from "vitest-when";
 import createError from "http-errors";
@@ -13,33 +21,36 @@ import {
 	mockExtractIp,
 } from "../../../test/middleware_mocks.js";
 import { mockSqlCall } from "../../../test/mock_sql.js";
+import { runFixtures } from "../../../test/run_fixtures.js";
 
 vi.mock("../../database");
 vi.mock("../../middleware");
 vi.mock("@stela/logger");
 
 const setupDatabase = async (): Promise<void> => {
-	await db.sql("record.fixtures.create_test_accounts");
-	await db.sql("record.fixtures.create_test_archives");
-	await db.sql("record.fixtures.create_test_account_archives");
-	await db.sql("record.fixtures.create_test_locations");
-	await db.sql("record.fixtures.create_test_records");
-	await db.sql("record.fixtures.create_complete_test_record");
-	await db.sql("record.fixtures.create_test_folders");
-	await db.sql("record.fixtures.create_test_folder_links");
-	await db.sql("record.fixtures.create_test_accesses");
-	await db.sql("record.fixtures.create_test_files");
-	await db.sql("record.fixtures.create_complete_test_files");
-	await db.sql("record.fixtures.create_test_record_files");
-	await db.sql("record.fixtures.create_test_tags");
-	await db.sql("record.fixtures.create_test_tag_links");
-	await db.sql("record.fixtures.create_test_shares");
-	await db.sql("record.fixtures.create_test_profile_items");
-	await db.sql("record.fixtures.create_complete_test_folder_links");
-	await db.sql("record.fixtures.create_test_shareby_urls");
-	await db.sql("record.fixtures.create_test_invite_shares");
-	await db.sql("record.fixtures.create_test_account_space");
-	await db.sql("record.fixtures.create_test_archive_nbr");
+	await runFixtures(db, [
+		"record.fixtures.create_test_accounts",
+		"record.fixtures.create_test_archives",
+		"record.fixtures.create_test_account_archives",
+		"record.fixtures.create_test_locations",
+		"record.fixtures.create_test_records",
+		"record.fixtures.create_complete_test_record",
+		"record.fixtures.create_test_folders",
+		"record.fixtures.create_test_folder_links",
+		"record.fixtures.create_test_accesses",
+		"record.fixtures.create_test_files",
+		"record.fixtures.create_complete_test_files",
+		"record.fixtures.create_test_record_files",
+		"record.fixtures.create_test_tags",
+		"record.fixtures.create_test_tag_links",
+		"record.fixtures.create_test_shares",
+		"record.fixtures.create_test_profile_items",
+		"record.fixtures.create_complete_test_folder_links",
+		"record.fixtures.create_test_shareby_urls",
+		"record.fixtures.create_test_invite_shares",
+		"record.fixtures.create_test_account_space",
+		"record.fixtures.create_test_archive_nbr",
+	]);
 };
 
 const clearDatabase = async (): Promise<void> => {
@@ -78,9 +89,12 @@ describe("POST /record/{recordId}/copies", () => {
 	});
 
 	afterEach(async () => {
-		await clearDatabase();
 		vi.restoreAllMocks();
 		vi.resetAllMocks();
+	});
+
+	afterAll(async () => {
+		await clearDatabase();
 	});
 
 	test("expect 401 if not authenticated", async () => {

--- a/packages/api/src/record/controller/get_record_legacy.test.ts
+++ b/packages/api/src/record/controller/get_record_legacy.test.ts
@@ -1,10 +1,19 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+	vi,
+} from "vitest";
 import { logger } from "@stela/logger";
 import request from "supertest";
 import { app } from "../../app.js";
 import { db } from "../../database.js";
 import { extractShareTokenFromHeaders } from "../../middleware/index.js";
 import type { ArchiveRecord } from "../models.js";
+import { runFixtures } from "../../../test/run_fixtures.js";
 import {
 	mockExtractShareTokenFromHeaders,
 	mockExtractUserEmailFromAuthToken,
@@ -15,27 +24,29 @@ vi.mock("../../middleware");
 vi.mock("@stela/logger");
 
 const setupDatabase = async (): Promise<void> => {
-	await db.sql("record.fixtures.create_test_accounts");
-	await db.sql("record.fixtures.create_test_archives");
-	await db.sql("record.fixtures.create_test_account_archives");
-	await db.sql("record.fixtures.create_test_locations");
-	await db.sql("record.fixtures.create_test_records");
-	await db.sql("record.fixtures.create_complete_test_record");
-	await db.sql("record.fixtures.create_test_folders");
-	await db.sql("record.fixtures.create_test_folder_links");
-	await db.sql("record.fixtures.create_test_accesses");
-	await db.sql("record.fixtures.create_test_files");
-	await db.sql("record.fixtures.create_complete_test_files");
-	await db.sql("record.fixtures.create_test_record_files");
-	await db.sql("record.fixtures.create_test_tags");
-	await db.sql("record.fixtures.create_test_tag_links");
-	await db.sql("record.fixtures.create_test_shares");
-	await db.sql("record.fixtures.create_test_profile_items");
-	await db.sql("record.fixtures.create_complete_test_folder_links");
-	await db.sql("record.fixtures.create_test_shareby_urls");
-	await db.sql("record.fixtures.create_test_invite_shares");
-	await db.sql("record.fixtures.create_test_account_space");
-	await db.sql("record.fixtures.create_test_archive_nbr");
+	await runFixtures(db, [
+		"record.fixtures.create_test_accounts",
+		"record.fixtures.create_test_archives",
+		"record.fixtures.create_test_account_archives",
+		"record.fixtures.create_test_locations",
+		"record.fixtures.create_test_records",
+		"record.fixtures.create_complete_test_record",
+		"record.fixtures.create_test_folders",
+		"record.fixtures.create_test_folder_links",
+		"record.fixtures.create_test_accesses",
+		"record.fixtures.create_test_files",
+		"record.fixtures.create_complete_test_files",
+		"record.fixtures.create_test_record_files",
+		"record.fixtures.create_test_tags",
+		"record.fixtures.create_test_tag_links",
+		"record.fixtures.create_test_shares",
+		"record.fixtures.create_test_profile_items",
+		"record.fixtures.create_complete_test_folder_links",
+		"record.fixtures.create_test_shareby_urls",
+		"record.fixtures.create_test_invite_shares",
+		"record.fixtures.create_test_account_space",
+		"record.fixtures.create_test_archive_nbr",
+	]);
 };
 
 const clearDatabase = async (): Promise<void> => {
@@ -70,9 +81,12 @@ describe("GET /record (deprecated alias, no pagination)", () => {
 	});
 
 	afterEach(async () => {
-		await clearDatabase();
 		vi.restoreAllMocks();
 		vi.clearAllMocks();
+	});
+
+	afterAll(async () => {
+		await clearDatabase();
 	});
 
 	const agent = request(app);

--- a/packages/api/src/record/controller/get_record_share_links.test.ts
+++ b/packages/api/src/record/controller/get_record_share_links.test.ts
@@ -1,5 +1,13 @@
 import type { NextFunction } from "express";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+	vi,
+} from "vitest";
 import createError from "http-errors";
 import { logger } from "@stela/logger";
 import request from "supertest";
@@ -8,33 +16,36 @@ import { db } from "../../database.js";
 import { verifyUserAuthentication } from "../../middleware/index.js";
 import type { ShareLink } from "../../share_link/models.js";
 import { mockVerifyUserAuthentication } from "../../../test/middleware_mocks.js";
+import { runFixtures } from "../../../test/run_fixtures.js";
 
 vi.mock("../../database");
 vi.mock("../../middleware");
 vi.mock("@stela/logger");
 
 const setupDatabase = async (): Promise<void> => {
-	await db.sql("record.fixtures.create_test_accounts");
-	await db.sql("record.fixtures.create_test_archives");
-	await db.sql("record.fixtures.create_test_account_archives");
-	await db.sql("record.fixtures.create_test_locations");
-	await db.sql("record.fixtures.create_test_records");
-	await db.sql("record.fixtures.create_complete_test_record");
-	await db.sql("record.fixtures.create_test_folders");
-	await db.sql("record.fixtures.create_test_folder_links");
-	await db.sql("record.fixtures.create_test_accesses");
-	await db.sql("record.fixtures.create_test_files");
-	await db.sql("record.fixtures.create_complete_test_files");
-	await db.sql("record.fixtures.create_test_record_files");
-	await db.sql("record.fixtures.create_test_tags");
-	await db.sql("record.fixtures.create_test_tag_links");
-	await db.sql("record.fixtures.create_test_shares");
-	await db.sql("record.fixtures.create_test_profile_items");
-	await db.sql("record.fixtures.create_complete_test_folder_links");
-	await db.sql("record.fixtures.create_test_shareby_urls");
-	await db.sql("record.fixtures.create_test_invite_shares");
-	await db.sql("record.fixtures.create_test_account_space");
-	await db.sql("record.fixtures.create_test_archive_nbr");
+	await runFixtures(db, [
+		"record.fixtures.create_test_accounts",
+		"record.fixtures.create_test_archives",
+		"record.fixtures.create_test_account_archives",
+		"record.fixtures.create_test_locations",
+		"record.fixtures.create_test_records",
+		"record.fixtures.create_complete_test_record",
+		"record.fixtures.create_test_folders",
+		"record.fixtures.create_test_folder_links",
+		"record.fixtures.create_test_accesses",
+		"record.fixtures.create_test_files",
+		"record.fixtures.create_complete_test_files",
+		"record.fixtures.create_test_record_files",
+		"record.fixtures.create_test_tags",
+		"record.fixtures.create_test_tag_links",
+		"record.fixtures.create_test_shares",
+		"record.fixtures.create_test_profile_items",
+		"record.fixtures.create_complete_test_folder_links",
+		"record.fixtures.create_test_shareby_urls",
+		"record.fixtures.create_test_invite_shares",
+		"record.fixtures.create_test_account_space",
+		"record.fixtures.create_test_archive_nbr",
+	]);
 };
 
 const clearDatabase = async (): Promise<void> => {
@@ -73,9 +84,12 @@ describe("GET /records/{id}/share-links", () => {
 	});
 
 	afterEach(async () => {
-		await clearDatabase();
 		vi.restoreAllMocks();
 		vi.clearAllMocks();
+	});
+
+	afterAll(async () => {
+		await clearDatabase();
 	});
 
 	test("expect to return share links for a record", async () => {

--- a/packages/api/src/record/controller/get_records_page.test.ts
+++ b/packages/api/src/record/controller/get_records_page.test.ts
@@ -1,9 +1,18 @@
 import { logger } from "@stela/logger";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+	vi,
+} from "vitest";
 import request from "supertest";
 import { app } from "../../app.js";
 import { db } from "../../database.js";
 import type { ArchiveRecord, GetRecordsResponse } from "../models.js";
+import { runFixtures } from "../../../test/run_fixtures.js";
 import {
 	mockExtractShareTokenFromHeaders,
 	mockExtractUserEmailFromAuthToken,
@@ -14,27 +23,29 @@ vi.mock("../../middleware");
 vi.mock("@stela/logger");
 
 const setupDatabase = async (): Promise<void> => {
-	await db.sql("record.fixtures.create_test_accounts");
-	await db.sql("record.fixtures.create_test_archives");
-	await db.sql("record.fixtures.create_test_account_archives");
-	await db.sql("record.fixtures.create_test_locations");
-	await db.sql("record.fixtures.create_test_records");
-	await db.sql("record.fixtures.create_complete_test_record");
-	await db.sql("record.fixtures.create_test_folders");
-	await db.sql("record.fixtures.create_test_folder_links");
-	await db.sql("record.fixtures.create_test_accesses");
-	await db.sql("record.fixtures.create_test_files");
-	await db.sql("record.fixtures.create_complete_test_files");
-	await db.sql("record.fixtures.create_test_record_files");
-	await db.sql("record.fixtures.create_test_tags");
-	await db.sql("record.fixtures.create_test_tag_links");
-	await db.sql("record.fixtures.create_test_shares");
-	await db.sql("record.fixtures.create_test_profile_items");
-	await db.sql("record.fixtures.create_complete_test_folder_links");
-	await db.sql("record.fixtures.create_test_shareby_urls");
-	await db.sql("record.fixtures.create_test_invite_shares");
-	await db.sql("record.fixtures.create_test_account_space");
-	await db.sql("record.fixtures.create_test_archive_nbr");
+	await runFixtures(db, [
+		"record.fixtures.create_test_accounts",
+		"record.fixtures.create_test_archives",
+		"record.fixtures.create_test_account_archives",
+		"record.fixtures.create_test_locations",
+		"record.fixtures.create_test_records",
+		"record.fixtures.create_complete_test_record",
+		"record.fixtures.create_test_folders",
+		"record.fixtures.create_test_folder_links",
+		"record.fixtures.create_test_accesses",
+		"record.fixtures.create_test_files",
+		"record.fixtures.create_complete_test_files",
+		"record.fixtures.create_test_record_files",
+		"record.fixtures.create_test_tags",
+		"record.fixtures.create_test_tag_links",
+		"record.fixtures.create_test_shares",
+		"record.fixtures.create_test_profile_items",
+		"record.fixtures.create_complete_test_folder_links",
+		"record.fixtures.create_test_shareby_urls",
+		"record.fixtures.create_test_invite_shares",
+		"record.fixtures.create_test_account_space",
+		"record.fixtures.create_test_archive_nbr",
+	]);
 };
 
 const clearDatabase = async (): Promise<void> => {
@@ -69,9 +80,12 @@ describe("GET /records", () => {
 	});
 
 	afterEach(async () => {
-		await clearDatabase();
 		vi.restoreAllMocks();
 		vi.clearAllMocks();
+	});
+
+	afterAll(async () => {
+		await clearDatabase();
 	});
 
 	const agent = request(app);

--- a/packages/api/src/record/controller/get_single_record.test.ts
+++ b/packages/api/src/record/controller/get_single_record.test.ts
@@ -1,9 +1,18 @@
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+	vi,
+} from "vitest";
 import { logger } from "@stela/logger";
 import request from "supertest";
 import { app } from "../../app.js";
 import { db } from "../../database.js";
 import type { ArchiveRecord } from "../models.js";
+import { runFixtures } from "../../../test/run_fixtures.js";
 import {
 	mockExtractShareTokenFromHeaders,
 	mockExtractUserEmailFromAuthToken,
@@ -14,27 +23,29 @@ vi.mock("../../middleware");
 vi.mock("@stela/logger");
 
 const setupDatabase = async (): Promise<void> => {
-	await db.sql("record.fixtures.create_test_accounts");
-	await db.sql("record.fixtures.create_test_archives");
-	await db.sql("record.fixtures.create_test_account_archives");
-	await db.sql("record.fixtures.create_test_locations");
-	await db.sql("record.fixtures.create_test_records");
-	await db.sql("record.fixtures.create_complete_test_record");
-	await db.sql("record.fixtures.create_test_folders");
-	await db.sql("record.fixtures.create_test_folder_links");
-	await db.sql("record.fixtures.create_test_accesses");
-	await db.sql("record.fixtures.create_test_files");
-	await db.sql("record.fixtures.create_complete_test_files");
-	await db.sql("record.fixtures.create_test_record_files");
-	await db.sql("record.fixtures.create_test_tags");
-	await db.sql("record.fixtures.create_test_tag_links");
-	await db.sql("record.fixtures.create_test_shares");
-	await db.sql("record.fixtures.create_test_profile_items");
-	await db.sql("record.fixtures.create_complete_test_folder_links");
-	await db.sql("record.fixtures.create_test_shareby_urls");
-	await db.sql("record.fixtures.create_test_invite_shares");
-	await db.sql("record.fixtures.create_test_account_space");
-	await db.sql("record.fixtures.create_test_archive_nbr");
+	await runFixtures(db, [
+		"record.fixtures.create_test_accounts",
+		"record.fixtures.create_test_archives",
+		"record.fixtures.create_test_account_archives",
+		"record.fixtures.create_test_locations",
+		"record.fixtures.create_test_records",
+		"record.fixtures.create_complete_test_record",
+		"record.fixtures.create_test_folders",
+		"record.fixtures.create_test_folder_links",
+		"record.fixtures.create_test_accesses",
+		"record.fixtures.create_test_files",
+		"record.fixtures.create_complete_test_files",
+		"record.fixtures.create_test_record_files",
+		"record.fixtures.create_test_tags",
+		"record.fixtures.create_test_tag_links",
+		"record.fixtures.create_test_shares",
+		"record.fixtures.create_test_profile_items",
+		"record.fixtures.create_complete_test_folder_links",
+		"record.fixtures.create_test_shareby_urls",
+		"record.fixtures.create_test_invite_shares",
+		"record.fixtures.create_test_account_space",
+		"record.fixtures.create_test_archive_nbr",
+	]);
 };
 
 const clearDatabase = async (): Promise<void> => {
@@ -69,9 +80,12 @@ describe("GET /records/:recordId", () => {
 	});
 
 	afterEach(async () => {
-		await clearDatabase();
 		vi.restoreAllMocks();
 		vi.clearAllMocks();
+	});
+
+	afterAll(async () => {
+		await clearDatabase();
 	});
 
 	const agent = request(app);

--- a/packages/api/src/record/controller/update_record.test.ts
+++ b/packages/api/src/record/controller/update_record.test.ts
@@ -1,5 +1,13 @@
 import { when } from "vitest-when";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+	vi,
+} from "vitest";
 import { logger } from "@stela/logger";
 import request from "supertest";
 import { app } from "../../app.js";
@@ -8,33 +16,36 @@ import { AccessRole } from "../../access/models.js";
 import { mockVerifyUserAuthentication } from "../../../test/middleware_mocks.js";
 import { mockSqlCall } from "../../../test/mock_sql.js";
 import type { ArchiveRecord } from "../models.js";
+import { runFixtures } from "../../../test/run_fixtures.js";
 
 vi.mock("../../database");
 vi.mock("../../middleware");
 vi.mock("@stela/logger");
 
 const setupDatabase = async (): Promise<void> => {
-	await db.sql("record.fixtures.create_test_accounts");
-	await db.sql("record.fixtures.create_test_archives");
-	await db.sql("record.fixtures.create_test_account_archives");
-	await db.sql("record.fixtures.create_test_locations");
-	await db.sql("record.fixtures.create_test_records");
-	await db.sql("record.fixtures.create_complete_test_record");
-	await db.sql("record.fixtures.create_test_folders");
-	await db.sql("record.fixtures.create_test_folder_links");
-	await db.sql("record.fixtures.create_test_accesses");
-	await db.sql("record.fixtures.create_test_files");
-	await db.sql("record.fixtures.create_complete_test_files");
-	await db.sql("record.fixtures.create_test_record_files");
-	await db.sql("record.fixtures.create_test_tags");
-	await db.sql("record.fixtures.create_test_tag_links");
-	await db.sql("record.fixtures.create_test_shares");
-	await db.sql("record.fixtures.create_test_profile_items");
-	await db.sql("record.fixtures.create_complete_test_folder_links");
-	await db.sql("record.fixtures.create_test_shareby_urls");
-	await db.sql("record.fixtures.create_test_invite_shares");
-	await db.sql("record.fixtures.create_test_account_space");
-	await db.sql("record.fixtures.create_test_archive_nbr");
+	await runFixtures(db, [
+		"record.fixtures.create_test_accounts",
+		"record.fixtures.create_test_archives",
+		"record.fixtures.create_test_account_archives",
+		"record.fixtures.create_test_locations",
+		"record.fixtures.create_test_records",
+		"record.fixtures.create_complete_test_record",
+		"record.fixtures.create_test_folders",
+		"record.fixtures.create_test_folder_links",
+		"record.fixtures.create_test_accesses",
+		"record.fixtures.create_test_files",
+		"record.fixtures.create_complete_test_files",
+		"record.fixtures.create_test_record_files",
+		"record.fixtures.create_test_tags",
+		"record.fixtures.create_test_tag_links",
+		"record.fixtures.create_test_shares",
+		"record.fixtures.create_test_profile_items",
+		"record.fixtures.create_complete_test_folder_links",
+		"record.fixtures.create_test_shareby_urls",
+		"record.fixtures.create_test_invite_shares",
+		"record.fixtures.create_test_account_space",
+		"record.fixtures.create_test_archive_nbr",
+	]);
 };
 
 const clearDatabase = async (): Promise<void> => {
@@ -73,9 +84,12 @@ describe("PATCH /records", () => {
 	});
 
 	afterEach(async () => {
-		await clearDatabase();
 		vi.restoreAllMocks();
 		vi.resetAllMocks();
+	});
+
+	afterAll(async () => {
+		await clearDatabase();
 	});
 
 	test("expect an empty query to cause a 400 error", async () => {

--- a/packages/api/src/share_link/controller.test.ts
+++ b/packages/api/src/share_link/controller.test.ts
@@ -16,19 +16,22 @@ import {
 	mockExtractUserEmailFromAuthToken,
 } from "../../test/middleware_mocks.js";
 import { mockSqlCall } from "../../test/mock_sql.js";
+import { runFixtures } from "../../test/run_fixtures.js";
 
 vi.mock("../database");
 vi.mock("../middleware");
 vi.mock("uuid");
 
 const loadFixtures = async (): Promise<void> => {
-	await db.sql("share_link.fixtures.create_test_accounts");
-	await db.sql("share_link.fixtures.create_test_archives");
-	await db.sql("share_link.fixtures.create_test_account_archives");
-	await db.sql("share_link.fixtures.create_test_records");
-	await db.sql("share_link.fixtures.create_test_folders");
-	await db.sql("share_link.fixtures.create_test_folder_links");
-	await db.sql("share_link.fixtures.create_test_shareby_urls");
+	await runFixtures(db, [
+		"share_link.fixtures.create_test_accounts",
+		"share_link.fixtures.create_test_archives",
+		"share_link.fixtures.create_test_account_archives",
+		"share_link.fixtures.create_test_records",
+		"share_link.fixtures.create_test_folders",
+		"share_link.fixtures.create_test_folder_links",
+		"share_link.fixtures.create_test_shareby_urls",
+	]);
 };
 
 const clearDatabase = async (): Promise<void> => {

--- a/packages/api/src/storage/controller.test.ts
+++ b/packages/api/src/storage/controller.test.ts
@@ -1,5 +1,13 @@
 import request from "supertest";
-import { afterEach, beforeEach, describe, expect, test, vi } from "vitest";
+import {
+	afterAll,
+	afterEach,
+	beforeEach,
+	describe,
+	expect,
+	test,
+	vi,
+} from "vitest";
 import { when } from "vitest-when";
 import { logger } from "@stela/logger";
 import { app } from "../app.js";
@@ -11,6 +19,7 @@ import {
 	sendGiftNotification,
 } from "../email/index.js";
 import { mockVerifyUserAuthentication } from "../../test/middleware_mocks.js";
+import { runFixtures } from "../../test/run_fixtures.js";
 
 vi.mock("../database");
 vi.mock("../middleware");
@@ -135,8 +144,11 @@ describe("/storage/gift", () => {
 	});
 
 	afterEach(async () => {
-		await clearDatabase();
 		vi.resetAllMocks();
+	});
+
+	afterAll(async () => {
+		await clearDatabase();
 	});
 
 	test("should call verifyUserAuthentication", async () => {
@@ -250,9 +262,11 @@ describe("/storage/gift", () => {
 	});
 
 	test("should return a 500 error if email from auth token has no permanent account", async () => {
-		await db.sql("storage.fixtures.create_test_accounts");
-		await db.sql("storage.fixtures.create_test_account_space");
-		await db.sql("storage.fixtures.create_test_emails");
+		await runFixtures(db, [
+			"storage.fixtures.create_test_accounts",
+			"storage.fixtures.create_test_account_space",
+			"storage.fixtures.create_test_emails",
+		]);
 		mockVerifyUserAuthentication(
 			"not_a_user@permanent.org",
 			"13bb917e-7c75-4971-a8ee-b22e82432888",
@@ -268,9 +282,11 @@ describe("/storage/gift", () => {
 	});
 
 	test("should create a ledger entry with correct values if recipient already has an account", async () => {
-		await db.sql("storage.fixtures.create_test_accounts");
-		await db.sql("storage.fixtures.create_test_account_space");
-		await db.sql("storage.fixtures.create_test_emails");
+		await runFixtures(db, [
+			"storage.fixtures.create_test_accounts",
+			"storage.fixtures.create_test_account_space",
+			"storage.fixtures.create_test_emails",
+		]);
 
 		const initialSenderSpace = await getAccountSpace(senderAccountId);
 		const initialRecipientSpace = await getAccountSpace(recipientOneAccountId);
@@ -288,9 +304,11 @@ describe("/storage/gift", () => {
 	});
 
 	test("successful gift should update account_space for sender", async () => {
-		await db.sql("storage.fixtures.create_test_accounts");
-		await db.sql("storage.fixtures.create_test_account_space");
-		await db.sql("storage.fixtures.create_test_emails");
+		await runFixtures(db, [
+			"storage.fixtures.create_test_accounts",
+			"storage.fixtures.create_test_account_space",
+			"storage.fixtures.create_test_emails",
+		]);
 
 		const initialAccountSpace = await getAccountSpace(senderAccountId);
 		await agent
@@ -321,9 +339,11 @@ describe("/storage/gift", () => {
 	});
 
 	test("successful gift should update account_space for recipient", async () => {
-		await db.sql("storage.fixtures.create_test_accounts");
-		await db.sql("storage.fixtures.create_test_emails");
-		await db.sql("storage.fixtures.create_test_account_space");
+		await runFixtures(db, [
+			"storage.fixtures.create_test_accounts",
+			"storage.fixtures.create_test_emails",
+			"storage.fixtures.create_test_account_space",
+		]);
 		const initialAccountSpace = await getAccountSpace(recipientOneAccountId);
 		await agent
 			.post("/api/v2/storage/gift")
@@ -353,9 +373,11 @@ describe("/storage/gift", () => {
 	});
 
 	test("should create a multiple correct ledger entries if there are multiple recipients", async () => {
-		await db.sql("storage.fixtures.create_test_accounts");
-		await db.sql("storage.fixtures.create_test_account_space");
-		await db.sql("storage.fixtures.create_test_emails");
+		await runFixtures(db, [
+			"storage.fixtures.create_test_accounts",
+			"storage.fixtures.create_test_account_space",
+			"storage.fixtures.create_test_emails",
+		]);
 
 		const initialSenderSpace = await getAccountSpace(senderAccountId);
 		const initialRecipientOneSpace = await getAccountSpace(
@@ -388,9 +410,11 @@ describe("/storage/gift", () => {
 	});
 
 	test("should return an invalid request status if sender doesn't have enough storage", async () => {
-		await db.sql("storage.fixtures.create_test_accounts");
-		await db.sql("storage.fixtures.create_test_account_space");
-		await db.sql("storage.fixtures.create_test_emails");
+		await runFixtures(db, [
+			"storage.fixtures.create_test_accounts",
+			"storage.fixtures.create_test_account_space",
+			"storage.fixtures.create_test_emails",
+		]);
 
 		await agent
 			.post("/api/v2/storage/gift")
@@ -402,9 +426,11 @@ describe("/storage/gift", () => {
 	});
 
 	test("should create an invite if recipient doesn't have an account", async () => {
-		await db.sql("storage.fixtures.create_test_accounts");
-		await db.sql("storage.fixtures.create_test_account_space");
-		await db.sql("storage.fixtures.create_test_emails");
+		await runFixtures(db, [
+			"storage.fixtures.create_test_accounts",
+			"storage.fixtures.create_test_account_space",
+			"storage.fixtures.create_test_emails",
+		]);
 
 		const newUserEmails = [
 			"test+not_a_user_yet@permanent.org",
@@ -430,10 +456,12 @@ describe("/storage/gift", () => {
 	});
 
 	test("should not create an invite if recipient already has an invite", async () => {
-		await db.sql("storage.fixtures.create_test_accounts");
-		await db.sql("storage.fixtures.create_test_account_space");
-		await db.sql("storage.fixtures.create_test_emails");
-		await db.sql("storage.fixtures.create_test_invites");
+		await runFixtures(db, [
+			"storage.fixtures.create_test_accounts",
+			"storage.fixtures.create_test_account_space",
+			"storage.fixtures.create_test_emails",
+			"storage.fixtures.create_test_invites",
+		]);
 
 		const newUserEmails = ["Test+Already_Invited@permanent.org"];
 
@@ -453,9 +481,11 @@ describe("/storage/gift", () => {
 	});
 
 	test("should create a gift purchase ledger entry if recipient doesn't have an account", async () => {
-		await db.sql("storage.fixtures.create_test_accounts");
-		await db.sql("storage.fixtures.create_test_account_space");
-		await db.sql("storage.fixtures.create_test_emails");
+		await runFixtures(db, [
+			"storage.fixtures.create_test_accounts",
+			"storage.fixtures.create_test_account_space",
+			"storage.fixtures.create_test_emails",
+		]);
 
 		const initialSenderSpace = await getAccountSpace(senderAccountId);
 
@@ -485,9 +515,11 @@ describe("/storage/gift", () => {
 	});
 
 	test("should send invitation email if recipient doesn't have an account", async () => {
-		await db.sql("storage.fixtures.create_test_accounts");
-		await db.sql("storage.fixtures.create_test_account_space");
-		await db.sql("storage.fixtures.create_test_emails");
+		await runFixtures(db, [
+			"storage.fixtures.create_test_accounts",
+			"storage.fixtures.create_test_account_space",
+			"storage.fixtures.create_test_emails",
+		]);
 
 		const newUserEmails = [
 			"test+not_a_user_yet@permanent.org",
@@ -506,9 +538,11 @@ describe("/storage/gift", () => {
 	});
 
 	test("should send gift notification email if recipient does have an account", async () => {
-		await db.sql("storage.fixtures.create_test_accounts");
-		await db.sql("storage.fixtures.create_test_account_space");
-		await db.sql("storage.fixtures.create_test_emails");
+		await runFixtures(db, [
+			"storage.fixtures.create_test_accounts",
+			"storage.fixtures.create_test_account_space",
+			"storage.fixtures.create_test_emails",
+		]);
 
 		const newUserEmails = ["test+1@permanent.org"];
 
@@ -524,10 +558,12 @@ describe("/storage/gift", () => {
 	});
 
 	test("should report what happened to each email passed in", async () => {
-		await db.sql("storage.fixtures.create_test_accounts");
-		await db.sql("storage.fixtures.create_test_account_space");
-		await db.sql("storage.fixtures.create_test_emails");
-		await db.sql("storage.fixtures.create_test_invites");
+		await runFixtures(db, [
+			"storage.fixtures.create_test_accounts",
+			"storage.fixtures.create_test_account_space",
+			"storage.fixtures.create_test_emails",
+			"storage.fixtures.create_test_invites",
+		]);
 
 		const recipientEmails = [
 			"test+already_invited@permanent.org",

--- a/packages/api/test/run_fixtures.ts
+++ b/packages/api/test/run_fixtures.ts
@@ -1,0 +1,19 @@
+import type { TinyPg } from "tinypg";
+
+export const runFixtures = async (
+	db: TinyPg,
+	names: string[],
+): Promise<void> => {
+	const sql = names
+		.map((name) => {
+			const { sql_db_calls: sqlDbCalls } = db;
+			const { [name]: dbCall } = sqlDbCalls;
+			if (dbCall === undefined) {
+				throw new Error(`Sql query with name [${name}] not found!`);
+			}
+			return dbCall.config.text;
+		})
+		.join(";\n");
+
+	await db.query(sql);
+};


### PR DESCRIPTION
This commit makes two changes that make the API tests interact with the database more efficiently. The first is that it updates the tests to use a single database call to set up all their fixture data, rather than using one call per affected table. The second is that it removes redundant database clears after tests (because tests all clear the database before running). This speeds up the API tests by ~25% on my machine.