### PR TITLE
Ignore major `typescript` version updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,8 @@ updates:
         update-types: ["version-update:semver-major"]
       - dependency-name: "uuid"
         update-types: ["version-update:semver-major"]
+      - dependency-name: "typescript"
+        update-types: ["version-update:semver-major"]
     groups:
       eslint:
         patterns:


### PR DESCRIPTION
This PR updates dependabot to ignore major versions of `typescript` to prevent dependency conflicts.