### PR TITLE
Remove redundant terraform plan steps in deploys

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -50,23 +50,6 @@ jobs:
       - name: Terraform Validate
         id: validate
         run: terraform validate -no-color
-      - name: Terraform Plan
-        id: plan
-        run: |
-          terraform plan -no-color -input=false \
-          -var "image_overrides={
-            \"access-copy-dev-lambda\"           = \"$ACCESS_COPY_LAMBDA_IMAGE_TAG\",
-            \"account-space-update-dev-lambda\"  = \"$ACCOUNT_SPACE_UPDATE_IMAGE_TAG\",
-            \"archivematica-cleanup-dev\"        = \"$AM_CLEANUP_IMAGE_TAG\",
-            \"event-send-dev\"                   = \"$EVENT_SEND_IMAGE_TAG\",
-            \"file-copier-dev-lambda\"           = \"$FILE_COPIER_LAMBDA_IMAGE_TAG\",
-            \"file-url-refresh-dev\"             = \"$FILE_URL_REFRESH_IMAGE_TAG\",
-            \"metadata-attacher-dev-lambda\"     = \"$METADATA_ATTACHER_LAMBDA_IMAGE_TAG\",
-            \"record-thumbnail-dev-lambda\"      = \"$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG\",
-            \"stela-dev\"                        = \"$API_IMAGE_TAG\",
-            \"thumbnail-refresh-dev\"            = \"$THUMBNAIL_REFRESH_IMAGE_TAG\",
-            \"trigger-archivematica-dev-lambda\" = \"$TRIGGER_ARCHIVEMATICA_IMAGE_TAG\"
-          }"
       - name: Terraform Apply
         run: |
           terraform apply -auto-approve -input=false \

--- a/.github/workflows/prod_deploy.yml
+++ b/.github/workflows/prod_deploy.yml
@@ -60,21 +60,6 @@ jobs:
       - name: Terraform Validate
         id: validate
         run: terraform validate -no-color
-      - name: Terraform Plan
-        id: plan
-        run: |
-          terraform plan -no-color -input=false \
-          -var="stela_image=$API_IMAGE_TAG" \
-          -var="archivematica_cleanup_image=$AM_CLEANUP_IMAGE_TAG" \
-          -var="record_thumbnail_lambda_image=$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG" \
-          -var="thumbnail_refresh_image=$THUMBNAIL_REFRESH_IMAGE_TAG" \
-          -var="file_url_refresh_image=$FILE_URL_REFRESH_IMAGE_TAG" \
-          -var="access_copy_lambda_image=$ACCESS_COPY_LAMBDA_IMAGE_TAG" \
-          -var="account_space_updater_lambda_image=$ACCOUNT_SPACE_UPDATE_IMAGE_TAG" \
-          -var="trigger_archivematica_lambda_image=$TRIGGER_ARCHIVEMATICA_IMAGE_TAG" \
-          -var="metadata_attacher_lambda_image=$METADATA_ATTACHER_LAMBDA_IMAGE_TAG" \
-          -var="event_send_image=$EVENT_SEND_IMAGE_TAG" \
-          -var="file_copier_lambda_image=$FILE_COPIER_LAMBDA_IMAGE_TAG"
       - name: Terraform Apply
         run: |
           terraform apply -auto-approve -input=false \

--- a/.github/workflows/staging_deploy.yml
+++ b/.github/workflows/staging_deploy.yml
@@ -96,23 +96,6 @@ jobs:
       - name: Terraform Validate
         id: validate
         run: terraform validate -no-color
-      - name: Terraform Plan
-        id: plan
-        run: |
-          terraform plan -no-color -input=false \
-          -var="image_overrides={
-            \"access-copy-staging-lambda\"           = \"$ACCESS_COPY_LAMBDA_IMAGE_TAG\",
-            \"account-space-update-staging-lambda\"  = \"$ACCOUNT_SPACE_UPDATE_IMAGE_TAG\",
-            \"archivematica-cleanup-staging\"        = \"$AM_CLEANUP_IMAGE_TAG\",
-            \"event-send-staging\"                   = \"$EVENT_SEND_IMAGE_TAG\",
-            \"file-copier-staging-lambda\"           = \"$FILE_COPIER_LAMBDA_IMAGE_TAG\",
-            \"file-url-refresh-staging\"             = \"$FILE_URL_REFRESH_IMAGE_TAG\",
-            \"metadata-attacher-staging-lambda\"     = \"$METADATA_ATTACHER_LAMBDA_IMAGE_TAG\",
-            \"record-thumbnail-staging-lambda\"      = \"$RECORD_THUMBNAIL_LAMBDA_IMAGE_TAG\",
-            \"stela-staging\"                        = \"$API_IMAGE_TAG\",
-            \"thumbnail-refresh-staging\"            = \"$THUMBNAIL_REFRESH_IMAGE_TAG\",
-            \"trigger-archivematica-staging-lambda\" = \"$TRIGGER_ARCHIVEMATICA_IMAGE_TAG\"
-          }"
       - name: Terraform Apply
         run: |
           terraform apply -auto-approve -input=false \


### PR DESCRIPTION
Currently when we deploy this project we run `terraform plan`, then `terraform apply`. The intent was that if there was something wrong we'd catch it at the plan stage without ever getting to the apply. However, this was based on a misunderstanding of terraform; `terraform apply` runs a plan first, then applies it. Thus errors that can be caught at planning will still be caught before any changes take place even if we just run `terraform apply`.