### PR TITLE
Add accessRole field to records and folders

### DIFF
--- a/packages/api/docs/src/models/folder.yaml
+++ b/packages/api/docs/src/models/folder.yaml
@@ -21,6 +21,7 @@ folder:
     - status
     - createdAt
     - updatedAt
+    - accessRole
   properties:
     id:
       type: string
@@ -154,3 +155,11 @@ folder:
         - timeline
         - grid
         - deprecated
+    accessRole:
+      description: >
+        The caller's effective access role for this folder — the most
+        permissive role available across all applicable access paths:
+        membership in the folder's archive, an archive-to-archive share
+        targeting the folder, a valid share token, or public access to the
+        folder.
+      $ref: "./archive_membership_role.yaml#/archiveMembershipRole"

--- a/packages/api/docs/src/models/record.yaml
+++ b/packages/api/docs/src/models/record.yaml
@@ -50,6 +50,7 @@ record:
     - createdAt
     - updatedAt
     - archive
+    - accessRole
   properties:
     id:
       type: string
@@ -158,3 +159,11 @@ record:
           type: string
         name:
           type: string
+    accessRole:
+      description: >
+        The caller's effective access role for this record — the most
+        permissive role available across all applicable access paths:
+        membership in the record's archive, an archive-to-archive share
+        targeting the record, a valid share token, or public access to the
+        record.
+      $ref: "./archive_membership_role.yaml#/archiveMembershipRole"

--- a/packages/api/src/access/permission.test.ts
+++ b/packages/api/src/access/permission.test.ts
@@ -13,8 +13,11 @@ import {
 	getRecordAccessRole,
 	getFolderAccessRole,
 	isItemPublic,
+	leastPermissiveAccessRole,
+	mostPermissiveAccessRole,
+	resolveAccessRole,
 } from "./permission.js";
-import { AccessRole } from "./models.js";
+import { AccessRole, ArchiveMembershipRole } from "./models.js";
 import { db } from "../database.js";
 import { runFixtures } from "../../test/run_fixtures.js";
 
@@ -367,5 +370,126 @@ describe("isItemPublic", () => {
 				createError.InternalServerError("Failed to access database"),
 			);
 		}
+	});
+});
+
+describe("leastPermissiveAccessRole", () => {
+	test("returns the lesser of two roles", () => {
+		expect(
+			leastPermissiveAccessRole(AccessRole.Owner, AccessRole.Viewer),
+		).toEqual(AccessRole.Viewer);
+	});
+
+	test("returns the other role when one side is null", () => {
+		expect(leastPermissiveAccessRole(null, AccessRole.Editor)).toEqual(
+			AccessRole.Editor,
+		);
+		expect(leastPermissiveAccessRole(AccessRole.Editor, null)).toEqual(
+			AccessRole.Editor,
+		);
+	});
+
+	test("returns null when both sides are null", () => {
+		expect(leastPermissiveAccessRole(null, null)).toBeNull();
+	});
+});
+
+describe("mostPermissiveAccessRole", () => {
+	test("returns the greatest role among the list", () => {
+		expect(
+			mostPermissiveAccessRole([
+				AccessRole.Viewer,
+				AccessRole.Manager,
+				AccessRole.Contributor,
+			]),
+		).toEqual(AccessRole.Manager);
+	});
+
+	test("ignores null and undefined entries", () => {
+		expect(
+			mostPermissiveAccessRole([null, undefined, AccessRole.Curator]),
+		).toEqual(AccessRole.Curator);
+	});
+
+	test("returns null when every entry is null, undefined, or the list is empty", () => {
+		expect(mostPermissiveAccessRole([null, undefined])).toBeNull();
+		expect(mostPermissiveAccessRole([])).toBeNull();
+	});
+});
+
+describe("resolveAccessRole", () => {
+	test("returns the archive membership role when it is the only applicable path", () => {
+		const accessRole = resolveAccessRole({
+			archiveAccessRole: AccessRole.Owner,
+			shareAccessRoles: null,
+			shareTokenGrantsAccess: false,
+			isPublic: false,
+		});
+		expect(accessRole).toEqual(ArchiveMembershipRole.Owner);
+	});
+
+	test("caps a share's role at the sharing archive's own membership role", () => {
+		const accessRole = resolveAccessRole({
+			archiveAccessRole: null,
+			shareAccessRoles: [
+				{
+					archiveAccessRole: AccessRole.Viewer,
+					shareAccessRole: AccessRole.Manager,
+				},
+			],
+			shareTokenGrantsAccess: false,
+			isPublic: false,
+		});
+		expect(accessRole).toEqual(ArchiveMembershipRole.Viewer);
+	});
+
+	test("returns the most permissive role across every applicable path", () => {
+		const accessRole = resolveAccessRole({
+			archiveAccessRole: AccessRole.Viewer,
+			shareAccessRoles: [
+				{
+					archiveAccessRole: AccessRole.Manager,
+					shareAccessRole: AccessRole.Curator,
+				},
+			],
+			shareTokenGrantsAccess: true,
+			isPublic: true,
+		});
+		expect(accessRole).toEqual(ArchiveMembershipRole.Curator);
+	});
+
+	test("grants viewer access via a share token alone", () => {
+		const accessRole = resolveAccessRole({
+			archiveAccessRole: null,
+			shareAccessRoles: null,
+			shareTokenGrantsAccess: true,
+			isPublic: false,
+		});
+		expect(accessRole).toEqual(ArchiveMembershipRole.Viewer);
+	});
+
+	test("grants viewer access via public access alone", () => {
+		const accessRole = resolveAccessRole({
+			archiveAccessRole: null,
+			shareAccessRoles: null,
+			shareTokenGrantsAccess: false,
+			isPublic: true,
+		});
+		expect(accessRole).toEqual(ArchiveMembershipRole.Viewer);
+	});
+
+	test("throws an internal server error when no access path applies", () => {
+		expect(() =>
+			resolveAccessRole({
+				archiveAccessRole: null,
+				shareAccessRoles: null,
+				shareTokenGrantsAccess: false,
+				isPublic: false,
+			}),
+		).toThrow(
+			createError.InternalServerError(
+				"Unable to resolve caller's access role for item",
+			),
+		);
 	});
 });

--- a/packages/api/src/access/permission.ts
+++ b/packages/api/src/access/permission.ts
@@ -1,6 +1,10 @@
 import createError from "http-errors";
 import { logger } from "@stela/logger";
-import { AccessRole } from "./models.js";
+import {
+	AccessRole,
+	type ArchiveMembershipRole,
+	accessRoleToArchiveMembershipRole,
+} from "./models.js";
 import { db } from "../database.js";
 
 const VIEWER_ACCESS_ROLE_RANK = 1;
@@ -25,17 +29,65 @@ export const accessRoleLessThan = (
 	return accessRoleRank.get(roleOne) < accessRoleRank.get(roleTwo);
 };
 
-const moreLimitedAccessRole = (
-	roleOne: AccessRole | null,
-	roleTwo: AccessRole | null,
+export const leastPermissiveAccessRole = (
+	roleOne: AccessRole | null | undefined,
+	roleTwo: AccessRole | null | undefined,
 ): AccessRole | null => {
-	if (roleOne === null) {
-		return roleTwo;
+	if (roleOne === null || roleOne === undefined) {
+		return roleTwo ?? null;
 	}
-	if (roleTwo === null) {
+	if (roleTwo === null || roleTwo === undefined) {
 		return roleOne;
 	}
 	return accessRoleLessThan(roleOne, roleTwo) ? roleOne : roleTwo;
+};
+
+export const mostPermissiveAccessRole = (
+	roles: Array<AccessRole | null | undefined>,
+): AccessRole | null =>
+	roles.reduce<AccessRole | null>((accumulator, role) => {
+		if (role === null || role === undefined) {
+			return accumulator;
+		}
+		if (accumulator === null) {
+			return role;
+		}
+		return accessRoleLessThan(accumulator, role) ? role : accumulator;
+	}, null);
+
+export interface ShareAccessRolePair {
+	archiveAccessRole: AccessRole;
+	shareAccessRole: AccessRole;
+}
+
+export const resolveAccessRole = (input: {
+	archiveAccessRole: AccessRole | null;
+	shareAccessRoles: ShareAccessRolePair[] | null;
+	shareTokenGrantsAccess: boolean;
+	isPublic: boolean;
+}): ArchiveMembershipRole => {
+	const roles: Array<AccessRole | null> = [
+		input.archiveAccessRole,
+		...(input.shareAccessRoles ?? []).map((share) =>
+			leastPermissiveAccessRole(share.archiveAccessRole, share.shareAccessRole),
+		),
+	];
+	if (input.shareTokenGrantsAccess) {
+		roles.push(AccessRole.Viewer);
+	}
+	if (input.isPublic) {
+		roles.push(AccessRole.Viewer);
+	}
+
+	const accessRole = mostPermissiveAccessRole(roles);
+	if (accessRole === null) {
+		// Should be unreachable: the SQL WHERE clause that selects a row already
+		// guarantees at least one access path applies.
+		throw createError.InternalServerError(
+			"Unable to resolve caller's access role for item",
+		);
+	}
+	return accessRoleToArchiveMembershipRole(accessRole);
 };
 
 export const getItemAccessRole = async (
@@ -61,19 +113,11 @@ export const getItemAccessRole = async (
 		throw createError.NotFound();
 	}
 
-	const accessRole = result.rows
-		.map((row) =>
-			moreLimitedAccessRole(row.archiveAccessRole, row.shareAccessRole),
-		)
-		.reduce((accumulator, role) => {
-			if (accumulator === null) {
-				return role;
-			}
-			if (role === null) {
-				return accumulator;
-			}
-			return accessRoleLessThan(accumulator, role) ? role : accumulator;
-		});
+	const accessRole = mostPermissiveAccessRole(
+		result.rows.map((row) =>
+			leastPermissiveAccessRole(row.archiveAccessRole, row.shareAccessRole),
+		),
+	);
 
 	if (accessRole === null) {
 		throw createError.NotFound();

--- a/packages/api/src/folder/controller/get_folders_page.test.ts
+++ b/packages/api/src/folder/controller/get_folders_page.test.ts
@@ -114,6 +114,24 @@ describe("GET /folders", () => {
 		expect(body.pagination).toBeDefined();
 	});
 
+	test("expect accessRole to reflect the caller's own archive membership even though the folder is also public", async () => {
+		const response = await agent
+			.get("/api/v2/folders?folderIds[]=1&pageSize=100")
+			.expect(200);
+		const { body } = response as { body: GetFoldersResponse };
+		expect(body.items[0]?.accessRole).toEqual("owner");
+	});
+
+	test("expect accessRole to reflect an archive-to-archive share when the caller has no membership in the folder's own archive", async () => {
+		mockExtractUserEmailFromAuthToken("test+2@permanent.org");
+		const response = await agent
+			.get("/api/v2/folders?folderIds[]=2&pageSize=100")
+			.expect(200);
+		const { body } = response as { body: GetFoldersResponse };
+		expect(body.items).toHaveLength(1);
+		expect(body.items[0]?.accessRole).toEqual("viewer");
+	});
+
 	test("expect no more than pageSize items to be returned", async () => {
 		const response = await agent
 			.get(
@@ -206,6 +224,7 @@ describe("GET /folders", () => {
 		const { body } = response as { body: GetFoldersResponse };
 		expect(body.items).toHaveLength(1);
 		expect(body.items[0]?.folderId).toEqual("1");
+		expect(body.items[0]?.accessRole).toEqual("viewer");
 	});
 
 	test("should not return a private folder if the user is not authenticated", async () => {
@@ -227,6 +246,7 @@ describe("GET /folders", () => {
 		const { body } = response as { body: GetFoldersResponse };
 		expect(body.items).toHaveLength(1);
 		expect(body.items[0]?.folderId).toEqual("2");
+		expect(body.items[0]?.accessRole).toEqual("viewer");
 	});
 
 	test("should not retrieve a deleted folder", async () => {

--- a/packages/api/src/folder/models.ts
+++ b/packages/api/src/folder/models.ts
@@ -2,6 +2,8 @@ import type { PendingShare, Share } from "../share/models.js";
 import type { Tag } from "../tag/models.js";
 import type { ArchiveRecord } from "../record/models.js";
 import type { Location, LocationInput } from "../location/models.js";
+import type { AccessRole, ArchiveMembershipRole } from "../access/models.js";
+import type { ShareAccessRolePair } from "../access/permission.js";
 
 export type FolderChildItem =
 	| (ArchiveRecord & { itemType: "record" | "folder" })
@@ -56,7 +58,7 @@ export interface FolderRow {
 		folderLinkIds: string[];
 		archiveNumbers: Array<string | null>;
 	};
-	publicAt?: string;
+	publicAt: string | null;
 	sort: FolderSortOrder;
 	thumbnailUrls?: ThumbnailUrls;
 	type: FolderType;
@@ -69,6 +71,9 @@ export interface FolderRow {
 			name: string;
 		};
 	};
+	archiveAccessRole: AccessRole | null;
+	shareAccessRoles: ShareAccessRolePair[] | null;
+	shareTokenGrantsAccess: boolean;
 }
 
 export interface ThumbnailUrls {
@@ -110,7 +115,7 @@ export interface Folder {
 		folderLinkIds: string[];
 		archiveNumbers: Array<string | null>;
 	};
-	publicAt?: string;
+	publicAt: string | null;
 	sort: PrettyFolderSortOrder;
 	thumbnailUrls?: ThumbnailUrls;
 	type: PrettyFolderType;
@@ -123,6 +128,7 @@ export interface Folder {
 			name: string;
 		};
 	};
+	accessRole: ArchiveMembershipRole;
 }
 
 export interface FolderLink {

--- a/packages/api/src/folder/queries/get_folders.sql
+++ b/packages/api/src/folder/queries/get_folders.sql
@@ -325,7 +325,52 @@ all_folders AS (
       folder.thumburl2000,
       '256',
       folder.thumbnail256
-    ) AS "thumbnailUrls"
+    ) AS "thumbnailUrls",
+    (
+      SELECT account_archive.accessrole
+      FROM account_archive
+      INNER JOIN account
+        ON account_archive.accountid = account.accountid
+      WHERE
+        account_archive.archiveid = folder.archiveid
+        AND account.primaryemail = :email
+        AND account_archive.status = 'status.generic.ok'
+        AND account.status = 'status.auth.ok'
+    ) AS "archiveAccessRole",
+    (
+      SELECT
+        ARRAY_AGG(
+          JSONB_BUILD_OBJECT(
+            'archiveAccessRole',
+            account_archive.accessrole,
+            'shareAccessRole',
+            access.accessrole
+          )
+        )
+      FROM access
+      INNER JOIN folder_link AS share_folder_link
+        ON
+          access.folder_linkid = share_folder_link.folder_linkid
+          AND share_folder_link.folderid = folder.folderid
+          AND share_folder_link.status = 'status.generic.ok'
+      INNER JOIN account_archive
+        ON
+          access.archiveid = account_archive.archiveid
+          AND account_archive.status = 'status.generic.ok'
+      INNER JOIN account
+        ON
+          account_archive.accountid = account.accountid
+          AND account.primaryemail = :email
+          AND account.status = 'status.auth.ok'
+      WHERE
+        access.status = 'status.generic.ok'
+    ) AS "shareAccessRoles",
+    (
+      :shareToken::text IS NOT NULL
+      AND :shareToken = ANY(
+        aggregated_ancestor_unrestricted_share_tokens.tokens
+      )
+    ) AS "shareTokenGrantsAccess"
   FROM
     folder
   INNER JOIN

--- a/packages/api/src/folder/service.ts
+++ b/packages/api/src/folder/service.ts
@@ -23,6 +23,7 @@ import {
 import {
 	getFolderAccessRole,
 	accessRoleLessThan,
+	resolveAccessRole,
 } from "../access/permission.js";
 import { AccessRole } from "../access/models.js";
 import { getRecords } from "../record/service.js";
@@ -100,15 +101,29 @@ export const prettifyFolderView = (view: FolderView): PrettyFolderView => {
 	}
 };
 
-const mapFolderRow = (row: FolderRow): Folder => ({
-	...row,
-	size: row.size === null ? null : +row.size,
-	imageRatio: +(row.imageRatio ?? 0),
-	sort: prettifyFolderSortType(row.sort),
-	type: prettifyFolderType(row.type),
-	status: prettifyFolderStatus(row.status),
-	view: prettifyFolderView(row.view),
-});
+const mapFolderRow = (row: FolderRow): Folder => {
+	const {
+		archiveAccessRole,
+		shareAccessRoles,
+		shareTokenGrantsAccess,
+		...rest
+	} = row;
+	return {
+		...rest,
+		size: row.size === null ? null : +row.size,
+		imageRatio: +(row.imageRatio ?? 0),
+		sort: prettifyFolderSortType(row.sort),
+		type: prettifyFolderType(row.type),
+		status: prettifyFolderStatus(row.status),
+		view: prettifyFolderView(row.view),
+		accessRole: resolveAccessRole({
+			archiveAccessRole,
+			shareAccessRoles,
+			shareTokenGrantsAccess,
+			isPublic: row.publicAt !== null && new Date(row.publicAt) <= new Date(),
+		}),
+	};
+};
 
 export const getFolders = async (
 	folderIds: string[],

--- a/packages/api/src/record/controller/get_records_page.test.ts
+++ b/packages/api/src/record/controller/get_records_page.test.ts
@@ -208,6 +208,16 @@ describe("GET /records", () => {
 		const { body } = response as { body: GetRecordsResponse };
 		expect(body.items).toHaveLength(1);
 		expect(body.items[0]?.recordId).toEqual("10001");
+		expect(body.items[0]?.accessRole).toEqual("viewer");
+	});
+
+	test("expect accessRole to reflect the caller's own archive membership even when a lesser share role also applies", async () => {
+		const response = await agent
+			.get("/api/v2/records?recordIds[]=10002&pageSize=100")
+			.expect(200);
+		const { body } = response as { body: GetRecordsResponse };
+		expect(body.items).toHaveLength(1);
+		expect(body.items[0]?.accessRole).toEqual("owner");
 	});
 
 	test("expect not to return a private record when not logged in", async () => {
@@ -229,6 +239,7 @@ describe("GET /records", () => {
 		const { body } = response as { body: GetRecordsResponse };
 		expect(body.items).toHaveLength(1);
 		expect(body.items[0]?.recordId).toEqual("10002");
+		expect(body.items[0]?.accessRole).toEqual("viewer");
 	});
 
 	test("expect not to return a private record when share token provided is not unlisted", async () => {
@@ -263,6 +274,7 @@ describe("GET /records", () => {
 		const { body } = response as { body: GetRecordsResponse };
 		expect(body.items).toHaveLength(1);
 		expect(body.items[0]?.recordId).toEqual("10002");
+		expect(body.items[0]?.accessRole).toEqual("viewer");
 	});
 
 	test("expect to return a private record shared with the logged in account", async () => {
@@ -272,6 +284,7 @@ describe("GET /records", () => {
 		const { body } = response as { body: GetRecordsResponse };
 		expect(body.items).toHaveLength(1);
 		expect(body.items[0]?.recordId).toEqual("10006");
+		expect(body.items[0]?.accessRole).toEqual("viewer");
 	});
 
 	test("expect to not return a record in a deleted archive", async () => {
@@ -309,6 +322,9 @@ describe("GET /records", () => {
 		);
 		expect(recordIds).toHaveLength(2);
 		expect(recordIds).toEqual(expect.arrayContaining(["10001", "10008"]));
+		body.items.forEach((record: ArchiveRecord) => {
+			expect(record.accessRole).toEqual("viewer");
+		});
 	});
 
 	test("expect to log error and return 500 if database lookup fails", async () => {

--- a/packages/api/src/record/controller/get_single_record.test.ts
+++ b/packages/api/src/record/controller/get_single_record.test.ts
@@ -211,6 +211,7 @@ describe("GET /records/:recordId", () => {
 					},
 				},
 			],
+			accessRole: "owner",
 		});
 		expect(record).toMatchObject({
 			pendingShares: expect.arrayContaining([

--- a/packages/api/src/record/models.ts
+++ b/packages/api/src/record/models.ts
@@ -2,6 +2,8 @@ import type { FileType } from "@stela/permanent_models";
 import type { PendingShare, Share } from "../share/models.js";
 import type { Tag } from "../tag/models.js";
 import type { Location, LocationInput } from "../location/models.js";
+import type { AccessRole, ArchiveMembershipRole } from "../access/models.js";
+import type { ShareAccessRolePair } from "../access/permission.js";
 
 export interface ArchiveRecord {
 	id: string;
@@ -10,7 +12,7 @@ export interface ArchiveRecord {
 	displayName: string;
 	archiveNumber?: string;
 	description?: string;
-	publicAt?: string;
+	publicAt: string | null;
 	downloadName?: string;
 	uploadFileName: string;
 	uploadAccountId: string;
@@ -51,6 +53,7 @@ export interface ArchiveRecord {
 			name: string;
 		};
 	};
+	accessRole: ArchiveMembershipRole;
 }
 
 export interface ArchiveRecordRow {
@@ -60,7 +63,7 @@ export interface ArchiveRecordRow {
 	displayName: string;
 	archiveNumber?: string;
 	description?: string;
-	publicAt?: string;
+	publicAt: string | null;
 	downloadName?: string;
 	uploadFileName: string;
 	uploadAccountId: string;
@@ -100,6 +103,9 @@ export interface ArchiveRecordRow {
 			name: string;
 		};
 	};
+	archiveAccessRole: AccessRole | null;
+	shareAccessRoles: ShareAccessRolePair[] | null;
+	shareTokenGrantsAccess: boolean;
 }
 
 export interface ArchiveFile {

--- a/packages/api/src/record/queries/get_records.sql
+++ b/packages/api/src/record/queries/get_records.sql
@@ -289,7 +289,52 @@ all_records AS (
       archive.archivenbr,
       'name',
       profile_item.string1
-    ) AS archive
+    ) AS archive,
+    (
+      SELECT account_archive.accessrole
+      FROM account_archive
+      INNER JOIN account
+        ON account_archive.accountid = account.accountid
+      WHERE
+        account_archive.archiveid = record.archiveid
+        AND account.primaryemail = :accountEmail
+        AND account_archive.status = 'status.generic.ok'
+        AND account.status = 'status.auth.ok'
+    ) AS "archiveAccessRole",
+    (
+      SELECT
+        ARRAY_AGG(
+          JSONB_BUILD_OBJECT(
+            'archiveAccessRole',
+            account_archive.accessrole,
+            'shareAccessRole',
+            access.accessrole
+          )
+        )
+      FROM access
+      INNER JOIN folder_link AS share_folder_link
+        ON
+          access.folder_linkid = share_folder_link.folder_linkid
+          AND share_folder_link.recordid = record.recordid
+          AND share_folder_link.status = 'status.generic.ok'
+      INNER JOIN account_archive
+        ON
+          access.archiveid = account_archive.archiveid
+          AND account_archive.status = 'status.generic.ok'
+      INNER JOIN account
+        ON
+          account_archive.accountid = account.accountid
+          AND account.primaryemail = :accountEmail
+          AND account.status = 'status.auth.ok'
+      WHERE
+        access.status = 'status.generic.ok'
+    ) AS "shareAccessRoles",
+    (
+      :shareToken::TEXT IS NOT NULL
+      AND :shareToken = ANY(
+        aggregated_ancestor_unrestricted_share_tokens.tokens
+      )
+    ) AS "shareTokenGrantsAccess"
   FROM
     record
   INNER JOIN
@@ -333,14 +378,14 @@ all_records AS (
       folder_link.parentfolderid = parent_folder.folderid
       AND parent_folder.status != 'status.generic.deleted'
   LEFT JOIN
-    access
+    access AS share_access
     ON
-      folder_link.folder_linkid = access.folder_linkid
-      AND access.status = 'status.generic.ok'
+      folder_link.folder_linkid = share_access.folder_linkid
+      AND share_access.status = 'status.generic.ok'
   LEFT JOIN
     account_archive AS share_account_archive
     ON
-      access.archiveid = share_account_archive.archiveid
+      share_access.archiveid = share_account_archive.archiveid
       AND share_account_archive.status = 'status.generic.ok'
   LEFT JOIN
     account AS share_account

--- a/packages/api/src/record/service.ts
+++ b/packages/api/src/record/service.ts
@@ -13,6 +13,7 @@ import {
 	getRecordAccessRole,
 	accessRoleLessThan,
 	getArchiveAccessRole,
+	resolveAccessRole,
 } from "../access/permission.js";
 import { AccessRole } from "../access/models.js";
 import { shareLinkService } from "../share_link/service.js";
@@ -21,11 +22,25 @@ import { getFolders } from "../folder/service.js";
 import { type Folder, PrettyFolderType } from "../folder/models.js";
 import { insertLocation, updateLocation } from "../location/service.js";
 
-const mapRecordRow = (row: ArchiveRecordRow): ArchiveRecord => ({
-	...row,
-	size: +(row.size ?? 0),
-	imageRatio: +(row.imageRatio ?? 0),
-});
+const mapRecordRow = (row: ArchiveRecordRow): ArchiveRecord => {
+	const {
+		archiveAccessRole,
+		shareAccessRoles,
+		shareTokenGrantsAccess,
+		...rest
+	} = row;
+	return {
+		...rest,
+		size: +(row.size ?? 0),
+		imageRatio: +(row.imageRatio ?? 0),
+		accessRole: resolveAccessRole({
+			archiveAccessRole,
+			shareAccessRoles,
+			shareTokenGrantsAccess,
+			isPublic: row.publicAt !== null && new Date(row.publicAt) <= new Date(),
+		}),
+	};
+};
 
 export const getRecords = async (requestQuery: {
 	recordIds: string[] | undefined;


### PR DESCRIPTION
When clients access records and folders, they need to know what permissions level the caller has with respect to that record or folder. To that end, this commit adds an accessRole field to record and folder objects returned by the API.